### PR TITLE
feat(engine): W-S3a — persist resume-identity (WaitSignal) + kind-aware targeted arm (ADR-0099)

### DIFF
--- a/apps/server/tests/execution_store_durability.rs
+++ b/apps/server/tests/execution_store_durability.rs
@@ -73,6 +73,7 @@ async fn enqueue_and_close(db_path: &str) -> String {
         scope: test_scope(),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     control_queue
         .enqueue(&msg)
@@ -165,6 +166,7 @@ async fn in_memory_control_queue_does_not_survive_recreation() {
         scope: test_scope(),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     queue_1
         .enqueue(&msg)

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -922,6 +922,8 @@ impl AppState {
             scope: scope.clone(),
             w3c_traceparent: w3c.as_ref().map(|c| c.traceparent().to_owned()),
             reclaim_count: 0,
+            // No targeted-Resume producer yet (W-S3d); enqueue untargeted.
+            resume_target: None,
         };
         queue.enqueue(&msg).await.map_err(|e| {
             use nebula_storage_port::StorageError;
@@ -984,6 +986,8 @@ impl AppState {
             scope: scope.clone(),
             w3c_traceparent: w3c.as_ref().map(|c| c.traceparent().to_owned()),
             reclaim_count: 0,
+            // No targeted-Resume producer yet (W-S3d); enqueue untargeted.
+            resume_target: None,
         };
         let batch = nebula_storage_port::TransitionBatch::builder()
             .scope(scope.clone())

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -38,7 +38,7 @@ use nebula_metrics::{
     naming::{NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, control_reclaim_outcome},
 };
 use nebula_storage_port::Scope;
-use nebula_storage_port::dto::ControlCommand;
+use nebula_storage_port::dto::{ControlCommand, ResumeTarget};
 use nebula_storage_port::store::ControlQueue;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -208,6 +208,10 @@ pub trait ControlDispatch: Send + Sync {
     /// Deliver a `Resume` command to a suspended execution.
     ///
     /// `scope` is the per-message tenant scope from `ControlMsg.scope`.
+    /// `resume_target` is the per-message resume target from
+    /// `ControlMsg.resume_target` (W-S3a): `Some(target)` arms only the parked
+    /// signal wait whose persisted identity matches the target by kind +
+    /// identity; `None` arms every signal wait (the untargeted W-S2b behavior).
     ///
     /// A2 wired the canonical body in
     /// [`crate::control_dispatch::EngineControlDispatch`].
@@ -220,6 +224,7 @@ pub trait ControlDispatch: Send + Sync {
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+        resume_target: Option<ResumeTarget>,
     ) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Restart` command to an execution.
@@ -271,6 +276,10 @@ struct ClaimedRow {
     scope: Scope,
     /// W3C `traceparent` carrier captured at enqueue, if any.
     w3c: Option<nebula_core::W3cTraceContext>,
+    /// Which parked signal wait a `Resume` targets (W-S3a). Threaded into
+    /// `dispatch_resume` so the engine arms only the matching wait; `None` is an
+    /// untargeted Resume. Ignored for non-`Resume` commands.
+    resume_target: Option<ResumeTarget>,
 }
 
 impl RawClaimed {
@@ -322,6 +331,7 @@ impl RawClaimed {
             command: m.command,
             scope: m.scope,
             w3c,
+            resume_target: m.resume_target,
         })
     }
 }
@@ -635,6 +645,7 @@ impl ControlConsumer {
             command,
             scope,
             w3c: w3c_opt,
+            resume_target,
         } = match raw.normalize() {
             Ok(row) => row,
             Err(reason) => {
@@ -683,7 +694,9 @@ impl ControlConsumer {
                 },
                 ControlCommand::Resume => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Resume (A2)");
-                    dispatch.dispatch_resume(&scope, execution_id).await
+                    dispatch
+                        .dispatch_resume(&scope, execution_id, resume_target)
+                        .await
                 },
                 ControlCommand::Restart => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Restart (A2)");

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nebula_core::id::ExecutionId;
 use nebula_execution::ExecutionStatus;
-use nebula_storage_port::{Scope, store::ExecutionStore};
+use nebula_storage_port::{Scope, dto::ResumeTarget, store::ExecutionStore};
 
 use crate::{
     WorkflowEngine,
@@ -310,6 +310,7 @@ impl ControlDispatch for EngineControlDispatch {
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+        resume_target: Option<ResumeTarget>,
     ) -> Result<(), ControlDispatchError> {
         match self.read_status(scope, execution_id).await? {
             None => Err(ControlDispatchError::Rejected(format!(
@@ -336,43 +337,45 @@ impl ControlDispatch for EngineControlDispatch {
             // No-live-owner recovery (`NoLiveEntry`) keeps today's behavior:
             // defer for B1 reclaim. Recovering a `Running` execution that has no
             // live loop on ANY runner is a future (W-S3) slice.
-            Some(ExecutionStatus::Running) => match self.engine.resume_live(execution_id).await {
-                ResumeDelivery::Acked(ResumeOutcome::Armed { count }) => {
-                    tracing::info!(
-                        %execution_id,
-                        armed_count = count,
-                        "dispatch_resume: live frontier durably armed the signal wait(s)"
-                    );
-                    Ok(())
-                },
-                ResumeDelivery::Acked(ResumeOutcome::NothingToArm) => {
-                    tracing::info!(
-                        %execution_id,
-                        "dispatch_resume: live frontier had no signal-Waiting node to arm \
-                         (already armed / none parked); acking as idempotent no-op"
-                    );
-                    Ok(())
-                },
-                ResumeDelivery::Acked(ResumeOutcome::ArmFailed) => Self::defer_running_resume(
-                    &self.engine,
-                    execution_id,
-                    "live frontier self-arm checkpoint failed (lease lost mid-iteration)",
-                ),
-                ResumeDelivery::LoopGone => Self::defer_running_resume(
-                    &self.engine,
-                    execution_id,
-                    "live frontier loop exited before confirming the self-arm",
-                ),
-                ResumeDelivery::AckTimeout => Self::defer_running_resume(
-                    &self.engine,
-                    execution_id,
-                    "live frontier did not confirm the self-arm within the ack timeout",
-                ),
-                ResumeDelivery::NoLiveEntry => Self::defer_running_resume(
-                    &self.engine,
-                    execution_id,
-                    "Running with no live frontier on this runner (cross-runner or just-paused)",
-                ),
+            Some(ExecutionStatus::Running) => {
+                match self.engine.resume_live(execution_id, resume_target).await {
+                    ResumeDelivery::Acked(ResumeOutcome::Armed { count }) => {
+                        tracing::info!(
+                            %execution_id,
+                            armed_count = count,
+                            "dispatch_resume: live frontier durably armed the signal wait(s)"
+                        );
+                        Ok(())
+                    },
+                    ResumeDelivery::Acked(ResumeOutcome::NothingToArm) => {
+                        tracing::info!(
+                            %execution_id,
+                            "dispatch_resume: live frontier had no signal-Waiting node to arm \
+                             (already armed / none parked); acking as idempotent no-op"
+                        );
+                        Ok(())
+                    },
+                    ResumeDelivery::Acked(ResumeOutcome::ArmFailed) => Self::defer_running_resume(
+                        &self.engine,
+                        execution_id,
+                        "live frontier self-arm checkpoint failed (lease lost mid-iteration)",
+                    ),
+                    ResumeDelivery::LoopGone => Self::defer_running_resume(
+                        &self.engine,
+                        execution_id,
+                        "live frontier loop exited before confirming the self-arm",
+                    ),
+                    ResumeDelivery::AckTimeout => Self::defer_running_resume(
+                        &self.engine,
+                        execution_id,
+                        "live frontier did not confirm the self-arm within the ack timeout",
+                    ),
+                    ResumeDelivery::NoLiveEntry => Self::defer_running_resume(
+                        &self.engine,
+                        execution_id,
+                        "Running with no live frontier on this runner (cross-runner or just-paused)",
+                    ),
+                }
             },
             Some(
                 ExecutionStatus::Cancelling
@@ -412,7 +415,11 @@ impl ControlDispatch for EngineControlDispatch {
             //   lease TTL-expiry causes a FencedOut (surfaced as CasConflict) while
             //   the execution is still Paused — bounded lost-Resume.
             Some(ExecutionStatus::Paused) => {
-                match self.engine.satisfy_signal_waits(scope, execution_id).await {
+                match self
+                    .engine
+                    .satisfy_signal_waits(scope, execution_id, resume_target.as_ref())
+                    .await
+                {
                     Ok(SatisfyOutcome::Satisfied(satisfied_count)) => {
                         tracing::info!(
                             %execution_id,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -36,7 +36,7 @@ use nebula_execution::{
     ExecutionStatus,
     context::ExecutionBudget,
     plan::ExecutionPlan,
-    state::{AttemptOutcome, ExecutionState, WaitWake},
+    state::{AttemptOutcome, ExecutionState, WaitSignal, WaitWake},
     status::ExecutionTerminationReason,
 };
 use nebula_expression::ExpressionEngine;
@@ -55,6 +55,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use nebula_storage_port::Scope;
+use nebula_storage_port::dto::ResumeTarget;
 
 use crate::{
     credential_accessor::EngineCredentialAccessor, error::EngineError, event::ExecutionEvent,
@@ -366,15 +367,18 @@ static NEXT_REGISTRATION_ID: AtomicU64 = AtomicU64::new(1);
 /// completion (ADR-0099 W-S2b, P1#1).
 ///
 /// Carries a one-shot `ack` channel the loop fires AFTER it durably
-/// checkpoints the self-arm (or learns the arm failed). The request itself
-/// carries no node targeting — a Resume arms every signal wait (per-callback
-/// targeting is W-S3) — so the payload is purely the reply path.
+/// checkpoints the self-arm (or learns the arm failed), plus the
+/// `resume_target` that selects which parked signal wait(s) to arm (W-S3a).
 struct ResumeRequest {
     /// The loop sends exactly one [`ResumeOutcome`] here once the self-arm
     /// has durably landed or failed. A dropped sender (the loop exited
     /// before replying) resolves the awaiting receiver to `Err`, which
     /// [`WorkflowEngine::resume_live`] maps to [`ResumeDelivery::LoopGone`].
     ack: oneshot::Sender<ResumeOutcome>,
+    /// Which parked signal wait this Resume targets (W-S3a). `Some(target)`
+    /// arms only the kind+identity match; `None` arms every signal wait (the
+    /// W-S2b untargeted behavior).
+    resume_target: Option<ResumeTarget>,
 }
 
 /// The durable result of a live loop processing a [`ResumeRequest`].
@@ -595,7 +599,11 @@ impl WorkflowEngine {
     /// No-live-owner recovery (a `Running` execution with no live loop on ANY
     /// runner) and cross-runner Resume routing/affinity remain a future
     /// (W-S3) slice: today a `NoLiveEntry` simply defers for B1 reclaim.
-    pub(crate) async fn resume_live(&self, execution_id: ExecutionId) -> ResumeDelivery {
+    pub(crate) async fn resume_live(
+        &self,
+        execution_id: ExecutionId,
+        resume_target: Option<ResumeTarget>,
+    ) -> ResumeDelivery {
         // Build the reply channel, then drop the `running` map guard BEFORE
         // awaiting the ack — holding a `DashMap` ref across `.await` could
         // block other shards' access to the same bucket.
@@ -613,7 +621,10 @@ impl WorkflowEngine {
             if entry
                 .value()
                 .resume_tx
-                .try_send(ResumeRequest { ack: ack_tx })
+                .try_send(ResumeRequest {
+                    ack: ack_tx,
+                    resume_target,
+                })
                 .is_err()
             {
                 return ResumeDelivery::NoLiveEntry;
@@ -2625,11 +2636,19 @@ impl WorkflowEngine {
     ///   the caller must defer and let the current lease holder finish.
     /// - On success, the lease is released (best-effort) after the commit.
     ///
+    /// # Targeting (W-S3a)
+    ///
+    /// `resume_target` selects which parked signal wait this Resume arms:
+    /// `Some(target)` arms only the node whose persisted [`WaitSignal`] matches
+    /// the target by kind + identity (a webhook target never satisfies an
+    /// approval gate — the kind-confusion safety rule); `None` arms every
+    /// signal-driven wait (the W-S2b untargeted behavior).
+    ///
     /// # Returns
     ///
     /// [`SatisfyOutcome::Satisfied(n)`] when `n` signal-driven waiting nodes
     /// were armed for completion, or [`SatisfyOutcome::NothingToSatisfy`] when
-    /// none exist.
+    /// none match.
     ///
     /// # Errors
     ///
@@ -2642,10 +2661,13 @@ impl WorkflowEngine {
     ///   concurrent transition (version or fencing mismatch after our lease was
     ///   released by another path — should not happen under normal flow).
     /// - [`EngineError::CheckpointFailed`] on serialisation or store errors.
+    ///
+    /// [`WaitSignal`]: nebula_execution::state::WaitSignal
     pub(crate) async fn satisfy_signal_waits(
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+        resume_target: Option<&ResumeTarget>,
     ) -> Result<SatisfyOutcome, EngineError> {
         let Some(stores) = &self.stores else {
             // Library mode (no storage) — signal-park resume is a no-op.
@@ -2687,7 +2709,14 @@ impl WorkflowEngine {
 
         // Lease acquired — proceed under mutual exclusion.
         let outcome = self
-            .satisfy_signal_waits_under_lease(stores, scope, execution_id, &id, lease_token)
+            .satisfy_signal_waits_under_lease(
+                stores,
+                scope,
+                execution_id,
+                &id,
+                lease_token,
+                resume_target,
+            )
             .await;
 
         // Release the lease best-effort. The commit already wrote the new
@@ -2720,6 +2749,7 @@ impl WorkflowEngine {
         execution_id: ExecutionId,
         id: &str,
         lease_token: nebula_storage_port::FencingToken,
+        resume_target: Option<&ResumeTarget>,
     ) -> Result<SatisfyOutcome, EngineError> {
         let record = stores
             .execution
@@ -2767,45 +2797,29 @@ impl WorkflowEngine {
             return Ok(SatisfyOutcome::ExecutionNotResumable);
         }
 
-        // Collect nodes that are signal-driven waits. We identify them by
-        // `state == Waiting` AND `next_attempt_at == None` (no timer wake).
-        // Timer-driven waits (`next_attempt_at == Some(_)`) are already on
-        // `wait_heap` and will be handled by Phase-0b when the frontier
-        // resumes — satisfying them here would duplicate the completion.
-        let signal_waiting_nodes: Vec<NodeKey> = exec_state
-            .node_states
-            .iter()
-            .filter(|(_, ns)| ns.state == NodeState::Waiting && ns.next_attempt_at.is_none())
-            .map(|(id, _)| id.clone())
-            .collect();
+        // Arm the signal-driven waits selected by `resume_target` for Phase-0b
+        // completion: set each match's wake instant to `now` and LEAVE it
+        // `Waiting`. The subsequent `drive` re-seeds it into the frontier
+        // `wait_heap` (its `next_attempt_at` is now `Some`) and Phase-0b
+        // transitions it `Waiting → Completed` and activates downstream through
+        // the PORT-AWARE `process_outgoing_edges` — the same path a timer wait
+        // takes. Transitioning to `Completed` HERE would instead route the
+        // node's edges through `resume_execution`'s port-blind rebuild, which
+        // activates every outgoing edge (a multi-port wait would fire its
+        // `error`/custom branch on a normal Resume).
+        //
+        // `arm_signal_waits_under_lease` is the shared armer: a `Some(target)`
+        // Resume arms only the kind+identity match; a `None` Resume arms every
+        // signal wait (W-S2b behavior). It runs under the lease we hold, so the
+        // own-the-lease-before-RMW invariant (#856) is preserved.
+        let now = Utc::now();
+        let armed = arm_signal_waits_under_lease(&mut exec_state, resume_target, now);
 
-        if signal_waiting_nodes.is_empty() {
+        if armed.is_empty() {
             return Ok(SatisfyOutcome::NothingToSatisfy);
         }
 
-        let satisfied_count = signal_waiting_nodes.len();
-        let now = Utc::now();
-
-        for node_key in &signal_waiting_nodes {
-            // Arm the node for Phase-0b completion: set the wake instant to
-            // `now` and LEAVE the node `Waiting`. The subsequent `drive`
-            // re-seeds it into the frontier `wait_heap` (its `next_attempt_at`
-            // is now `Some`) and Phase-0b transitions it `Waiting → Completed`
-            // and activates downstream through the PORT-AWARE
-            // `process_outgoing_edges` — the same path a timer wait takes.
-            // Transitioning to `Completed` HERE would instead route the node's
-            // edges through `resume_execution`'s port-blind rebuild, which
-            // activates every outgoing edge (a multi-port wait would fire its
-            // `error`/custom branch on a normal Resume).
-            if let Some(ns) = exec_state.node_states.get_mut(node_key) {
-                // Arm for COMPLETION: a satisfied signal wait wakes to
-                // complete the node (`Waiting → Completed`), never to fail.
-                // (case-a made explicit by W-S2b's `wait_wake` discriminator.)
-                // The paired write keeps the next_attempt_at/wait_wake
-                // invariant intact.
-                ns.arm_wait_completion(now);
-            }
-        }
+        let satisfied_count = armed.len();
 
         // Mirror `ExecutionState::transition_node`: direct field mutation must
         // still advance `version`/`updated_at` so the serialized blob's
@@ -4022,52 +4036,40 @@ impl WorkflowEngine {
                     // loop exits before sending) resolves the caller's receiver
                     // to `Err` → `LoopGone` → Deferred — a free fail-safe.
                     //
-                    // Untargeted in v1 (mirrors case-a fork-2): a Resume arms
-                    // every signal wait. Per-callback_id targeting is W-S3
-                    // (carried in the durable CAS, not this volatile wake).
+                    // Targeted in W-S3a: `req.resume_target` selects which signal
+                    // wait(s) to arm — `Some(target)` arms only the kind+identity
+                    // match, `None` arms every signal wait (W-S2b behavior). The
+                    // shared `arm_signal_waits_under_lease` runs under THIS loop's
+                    // own lease (it is the sole writer of its own row), preserving
+                    // the own-the-lease-before-RMW invariant.
                     //
                     // A LIVE (`Running`) execution's signal waits are the
                     // timeout-bearing ones: parked with `wait_wake == Timeout`
                     // and a future `next_attempt_at` deadline. (A signal-only
                     // wait, `next_attempt_at == None`, would have driven the row
                     // to `Paused` — case-a, satisfied by the durable CAS, not
-                    // this channel.) We arm BOTH shapes defensively: re-stamp
+                    // this channel.) `arm_wait_completion` re-stamps
                     // `next_attempt_at = now` (overriding any future timeout
-                    // deadline so Phase-0b completes immediately) and flip
+                    // deadline so Phase-0b completes immediately) and flips
                     // `wait_wake = Completion` (a Resume completes, never times
                     // out). The stale future `(deadline, key)` heap entry pops
                     // later, finds the node non-`Waiting`, and is skipped — the
                     // race-safety the Phase-0b state re-read guarantees.
                     let now = Utc::now();
-                    let to_arm: Vec<NodeKey> = exec_state
-                        .node_states
-                        .iter()
-                        .filter(|(_, ns)| ns.state == NodeState::Waiting && is_signal_wait(ns))
-                        .map(|(id, _)| id.clone())
-                        .collect();
+                    let to_arm =
+                        arm_signal_waits_under_lease(exec_state, req.resume_target.as_ref(), now);
                     if to_arm.is_empty() {
-                        // Spurious or already-armed wake — nothing to do. Ack as
-                        // `NothingToArm` (the caller may ack the row; a duplicate
-                        // Resume to an already-armed node is idempotent), then
+                        // Spurious, already-armed, or no-match wake — nothing to
+                        // do. Ack as `NothingToArm` (the caller may ack the row; a
+                        // duplicate or non-matching Resume is idempotent), then
                         // loop back; the exit-condition / timers re-evaluate.
                         let _ = req.ack.send(ResumeOutcome::NothingToArm);
                         tracing::debug!(
                             target = "engine::wait",
                             %execution_id,
-                            "resume signalled but no signal-Waiting node to arm; ignoring"
+                            "resume signalled but no matching signal-Waiting node to arm; ignoring"
                         );
                         continue;
-                    }
-                    for node_key in &to_arm {
-                        if let Some(ns) = exec_state.node_states.get_mut(node_key) {
-                            // Arm for Phase-0b completion. The execution version
-                            // is bumped by the checkpoint below (this is a direct
-                            // field write on the loop's own in-memory state, the
-                            // same shape as `satisfy_signal_waits_under_lease`).
-                            // The paired write keeps the
-                            // next_attempt_at/wait_wake invariant intact.
-                            ns.arm_wait_completion(now);
-                        }
                     }
                     // Bump the version once so the checkpoint CAS advances and
                     // any reader observes the arm. (`set_node_state`/direct field
@@ -4406,6 +4408,39 @@ impl WorkflowEngine {
                         };
                         let (wake_at, wait_wake) = wake_plan;
 
+                        // Capture the resume-IDENTITY of a signal wait so a later
+                        // targeted Resume can match it (W-S3a). A signal condition
+                        // (Webhook / Approval / Execution) persists the minimum
+                        // identity needed for targeting — the callback_id /
+                        // approver / execution_id — never the Approval `message` or
+                        // any inbound payload (that is W-S4). A timer condition
+                        // (Until / Duration) carries no identity. This classifies
+                        // independently of the timer: `park_node` enforces that
+                        // `wait_signal.is_some()` iff the wait is signal-driven.
+                        let wait_signal: Option<WaitSignal> = match condition {
+                            WaitCondition::Webhook { callback_id } => Some(WaitSignal::Webhook {
+                                callback_id: callback_id.clone(),
+                            }),
+                            WaitCondition::Approval { approver, .. } => {
+                                Some(WaitSignal::Approval {
+                                    approver: approver.clone(),
+                                })
+                            },
+                            WaitCondition::Execution { execution_id } => {
+                                Some(WaitSignal::Execution {
+                                    execution_id: *execution_id,
+                                })
+                            },
+                            WaitCondition::Until { .. } | WaitCondition::Duration { .. } => None,
+                            // Any unclassified variant fails closed above (the
+                            // wake_plan `_` arm marks the node Failed and returns),
+                            // so this arm is unreachable at park time. Persisting
+                            // `None` here would be wrong (it would not match the
+                            // signal classification of an unknown variant), but the
+                            // node never reaches `park_node` in that case.
+                            _ => None,
+                        };
+
                         // Budget enforcement for the partial output committed at park
                         // time. The normal success path increments `total_output_bytes`
                         // AFTER the node completes; Phase 1's `check_budget` catches
@@ -4454,7 +4489,12 @@ impl WorkflowEngine {
                             }
                         }
 
-                        match exec_state.park_node(node_key.clone(), wake_at, wait_wake) {
+                        match exec_state.park_node(
+                            node_key.clone(),
+                            wake_at,
+                            wait_wake,
+                            wait_signal,
+                        ) {
                             Ok(()) => {
                                 // Signal park (no timer) that leaves NO other active
                                 // frontier work fully suspends the execution: persist
@@ -6712,6 +6752,100 @@ fn deserialize_stored_result(
 /// signal wait and a Resume must never re-arm it.
 fn is_signal_wait(ns: &nebula_execution::state::NodeExecutionState) -> bool {
     ns.next_attempt_at.is_none() || ns.wait_wake == Some(WaitWake::Timeout)
+}
+
+/// Whether a parked node's persisted [`WaitSignal`] identity matches a Resume's
+/// [`ResumeTarget`] — the KIND-AWARE targeting rule (ADR-0099 W-S3a).
+///
+/// A target matches ONLY a same-kind signal with an equal identity: a
+/// `Webhook` target matches a `WaitSignal::Webhook` whose `callback_id` is
+/// equal, and NEVER an `Approval` or `Execution` wait. This is the structural
+/// safety control that closes the kind-confusion confused-deputy bug — a
+/// webhook Resume can never satisfy an approval gate, regardless of string
+/// collisions.
+///
+/// A node with no persisted `wait_signal` (a legacy row, or a timer wait) never
+/// matches a target — only an untargeted Resume (no `ResumeTarget`) arms it.
+fn matches_resume_target(
+    ns: &nebula_execution::state::NodeExecutionState,
+    target: &ResumeTarget,
+) -> bool {
+    match (ns.wait_signal.as_ref(), target) {
+        (
+            Some(WaitSignal::Webhook { callback_id }),
+            ResumeTarget::Webhook { callback_id: want },
+        ) => callback_id == want,
+        (Some(WaitSignal::Approval { approver }), ResumeTarget::Approval { approver: want }) => {
+            approver == want
+        },
+        (
+            Some(WaitSignal::Execution { execution_id }),
+            ResumeTarget::Execution { execution_id: want },
+        ) => {
+            // Compare typed-to-typed: parse the target's opaque string form into
+            // an `ExecutionId` (no allocation on the persisted side) and match by
+            // value. A malformed target string simply never matches.
+            want.parse::<ExecutionId>()
+                .is_ok_and(|want_id| *execution_id == want_id)
+        },
+        // Any cross-kind pair, or a node with no persisted identity, never
+        // matches a target — the kind-confusion safety rule.
+        _ => false,
+    }
+}
+
+/// Arm — for Phase-0b completion — every signal-`Waiting` node selected by
+/// `resume_target`, returning the armed node keys (ADR-0099 W-S3a).
+///
+/// Shared by the two Resume arm sites — the `Paused` no-live-runner satisfy-CAS
+/// (under the freshly-acquired lease) and the live-frontier `ResumeSignalled`
+/// self-arm (under the loop's own lease). A node is selected when it is
+/// `Waiting`, [`is_signal_wait`] (a signal-only OR signal+timeout wait, never a
+/// timer-driven completion wait), AND matched by the target:
+///
+/// - `Some(target)` → KIND-AWARE match via [`matches_resume_target`]: arms only
+///   the node whose persisted [`WaitSignal`] equals the target by kind +
+///   identity. This is the structural close of both confused-deputy bugs (one
+///   Resume satisfying a sibling wait; a webhook Resume satisfying an approval
+///   gate).
+/// - `None` → the legacy untargeted Resume: arms every signal-`Waiting` node
+///   (preserves the W-S2b behavior).
+///
+/// Mutates only the in-memory `exec_state` (via [`arm_wait_completion`], the
+/// paired `next_attempt_at`/`wait_wake` write); the CALLER owns the lease and
+/// the durable checkpoint that commits the arm, preserving the
+/// own-the-lease-before-RMW invariant (#856). Does NOT bump the version — the
+/// caller does (mirroring each existing site's single bump).
+///
+/// [`arm_wait_completion`]: nebula_execution::state::NodeExecutionState::arm_wait_completion
+/// [`WaitSignal`]: nebula_execution::state::WaitSignal
+fn arm_signal_waits_under_lease(
+    exec_state: &mut ExecutionState,
+    resume_target: Option<&ResumeTarget>,
+    now: DateTime<Utc>,
+) -> Vec<NodeKey> {
+    let to_arm: Vec<NodeKey> = exec_state
+        .node_states
+        .iter()
+        .filter(|(_, ns)| {
+            ns.state == NodeState::Waiting
+                && is_signal_wait(ns)
+                && match resume_target {
+                    Some(target) => matches_resume_target(ns, target),
+                    None => true,
+                }
+        })
+        .map(|(id, _)| id.clone())
+        .collect();
+    for node_key in &to_arm {
+        if let Some(ns) = exec_state.node_states.get_mut(node_key) {
+            // Arm for COMPLETION: a satisfied signal wait wakes to complete the
+            // node (`Waiting → Completed`), never to fail. The paired write
+            // keeps the next_attempt_at/wait_wake invariant intact.
+            ns.arm_wait_completion(now);
+        }
+    }
+    to_arm
 }
 
 /// Mark a node as failed in the execution state.
@@ -12465,7 +12599,7 @@ mod tests {
     #[tokio::test]
     async fn resume_live_no_live_entry_when_absent() {
         let (engine, _) = make_engine(Arc::new(ActionRegistry::new()));
-        let outcome = engine.resume_live(ExecutionId::new()).await;
+        let outcome = engine.resume_live(ExecutionId::new(), None).await;
         assert!(
             matches!(outcome, ResumeDelivery::NoLiveEntry),
             "an absent execution must yield NoLiveEntry, got {outcome:?}"
@@ -12491,7 +12625,7 @@ mod tests {
             drop(req);
         });
 
-        let outcome = engine.resume_live(execution_id).await;
+        let outcome = engine.resume_live(execution_id, None).await;
         loop_side.await.unwrap();
         assert!(
             matches!(outcome, ResumeDelivery::LoopGone),
@@ -12512,7 +12646,7 @@ mod tests {
         let (_resume_rx, _guard) = publish_running_entry(&engine, execution_id);
 
         let engine_h = Arc::clone(&engine);
-        let resume = tokio::spawn(async move { engine_h.resume_live(execution_id).await });
+        let resume = tokio::spawn(async move { engine_h.resume_live(execution_id, None).await });
         // Advance past the ack timeout under paused time.
         tokio::time::advance(RESUME_ACK_TIMEOUT + Duration::from_secs(1)).await;
         let outcome = resume.await.unwrap();

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -101,6 +101,7 @@ pub use daemon::{
 pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, WorkflowEngine};
 pub use error::EngineError;
 pub use event::ExecutionEvent;
+pub use nebula_storage_port::dto::ResumeTarget;
 pub use plugin_wiring::PluginWiringError;
 // Re-export plugin types for convenience.
 pub use nebula_plugin::{Plugin, PluginKey, PluginManifest, PluginRegistry, ResolvedPlugin};

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -28,7 +28,7 @@ use nebula_storage::{InMemoryControlQueue, InMemoryExecutionStore};
 use nebula_storage_port::store::ControlQueue;
 use nebula_storage_port::{
     Scope,
-    dto::{ControlCommand, ControlMsg},
+    dto::{ControlCommand, ControlMsg, ResumeTarget},
 };
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
@@ -63,6 +63,20 @@ fn port_msg(execution_id: &ExecutionId, command: ControlCommand, row_id: u8) -> 
         scope: nebula_engine::store_seam::single_tenant_scope(),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
+    }
+}
+
+/// Build a `Resume` control message carrying an explicit `resume_target`, so a
+/// test can assert the consumer threads it through to `dispatch_resume` (W-S3a).
+fn port_resume_msg(
+    execution_id: &ExecutionId,
+    row_id: u8,
+    resume_target: Option<ResumeTarget>,
+) -> ControlMsg {
+    ControlMsg {
+        resume_target,
+        ..port_msg(execution_id, ControlCommand::Resume, row_id)
     }
 }
 
@@ -77,6 +91,11 @@ fn port_msg(execution_id: &ExecutionId, command: ControlCommand, row_id: u8) -> 
 #[derive(Default)]
 struct RecordingDispatch {
     observations: Mutex<Vec<(ControlCommand, ExecutionId, Scope)>>,
+    /// Resume targets observed on `dispatch_resume`, in arrival order. The
+    /// decisive witness that `ControlConsumer` threads `ControlMsg.resume_target`
+    /// through to the dispatch (W-S3a) — a regression that drops or hardcodes the
+    /// target would still leave the command/scope wiring tests green.
+    resume_targets: Mutex<Vec<Option<ResumeTarget>>>,
     notify: Notify,
 }
 
@@ -95,6 +114,10 @@ impl RecordingDispatch {
 
     fn snapshot(&self) -> Vec<(ControlCommand, ExecutionId, Scope)> {
         self.observations.lock().expect("poisoned").clone()
+    }
+
+    fn resume_target_snapshot(&self) -> Vec<Option<ResumeTarget>> {
+        self.resume_targets.lock().expect("poisoned").clone()
     }
 }
 
@@ -131,7 +154,12 @@ impl ControlDispatch for RecordingDispatch {
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+        resume_target: Option<ResumeTarget>,
     ) -> Result<(), ControlDispatchError> {
+        self.resume_targets
+            .lock()
+            .expect("poisoned")
+            .push(resume_target);
         self.record(ControlCommand::Resume, execution_id, scope.clone());
         Ok(())
     }
@@ -223,6 +251,7 @@ impl ControlDispatch for FlakyDispatch {
         &self,
         _scope: &Scope,
         execution_id: ExecutionId,
+        _resume_target: Option<ResumeTarget>,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
         self.record(ControlCommand::Resume, execution_id);
@@ -375,6 +404,72 @@ async fn consumer_observes_each_command_variant_via_dispatch_trait() {
     assert!(
         leftover.is_empty(),
         "all rows acked — claim_pending sees nothing pending"
+    );
+}
+
+/// **W-S3a — the consumer threads `ControlMsg.resume_target` into
+/// `dispatch_resume`.**
+///
+/// Enqueue two `Resume` rows: one carrying `resume_target = Some(Webhook { "cb"
+/// })` and one untargeted (`None`). The consumer must deliver each row's target
+/// to `dispatch_resume` unchanged. A regression that dropped or hardcoded the
+/// target would still leave the command/scope wiring tests green — so the
+/// observed targets are the decisive witness.
+///
+/// **Falsifiability**: have `handle_entry` pass `None` instead of
+/// `resume_target` (or drop the `ClaimedRow.resume_target` field) → the
+/// `Some(Webhook{..})` observation becomes `None` → the assertion fails → RED.
+#[tokio::test]
+async fn consumer_threads_resume_target_into_dispatch() {
+    let (_store, queue) = port_queue();
+    let recorder = RecordingDispatch::new();
+    let dispatch: Arc<dyn ControlDispatch> = recorder.clone();
+
+    let exec_targeted = ExecutionId::new();
+    let exec_untargeted = ExecutionId::new();
+    let target = ResumeTarget::Webhook {
+        callback_id: "cb".to_owned(),
+    };
+
+    queue
+        .enqueue(&port_resume_msg(&exec_targeted, 0, Some(target.clone())))
+        .await
+        .unwrap();
+    queue
+        .enqueue(&port_resume_msg(&exec_untargeted, 1, None))
+        .await
+        .unwrap();
+
+    let consumer = ControlConsumer::new(queue.clone(), dispatch, proc16(b"test-processor"))
+        .with_batch_size(16)
+        .with_poll_interval(Duration::from_millis(10));
+    let shutdown = CancellationToken::new();
+    let handle = consumer.spawn(shutdown.clone());
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if recorder.resume_target_snapshot().len() >= 2 {
+                break;
+            }
+            recorder.notify.notified().await;
+        }
+    })
+    .await
+    .expect("both Resume commands observed within 2s");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let targets = recorder.resume_target_snapshot();
+    assert_eq!(targets.len(), 2, "both Resume rows reached dispatch_resume");
+    assert!(
+        targets.contains(&Some(target)),
+        "the targeted Resume must thread Some(Webhook{{callback_id:\"cb\"}}) \
+         into dispatch_resume; observed {targets:?}"
+    );
+    assert!(
+        targets.contains(&None),
+        "the untargeted Resume must thread None into dispatch_resume; observed {targets:?}"
     );
 }
 

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -450,6 +450,7 @@ async fn dispatch_resume_drives_created_execution_to_completion() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume succeeds");
@@ -476,6 +477,7 @@ async fn dispatch_resume_is_idempotent_on_completed_execution() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .unwrap();
@@ -486,6 +488,7 @@ async fn dispatch_resume_is_idempotent_on_completed_execution() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("second resume is idempotent");

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -652,6 +652,7 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
             scope: nebula_engine::store_seam::single_tenant_scope(),
             w3c_traceparent: None,
             reclaim_count: 0,
+            resume_target: None,
         })
         .await
         .unwrap();

--- a/crates/engine/tests/resume_targeting.rs
+++ b/crates/engine/tests/resume_targeting.rs
@@ -1,0 +1,1012 @@
+//! Integration tests for ADR-0099 **W-S3a** — targeted, kind-aware Resume.
+//!
+//! W-S2b shipped the resume machinery but it is UNTARGETED: a Resume arms every
+//! signal-`Waiting` node of an execution. W-S3a persists each parked node's
+//! resume-IDENTITY (`WaitSignal`) and threads a `ResumeTarget` through
+//! `dispatch_resume` so a Resume arms ONLY the matching wait — and a webhook
+//! Resume can NEVER satisfy an approval gate (the kind-confusion safety rule).
+//!
+//! These tests drive a store-backed engine so the durable satisfy-CAS written
+//! by `satisfy_signal_waits` is observable, and assert on EFFECTS (which
+//! downstream gate ran, which node stayed `Waiting`) — not implementation
+//! details. Each has a falsifiability clause naming the regression it catches.
+//!
+//! ## Timing discipline
+//!
+//! `dispatch_start` / `dispatch_resume` both run the frontier loop synchronously
+//! to completion (park or terminal), so assertions follow immediately — no
+//! wall-clock sleeps.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+
+use chrono::Utc;
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, DataPassingPolicy,
+    EngineControlDispatch, InProcessRunner, ResumeTarget, WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
+use nebula_storage_port::{
+    dto::WorkflowVersionRecord,
+    store::{ExecutionStore, WorkflowVersionStore},
+};
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Action stubs ──────────────────────────────────────────────────────────────
+
+macro_rules! static_action_impl {
+    ($ty:ty, $key:expr, $name:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, "resume_targeting integration test stub")
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+/// Parks on `WaitCondition::Webhook { callback_id: "A" }` (no timeout) →
+/// persists `WaitSignal::Webhook { callback_id: "A" }`.
+struct WebhookWaitA;
+static_action_impl!(
+    WebhookWaitA,
+    action_key!("test.target.webhook_a"),
+    "WebhookWaitA"
+);
+impl StatelessAction for WebhookWaitA {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "A".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Parks on `WaitCondition::Webhook { callback_id: "B" }` (no timeout) →
+/// persists `WaitSignal::Webhook { callback_id: "B" }`.
+struct WebhookWaitB;
+static_action_impl!(
+    WebhookWaitB,
+    action_key!("test.target.webhook_b"),
+    "WebhookWaitB"
+);
+impl StatelessAction for WebhookWaitB {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "B".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Parks on `WaitCondition::Approval { approver: "boss", .. }` (no timeout) →
+/// persists `WaitSignal::Approval { approver: "boss" }`. The approval `message`
+/// is deliberately NOT persisted (that is W-S4).
+struct ApprovalWaitBoss;
+static_action_impl!(
+    ApprovalWaitBoss,
+    action_key!("test.target.approval_boss"),
+    "ApprovalWaitBoss"
+);
+impl StatelessAction for ApprovalWaitBoss {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Approval {
+                approver: "boss".to_owned(),
+                message: "please approve".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Counts invocations and succeeds — a downstream gate probe. The test asserts
+/// the exact invocation count to verify which wait's edge activated.
+struct CountingEcho {
+    invocation_count: Arc<AtomicU32>,
+}
+static_action_impl!(
+    CountingEcho,
+    action_key!("test.target.echo"),
+    "CountingEcho"
+);
+impl StatelessAction for CountingEcho {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocation_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// A second echo key so two independent waits can each gate their own probe.
+struct CountingEchoB {
+    invocation_count: Arc<AtomicU32>,
+}
+static_action_impl!(
+    CountingEchoB,
+    action_key!("test.target.echo_b"),
+    "CountingEchoB"
+);
+impl StatelessAction for CountingEchoB {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocation_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Stores ──────────────────────────────────────────────────────────────────
+
+struct Stores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl Stores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+
+    async fn save_workflow(&self, wf: &WorkflowDefinition) {
+        self.versions
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                WorkflowVersionRecord {
+                    workflow_id: wf.id.to_string(),
+                    number: 0,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(wf).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn create_execution(&self, workflow_id: nebula_core::WorkflowId) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        let state_json = serde_json::to_value(&exec_state).unwrap();
+        self.execution
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+                &workflow_id.to_string(),
+                state_json,
+            )
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    async fn persisted_status(&self, execution_id: ExecutionId) -> ExecutionStatus {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
+    }
+}
+
+/// Wire an engine + dispatch over a fresh registry. The caller registers the
+/// action keys it needs first.
+fn build(registry: Arc<ActionRegistry>, stores: &Stores) -> EngineControlDispatch {
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = Arc::new(stores.attach(WorkflowEngine::new(runtime, metrics).unwrap()));
+    EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone())
+}
+
+/// Register a stateless action instance under the metadata its `Action` impl
+/// declares — mirrors the `SignalHarness` registration pattern (the metadata's
+/// key must match the `NodeDefinition` action ref string).
+fn register_stateless<A>(registry: &ActionRegistry, action: A)
+where
+    A: StatelessAction + 'static,
+{
+    registry.register_stateless_instance(A::metadata(), action);
+}
+
+/// Two independent root waits, each gating its own downstream echo:
+/// `wait_a → echo_a` and `wait_b → echo_b`. Returns `(workflow_id)`.
+async fn two_webhook_subgraphs(
+    stores: &Stores,
+    echo_a: Arc<AtomicU32>,
+    echo_b: Arc<AtomicU32>,
+) -> (Arc<ActionRegistry>, nebula_core::WorkflowId) {
+    let registry = Arc::new(ActionRegistry::new());
+    register_stateless(&registry, WebhookWaitA);
+    register_stateless(&registry, WebhookWaitB);
+    register_stateless(
+        &registry,
+        CountingEcho {
+            invocation_count: echo_a,
+        },
+    );
+    register_stateless(
+        &registry,
+        CountingEchoB {
+            invocation_count: echo_b,
+        },
+    );
+
+    let wait_a = node_key!("wait_a");
+    let wait_b = node_key!("wait_b");
+    let downstream_a = node_key!("echo_a");
+    let downstream_b = node_key!("echo_b");
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "two-webhook-subgraphs".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(wait_a.clone(), "WaitA", "core", "test.target.webhook_a").unwrap(),
+            NodeDefinition::new(wait_b.clone(), "WaitB", "core", "test.target.webhook_b").unwrap(),
+            NodeDefinition::new(downstream_a.clone(), "EchoA", "core", "test.target.echo").unwrap(),
+            NodeDefinition::new(downstream_b.clone(), "EchoB", "core", "test.target.echo_b")
+                .unwrap(),
+        ],
+        connections: vec![
+            Connection::new(wait_a, downstream_a),
+            Connection::new(wait_b, downstream_b),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+    (registry, workflow_id)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+/// **W-S3a — a targeted Resume arms ONLY the matching callback_id.**
+///
+/// Two independent webhook waits in one execution (`wait_a` cb="A" → `echo_a`,
+/// `wait_b` cb="B" → `echo_b`). A Resume targeting `Webhook { callback_id: "A" }`
+/// must arm ONLY `wait_a`: `echo_a` runs exactly once, `echo_b` stays 0, and the
+/// execution stays `Paused` because `wait_b` is still parked.
+///
+/// **Falsifiability**: revert the identity match (make the arm predicate ignore
+/// the target and arm every signal wait, as W-S2b did) → BOTH waits arm →
+/// `echo_b == 1` and the execution Completes → the `echo_b == 0` / `Paused`
+/// assertions fail → RED.
+#[tokio::test]
+async fn targeted_resume_arms_only_matching_callback() {
+    let echo_a = Arc::new(AtomicU32::new(0));
+    let echo_b = Arc::new(AtomicU32::new(0));
+    let stores = Stores::new();
+    let (registry, workflow_id) =
+        two_webhook_subgraphs(&stores, Arc::clone(&echo_a), Arc::clone(&echo_b)).await;
+    let dispatch = build(registry, &stores);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let execution_id = stores.create_execution(workflow_id).await;
+
+    // Park both waits → execution Paused.
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park both webhook waits");
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after both signal nodes park"
+    );
+
+    // Targeted Resume for callback_id "A" — arms ONLY wait_a.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Webhook {
+                callback_id: "A".to_owned(),
+            }),
+        )
+        .await
+        .expect("targeted dispatch_resume must satisfy only the matching wait");
+
+    assert_eq!(
+        echo_a.load(Ordering::SeqCst),
+        1,
+        "echo_a must run exactly once — its wait was the target"
+    );
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        0,
+        "echo_b must NOT run — its wait (cb=B) was not targeted"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must stay Paused — wait_b is still parked"
+    );
+
+    // Now target "B": arms wait_b, runs echo_b, and the execution completes.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Webhook {
+                callback_id: "B".to_owned(),
+            }),
+        )
+        .await
+        .expect("second targeted dispatch_resume must satisfy the remaining wait");
+
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        1,
+        "echo_b must run exactly once after its callback is targeted"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must Complete once both waits have been targeted"
+    );
+}
+
+/// **W-S3a — a webhook Resume must NOT satisfy an approval gate (KIND-CONFUSION).**
+///
+/// One subgraph parks a `Webhook { callback_id: "boss" }` wait (→ `echo_a`); the
+/// other parks an `Approval { approver: "boss" }` gate (→ `echo_b`). The
+/// identities deliberately COLLIDE ("boss" == "boss"), so the only thing that
+/// can keep a webhook Resume from satisfying the approval gate is the KIND
+/// discriminator. A Resume targeting `Webhook { callback_id: "boss" }` must arm
+/// ONLY the webhook wait and must NEVER touch the approval gate.
+///
+/// This is the load-bearing security invariant: a webhook callback must not be
+/// able to forge a human approval — even when the labels coincide.
+///
+/// **Falsifiability**: revert the kind-awareness (match on the bare identity
+/// string, ignoring the variant kind) → the colliding "boss" identity makes the
+/// webhook Resume also arm the approval gate → `echo_b == 1` → the
+/// `echo_b == 0` assertion fails → RED.
+#[tokio::test]
+async fn webhook_resume_does_not_satisfy_approval_gate() {
+    let echo_a = Arc::new(AtomicU32::new(0));
+    let echo_b = Arc::new(AtomicU32::new(0));
+    let stores = Stores::new();
+
+    let registry = Arc::new(ActionRegistry::new());
+    register_stateless(&registry, WebhookWaitX);
+    register_stateless(&registry, ApprovalWaitBoss);
+    register_stateless(
+        &registry,
+        CountingEcho {
+            invocation_count: Arc::clone(&echo_a),
+        },
+    );
+    register_stateless(
+        &registry,
+        CountingEchoB {
+            invocation_count: Arc::clone(&echo_b),
+        },
+    );
+
+    let wait_webhook = node_key!("wait_webhook");
+    let wait_approval = node_key!("wait_approval");
+    let downstream_a = node_key!("echo_a");
+    let downstream_b = node_key!("echo_b");
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "webhook-vs-approval".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                wait_webhook.clone(),
+                "WaitWebhook",
+                "core",
+                "test.target.webhook_a",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                wait_approval.clone(),
+                "WaitApproval",
+                "core",
+                "test.target.approval_boss",
+            )
+            .unwrap(),
+            NodeDefinition::new(downstream_a.clone(), "EchoA", "core", "test.target.echo").unwrap(),
+            NodeDefinition::new(downstream_b.clone(), "EchoB", "core", "test.target.echo_b")
+                .unwrap(),
+        ],
+        connections: vec![
+            Connection::new(wait_webhook, downstream_a),
+            Connection::new(wait_approval, downstream_b),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let dispatch = build(registry, &stores);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let execution_id = stores.create_execution(workflow_id).await;
+
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the webhook wait and the approval gate");
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused with both signal nodes parked"
+    );
+
+    // A webhook Resume for "boss" must arm ONLY the webhook wait, never the
+    // approval gate — despite the colliding "boss" identity.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Webhook {
+                callback_id: "boss".to_owned(),
+            }),
+        )
+        .await
+        .expect("webhook-targeted dispatch_resume must satisfy only the webhook wait");
+
+    assert_eq!(
+        echo_a.load(Ordering::SeqCst),
+        1,
+        "the webhook wait's downstream must run exactly once"
+    );
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        0,
+        "the APPROVAL gate's downstream must NOT run — a webhook Resume must never \
+         satisfy an approval gate (kind-confusion safety rule)"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must stay Paused — the approval gate is still awaiting approval"
+    );
+}
+
+/// **W-S3a — an untargeted Resume preserves the W-S2b all-arm behavior.**
+///
+/// With `resume_target == None`, a Resume arms EVERY signal-`Waiting` node — so
+/// both independent webhook waits complete in one pass and the execution runs to
+/// `Completed` with both downstream probes fired exactly once.
+///
+/// **Falsifiability**: make `None` arm nothing (or only the first node) → one
+/// wait stays `Waiting` → the execution stays `Paused` and at least one
+/// `echo == 1` assertion fails → RED.
+#[tokio::test]
+async fn untargeted_resume_keeps_legacy_all_arm() {
+    let echo_a = Arc::new(AtomicU32::new(0));
+    let echo_b = Arc::new(AtomicU32::new(0));
+    let stores = Stores::new();
+    let (registry, workflow_id) =
+        two_webhook_subgraphs(&stores, Arc::clone(&echo_a), Arc::clone(&echo_b)).await;
+    let dispatch = build(registry, &stores);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let execution_id = stores.create_execution(workflow_id).await;
+
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park both webhook waits");
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    // Untargeted Resume — arms ALL signal waits (W-S2b behavior).
+    dispatch
+        .dispatch_resume(&scope, execution_id, None)
+        .await
+        .expect("untargeted dispatch_resume must satisfy every signal wait");
+
+    assert_eq!(
+        echo_a.load(Ordering::SeqCst),
+        1,
+        "echo_a must run — an untargeted Resume arms every signal wait"
+    );
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        1,
+        "echo_b must run — an untargeted Resume arms every signal wait"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must Complete — both waits armed in one untargeted pass"
+    );
+}
+
+/// A `Webhook { callback_id: "boss" }` wait whose callback_id deliberately
+/// COLLIDES with the approval gate's `approver` ("boss"). This makes the
+/// kind-confusion test's safety guard depend on the KIND discriminator alone:
+/// a kind-blind matcher comparing only the identity string would wrongly arm
+/// the approval gate. Reuses the `webhook_a` action key so the registry stays
+/// small (only one webhook action is registered per test).
+struct WebhookWaitX;
+static_action_impl!(
+    WebhookWaitX,
+    action_key!("test.target.webhook_a"),
+    "WebhookWaitX"
+);
+impl StatelessAction for WebhookWaitX {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "boss".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Parks on `WaitCondition::Execution { execution_id }` (no timeout), where
+/// `execution_id` is supplied at construction time. Used by the Execution-kind
+/// targeting tests so two sibling waits can park on DIFFERENT `ExecutionId`s.
+struct ExecutionWait {
+    wait_for: ExecutionId,
+}
+impl Action for ExecutionWait {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.target.execution_wait"),
+            "ExecutionWait",
+            "resume_targeting Execution-kind stub",
+        )
+    }
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+impl StatelessAction for ExecutionWait {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Execution {
+                execution_id: self.wait_for,
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// A second independent Execution-kind wait action key so the workflow DAG
+/// can have two `ExecutionWait` nodes without key collision.
+struct ExecutionWaitB {
+    wait_for: ExecutionId,
+}
+impl Action for ExecutionWaitB {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.target.execution_wait_b"),
+            "ExecutionWaitB",
+            "resume_targeting Execution-kind stub B",
+        )
+    }
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+impl StatelessAction for ExecutionWaitB {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Execution {
+                execution_id: self.wait_for,
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+// ── Execution-kind targeting tests ────────────────────────────────────────────
+
+/// **W-S3a — a targeted Resume arms ONLY the matching `ExecutionId`.**
+///
+/// Two independent `Execution`-kind waits in one execution: `wait_x` parks on
+/// `execution_id = X` (→ `echo_a`) and `wait_y` parks on `execution_id = Y`
+/// (→ `echo_b`). A Resume targeting `Execution { execution_id: X.to_string() }`
+/// must arm ONLY `wait_x`: `echo_a` runs exactly once, `echo_b` stays 0, and
+/// the execution stays `Paused` because `wait_y` is still parked.
+///
+/// **Falsifiability**: revert the identity check in the `Execution` arm of
+/// `matches_resume_target` to always return `true` (kind-only, ignoring the
+/// id string) → both waits arm → `echo_b == 1` and the execution Completes →
+/// the `echo_b == 0` / `Paused` assertions fail → RED.
+#[tokio::test]
+async fn targeted_resume_arms_only_matching_execution() {
+    let exec_id_x = ExecutionId::new();
+    let exec_id_y = ExecutionId::new();
+    let echo_a = Arc::new(AtomicU32::new(0));
+    let echo_b = Arc::new(AtomicU32::new(0));
+    let stores = Stores::new();
+
+    let registry = Arc::new(ActionRegistry::new());
+    // Two sibling waits on DIFFERENT ExecutionIds — DAG: wait_x→echo_a, wait_y→echo_b.
+    registry.register_stateless_instance(
+        ExecutionWait::metadata(),
+        ExecutionWait {
+            wait_for: exec_id_x,
+        },
+    );
+    registry.register_stateless_instance(
+        ExecutionWaitB::metadata(),
+        ExecutionWaitB {
+            wait_for: exec_id_y,
+        },
+    );
+    register_stateless(
+        &registry,
+        CountingEcho {
+            invocation_count: Arc::clone(&echo_a),
+        },
+    );
+    register_stateless(
+        &registry,
+        CountingEchoB {
+            invocation_count: Arc::clone(&echo_b),
+        },
+    );
+
+    let wait_x = node_key!("wait_x");
+    let wait_y = node_key!("wait_y");
+    let downstream_a = node_key!("echo_a");
+    let downstream_b = node_key!("echo_b");
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "two-execution-waits".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                wait_x.clone(),
+                "WaitX",
+                "core",
+                "test.target.execution_wait",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                wait_y.clone(),
+                "WaitY",
+                "core",
+                "test.target.execution_wait_b",
+            )
+            .unwrap(),
+            NodeDefinition::new(downstream_a.clone(), "EchoA", "core", "test.target.echo").unwrap(),
+            NodeDefinition::new(downstream_b.clone(), "EchoB", "core", "test.target.echo_b")
+                .unwrap(),
+        ],
+        connections: vec![
+            Connection::new(wait_x, downstream_a),
+            Connection::new(wait_y, downstream_b),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let dispatch = build(registry, &stores);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let execution_id = stores.create_execution(workflow_id).await;
+
+    // Park both Execution-kind waits.
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park both execution-kind waits");
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after both execution-kind waits park"
+    );
+
+    // Resume targeting ONLY execution_id X — must arm wait_x, never wait_y.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Execution {
+                execution_id: exec_id_x.to_string(),
+            }),
+        )
+        .await
+        .expect("targeted dispatch_resume must satisfy only the X execution wait");
+
+    assert_eq!(
+        echo_a.load(Ordering::SeqCst),
+        1,
+        "echo_a must run exactly once — wait_x (id=X) was the target"
+    );
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        0,
+        "echo_b must NOT run — wait_y (id=Y) was not targeted by the X Resume"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must stay Paused — wait_y is still parked"
+    );
+
+    // Resume targeting Y — arms wait_y, runs echo_b, execution Completes.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Execution {
+                execution_id: exec_id_y.to_string(),
+            }),
+        )
+        .await
+        .expect("second targeted dispatch_resume must satisfy the remaining wait");
+
+    assert_eq!(
+        echo_b.load(Ordering::SeqCst),
+        1,
+        "echo_b must run exactly once after wait_y is targeted"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must Complete once both Execution-kind waits have been targeted"
+    );
+}
+
+/// **W-S3a — a malformed `execution_id` string in the target never matches.**
+///
+/// A node parks on a valid `Execution { execution_id: X }` wait. A Resume is
+/// sent whose `ResumeTarget::Execution { execution_id }` carries a string that
+/// does NOT parse as a valid `ExecutionId` (e.g. `"not-a-valid-uuid"`). The
+/// `matches_resume_target` Execution arm calls `want.parse::<ExecutionId>()`
+/// which returns `Err` → `is_ok_and(...)` returns `false` → the node stays
+/// `Waiting` and the execution stays `Paused`. No panic, no spurious arm.
+///
+/// **Falsifiability**: remove the `parse::<ExecutionId>()` type gate and
+/// compare raw strings (`execution_id.to_string() == *want`) → the malformed
+/// string never equals the valid id, so this test would actually still pass —
+/// BUT the clippy `cmp_owned` lint fires and (more importantly) a *different*
+/// well-formed string that happens to share the same text but represents a
+/// different semantic type would match. The real invariant tested here is that
+/// the `Err` path of `parse` closes silently (no panic, no match).
+#[tokio::test]
+async fn execution_resume_parse_fail_never_matches() {
+    let exec_id_real = ExecutionId::new();
+    let echo_a = Arc::new(AtomicU32::new(0));
+    let stores = Stores::new();
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ExecutionWait::metadata(),
+        ExecutionWait {
+            wait_for: exec_id_real,
+        },
+    );
+    register_stateless(
+        &registry,
+        CountingEcho {
+            invocation_count: Arc::clone(&echo_a),
+        },
+    );
+
+    let wait_node = node_key!("wait_exec");
+    let echo_node = node_key!("echo_a");
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "execution-parse-fail".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                wait_node.clone(),
+                "WaitExec",
+                "core",
+                "test.target.execution_wait",
+            )
+            .unwrap(),
+            NodeDefinition::new(echo_node.clone(), "Echo", "core", "test.target.echo").unwrap(),
+        ],
+        connections: vec![Connection::new(wait_node, echo_node)],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let dispatch = build(registry, &stores);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let execution_id = stores.create_execution(workflow_id).await;
+
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the execution-kind wait");
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after the execution-kind wait parks"
+    );
+
+    // Resume with a string that does NOT parse as a valid ExecutionId.
+    dispatch
+        .dispatch_resume(
+            &scope,
+            execution_id,
+            Some(ResumeTarget::Execution {
+                execution_id: "not-a-valid-uuid".to_owned(),
+            }),
+        )
+        .await
+        .expect("dispatch_resume must not error — a parse-fail simply does not match");
+
+    // The parse-fail must close silently: no arm, no panic.
+    assert_eq!(
+        echo_a.load(Ordering::SeqCst),
+        0,
+        "echo must NOT run — the malformed target id must never match the parked wait"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must stay Paused — the malformed target left the wait intact"
+    );
+}

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -481,6 +481,7 @@ async fn dispatch_resume_satisfies_signal_wait_and_drives_to_completed() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume must satisfy the signal wait and drive to completion");
@@ -570,6 +571,7 @@ async fn dispatch_start_redelivery_does_not_satisfy_signal_wait() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("genuine dispatch_resume must satisfy the wait and complete the execution");
@@ -620,6 +622,7 @@ async fn dispatch_resume_is_idempotent_after_signal_wait_satisfied() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("first dispatch_resume must satisfy the wait");
@@ -635,6 +638,7 @@ async fn dispatch_resume_is_idempotent_after_signal_wait_satisfied() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("second dispatch_resume on a Completed execution must be idempotent");
@@ -821,6 +825,7 @@ async fn dispatch_resume_satisfies_all_signal_waits_in_one_pass() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume must satisfy all signal waits in one pass");
@@ -878,6 +883,7 @@ async fn dispatch_resume_on_created_execution_still_completes() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume on a Created execution must not error");
@@ -962,6 +968,7 @@ async fn dispatch_restart_does_not_satisfy_signal_wait() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("genuine dispatch_resume must satisfy the wait and complete the execution");
@@ -1019,6 +1026,7 @@ async fn two_sequential_resumes_produce_exactly_one_downstream_run() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("first Resume must satisfy the wait");
@@ -1030,6 +1038,7 @@ async fn two_sequential_resumes_produce_exactly_one_downstream_run() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("second Resume must be idempotent");
@@ -1106,7 +1115,10 @@ async fn dispatch_resume_defers_when_execution_lease_is_held() {
     // `satisfy_signal_waits` will find the lease busy and return `Leased`.
     // `dispatch_resume` must propagate this as `ControlDispatchError::Deferred`
     // so the consumer leaves the control-queue row in `Processing` for B1 reclaim.
-    let result = harness.dispatch.dispatch_resume(&scope, execution_id).await;
+    let result = harness
+        .dispatch
+        .dispatch_resume(&scope, execution_id, None)
+        .await;
     assert!(
         matches!(result, Err(ControlDispatchError::Deferred(_))),
         "dispatch_resume must return Deferred when the execution lease is held; got {result:?}"
@@ -1136,7 +1148,7 @@ async fn dispatch_resume_defers_when_execution_lease_is_held() {
     // The B1 reclaim path would redeliver the Resume command.  Simulate redelivery.
     harness
         .dispatch
-        .dispatch_resume(&scope, execution_id)
+        .dispatch_resume(&scope, execution_id, None)
         .await
         .expect("redelivered dispatch_resume must succeed after the lease is released");
 
@@ -1197,7 +1209,7 @@ async fn satisfy_signal_waits_releases_lease_after_commit() {
     // lease, drives (Phase-0b completes the node).
     harness
         .dispatch
-        .dispatch_resume(&scope, execution_id)
+        .dispatch_resume(&scope, execution_id, None)
         .await
         .expect("first dispatch_resume must succeed");
     assert_eq!(
@@ -1210,7 +1222,7 @@ async fn satisfy_signal_waits_releases_lease_after_commit() {
     // return Deferred — it returns Ok(()) proving the lease was released.
     harness
         .dispatch
-        .dispatch_resume(&scope, execution_id)
+        .dispatch_resume(&scope, execution_id, None)
         .await
         .expect("duplicate dispatch_resume on Completed must be a no-op, not Deferred");
 
@@ -1454,7 +1466,7 @@ async fn dispatch_resume_defers_when_satisfy_commit_is_fenced_out_and_execution_
     // ── Phase 3: arm the interceptor and call dispatch_resume ─────────────────
     interceptor.arm();
 
-    let result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    let result = dispatch2.dispatch_resume(&scope, execution_id, None).await;
     assert!(
         matches!(result, Err(ControlDispatchError::Deferred(_))),
         "dispatch_resume must return Deferred when satisfy_signal_waits is FencedOut \
@@ -1477,7 +1489,7 @@ async fn dispatch_resume_defers_when_satisfy_commit_is_fenced_out_and_execution_
     //
     // The interceptor self-disarmed after the first intercept, so this
     // redelivery goes through to the real store and the wait is properly satisfied.
-    let redeliver_result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    let redeliver_result = dispatch2.dispatch_resume(&scope, execution_id, None).await;
     assert!(
         redeliver_result.is_ok(),
         "redelivered dispatch_resume must succeed after the interceptor disarms; \
@@ -1742,7 +1754,7 @@ async fn satisfy_signal_waits_skips_when_execution_cancelled_under_lease() {
     // ── Phase 3: arm the injection and call dispatch_resume ───────────────────
     interceptor.arm();
 
-    let result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    let result = dispatch2.dispatch_resume(&scope, execution_id, None).await;
     assert!(
         result.is_ok(),
         "dispatch_resume must ack (Ok) when the execution was cancelled before satisfy; \
@@ -1947,7 +1959,7 @@ async fn satisfied_signal_wait_activates_main_port_only_not_error_branch() {
 
     // Resume: satisfy arms the wait, Phase-0b completes it on the main port.
     dispatch
-        .dispatch_resume(&scope, execution_id)
+        .dispatch_resume(&scope, execution_id, None)
         .await
         .expect("dispatch_resume must succeed");
 
@@ -2273,7 +2285,7 @@ async fn armed_signal_wait_is_completed_by_reclaim_drive_not_lost() {
     // execution when the lease holder is a crashed runner whose TTL has not
     // expired yet (P1: keep Resume redeliverable after drive lease contention).
     interceptor.arm_to_fail_the_drive();
-    let deferred = dispatch.dispatch_resume(&scope, execution_id).await;
+    let deferred = dispatch.dispatch_resume(&scope, execution_id, None).await;
     assert!(
         matches!(deferred, Err(ControlDispatchError::Deferred(_))),
         "post-satisfy drive that fails to acquire the lease must Defer (keep the Resume \

--- a/crates/engine/tests/wait_timeout.rs
+++ b/crates/engine/tests/wait_timeout.rs
@@ -847,6 +847,7 @@ async fn resume_before_timeout_completes_main_port_and_cancels_timer() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume on a live Running execution must succeed");
@@ -921,6 +922,7 @@ async fn resume_to_running_execution_reaches_live_loop() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume to a Running execution must be Ok (delivered to live loop)");
@@ -1268,6 +1270,7 @@ async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume must deliver to the live loop");
@@ -1547,6 +1550,7 @@ async fn one_resume_arms_multiple_parallel_signal_timeout_waits() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume on the live Running execution must succeed");
@@ -1624,6 +1628,7 @@ async fn resume_acks_only_after_successful_checkpoint() {
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
             execution_id,
+            None,
         )
         .await
         .expect("dispatch_resume on a live Running execution must succeed");
@@ -1769,7 +1774,7 @@ async fn fenced_out_self_arm_sends_arm_failed_then_deferred() {
     // FencedOut. The park checkpoint already landed before `NodeParked`.
     fenced.arm_fence();
 
-    let dispatch_outcome = dispatch.dispatch_resume(&scope, execution_id).await;
+    let dispatch_outcome = dispatch.dispatch_resume(&scope, execution_id, None).await;
     assert!(
         matches!(
             dispatch_outcome,
@@ -1848,6 +1853,7 @@ async fn duplicate_resume_to_armed_node_is_noop() {
                 .dispatch_resume(
                     &nebula_engine::store_seam::single_tenant_scope(),
                     execution_id,
+                    None,
                 )
                 .await
         },
@@ -1856,6 +1862,7 @@ async fn duplicate_resume_to_armed_node_is_noop() {
                 .dispatch_resume(
                     &nebula_engine::store_seam::single_tenant_scope(),
                     execution_id,
+                    None,
                 )
                 .await
         },

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -75,6 +75,59 @@ pub enum WaitWake {
     Timeout,
 }
 
+/// The external signal a parked [`NodeState::Waiting`] node is waiting **for**
+/// — the persisted resume-identity of a signal-driven wait.
+///
+/// A signal wait (`Webhook` / `Approval` / `Execution`) is satisfied by an
+/// explicit Resume, not a timer. Before W-S3a the parked node recorded only
+/// *that* it was waiting (via [`next_attempt_at`](NodeExecutionState::next_attempt_at)
+/// / [`wait_wake`](NodeExecutionState::wait_wake)), never *what for*: the
+/// `WaitCondition`'s identity was destructured away at park. That made every
+/// Resume untargeted — it armed every signal-`Waiting` node — and let a Resume
+/// for one wait satisfy an unrelated sibling, or a webhook Resume satisfy an
+/// approval gate (two confused-deputy bugs). `WaitSignal` persists the minimum
+/// identity needed to target the arm: the `callback_id` of a webhook, the
+/// `approver` of an approval gate, or the `execution_id` of an execution wait.
+///
+/// Only the **identity** is persisted — never the approval `message`, a webhook
+/// body, or any payload/schema. Carrying the inbound payload is a later slice
+/// (W-S4); persisting it here would widen the durable surface without a
+/// targeting need.
+///
+/// `WaitSignal` is the kind-aware peer of [`WaitWake`]: `wait_wake` records how
+/// a *timer* wake is read, `wait_signal` records which *external signal* a
+/// non-timer wait awaits. A node parked with a `timeout` carries both; a
+/// signal-only park carries `wait_signal` with no timer; a timer-driven wait
+/// (`Until` / `Duration`) carries neither — see
+/// [`park_node`](ExecutionState::park_node)'s invariant.
+///
+/// Extensible by design (`#[non_exhaustive]`): future wait-bearing kinds may
+/// introduce further signal identities.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum WaitSignal {
+    /// Awaiting an inbound HTTP callback identified by `callback_id`.
+    Webhook {
+        /// The author-declared callback label an inbound webhook Resume must
+        /// match. Mirrors `WaitCondition::Webhook::callback_id`.
+        callback_id: String,
+    },
+    /// Awaiting human approval from `approver`.
+    Approval {
+        /// Identifier of the person whose approval Resume must match. Mirrors
+        /// `WaitCondition::Approval::approver`. The approval `message` shown to
+        /// the approver is deliberately NOT persisted here — only the identity
+        /// needed for targeting.
+        approver: String,
+    },
+    /// Awaiting another execution to complete.
+    Execution {
+        /// The execution this wait is gated on. Mirrors
+        /// `WaitCondition::Execution::execution_id`.
+        execution_id: ExecutionId,
+    },
+}
+
 /// The execution state of a single node within a running workflow.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeExecutionState {
@@ -140,6 +193,30 @@ pub struct NodeExecutionState {
     /// [`park_node`]: ExecutionState::park_node
     #[serde(default)]
     pub wait_wake: Option<WaitWake>,
+    /// The external signal this parked node is waiting **for** — the persisted
+    /// resume-identity of a signal-driven wait. See [`WaitSignal`].
+    ///
+    /// `Some(_)` exactly when this node is parked on a SIGNAL `WaitCondition`
+    /// (`Webhook` / `Approval` / `Execution`), independent of
+    /// [`wait_wake`](Self::wait_wake) / [`next_attempt_at`](Self::next_attempt_at):
+    /// a signal-only park carries `wait_signal: Some, wake_at: None,
+    /// wait_wake: None`; a signal+timeout park (W-S2b) carries `wait_signal:
+    /// Some, wake_at: Some, wait_wake: Some(Timeout)`; a timer-driven wait
+    /// (`Until` / `Duration`) carries `wait_signal: None`.
+    /// [`park_node`](ExecutionState::park_node) enforces this signal/timer
+    /// classification as a typed runtime guard.
+    ///
+    /// A targeted Resume arms only the node whose `wait_signal` matches the
+    /// resume target (a webhook target matches only a `Webhook` signal whose
+    /// `callback_id` is equal — never an `Approval` / `Execution`); an
+    /// untargeted Resume keeps the legacy all-signal-waits behavior.
+    ///
+    /// Forward-compat: legacy persisted states that predate this field
+    /// deserialize as `None`. A `None` on a still-`Waiting` signal node is read
+    /// as "untargetable by identity" — only an untargeted Resume arms it, which
+    /// preserves W-S2b behavior for rows written before W-S3a.
+    #[serde(default)]
+    pub wait_signal: Option<WaitSignal>,
 }
 
 impl NodeExecutionState {
@@ -156,6 +233,7 @@ impl NodeExecutionState {
             error_message: None,
             next_attempt_at: None,
             wait_wake: None,
+            wait_signal: None,
         }
     }
 
@@ -244,10 +322,11 @@ impl NodeExecutionState {
         );
     }
 
-    /// Clear a parked wait's timer fields after the wake has been resolved
-    /// (the node completed or timed out): drop both `next_attempt_at` and
-    /// `wait_wake` so a later terminal state carries no contradictory wake
-    /// metadata.
+    /// Clear a parked wait's metadata after the wake has been resolved (the
+    /// node completed or timed out): drop `next_attempt_at`, `wait_wake`, and
+    /// the persisted `wait_signal` resume-identity so a later terminal state
+    /// carries no contradictory wait metadata. Once a wait has resolved, the
+    /// node is no longer arm-targetable, so its `wait_signal` is dropped too.
     ///
     /// Apply this only on the wait-cleanup paths (a resolved `Waiting` node).
     /// It must NOT be used on a `WaitingRetry` node: there `next_attempt_at` is
@@ -256,6 +335,7 @@ impl NodeExecutionState {
     pub fn clear_wait_timer(&mut self) {
         self.next_attempt_at = None;
         self.wait_wake = None;
+        self.wait_signal = None;
         debug_assert_eq!(
             self.next_attempt_at.is_some(),
             self.wait_wake.is_some(),
@@ -696,22 +776,38 @@ impl ExecutionState {
     ///
     /// Promotes `Running → Waiting`, stamps `next_attempt_at` with the
     /// timer wake instant (or clears it when no timer applies), records
-    /// the wake discriminator [`wait_wake`](NodeExecutionState::wait_wake),
+    /// the wake discriminator [`wait_wake`](NodeExecutionState::wait_wake)
+    /// and the resume-identity [`wait_signal`](NodeExecutionState::wait_signal),
     /// and bumps the execution version. Mirrors [`schedule_node_retry`] for
     /// the wait-park path.
     ///
-    /// # Invariant
+    /// # Invariants
     ///
-    /// `wait_wake.is_some() == wake_at.is_some()`. A timer wake (`wake_at`
-    /// `Some`) must declare what the wake means ([`WaitWake::Completion`]
-    /// for a timer-driven or armed-signal wait, [`WaitWake::Timeout`] for a
-    /// signal wait whose `timeout` is the wake), and a signal-only park (no
-    /// timer) must carry `None` (it is satisfied by a Resume, not a timer).
-    /// `park_node` is the sole caller-facing writer of the
-    /// (`next_attempt_at`, `wait_wake`) pair, and it takes both from the
-    /// caller — so the pairing is enforced as a fallible runtime guard (not a
+    /// 1. **Wake pairing** — `wait_wake.is_some() == wake_at.is_some()`. A timer
+    ///    wake (`wake_at` `Some`) must declare what the wake means
+    ///    ([`WaitWake::Completion`] for a timer-driven or armed-signal wait,
+    ///    [`WaitWake::Timeout`] for a signal wait whose `timeout` is the wake),
+    ///    and a wait with no timer must carry `None` (it is satisfied by a
+    ///    Resume, not a timer).
+    /// 2. **Signal/timer classification** — `wait_signal.is_some()` iff the wait
+    ///    is signal-driven, INDEPENDENT of the timer. Concretely a node is a
+    ///    signal wait when `wait_wake != Some(WaitWake::Completion)` (i.e. a
+    ///    signal-only park, `wait_wake == None`, or a signal+timeout park,
+    ///    `wait_wake == Some(Timeout)`), and a timer wait when
+    ///    `wait_wake == Some(WaitWake::Completion)`. So `wait_signal` MUST be
+    ///    `Some` for the former and `None` for the latter. This makes the three
+    ///    legal shapes the only representable ones:
+    ///    - signal-only: `wake_at None, wait_wake None, wait_signal Some`
+    ///    - signal+timeout: `wake_at Some, wait_wake Some(Timeout), wait_signal Some`
+    ///    - timer: `wake_at Some, wait_wake Some(Completion), wait_signal None`
+    ///
+    /// `park_node` is the sole caller-facing writer of the (`next_attempt_at`,
+    /// `wait_wake`, `wait_signal`) triple, and it takes all three from the
+    /// caller — so both invariants are enforced as fallible runtime guards (not
     /// `debug_assert!`): a `Some(wake_at), None` desync would turn a timeout
-    /// into a completion, which is load-bearing rather than a debug-only check.
+    /// into a completion, and a signal wait with no persisted identity (or a
+    /// timer wait with one) would mis-target a Resume — both load-bearing rather
+    /// than debug-only checks.
     ///
     /// The caller is responsible for:
     /// - Persisting the node's `partial_output` through the normal
@@ -722,13 +818,15 @@ impl ExecutionState {
     ///   timer-driven wakes.
     ///
     /// On success the per-node `Running → Waiting` transition, the
-    /// `next_attempt_at` stamp, and the `wait_wake` discriminator are all
-    /// reflected in `version`. On `Err` the state is left untouched.
+    /// `next_attempt_at` stamp, the `wait_wake` discriminator, and the
+    /// `wait_signal` resume-identity are all reflected in `version`. On `Err`
+    /// the state is left untouched.
     ///
     /// # Errors
     /// - [`ExecutionError::InvalidTransition`] if the (`wake_at`, `wait_wake`)
-    ///   pair is not both-`Some` or both-`None` — checked before any mutation,
-    ///   so a desync leaves the state untouched.
+    ///   pair is not both-`Some` or both-`None`, or if the signal/timer
+    ///   classification of (`wait_wake`, `wait_signal`) is inconsistent — both
+    ///   checked before any mutation, so a desync leaves the state untouched.
     /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
     /// - [`ExecutionError::InvalidTransition`] if the node is not in `Running`
     ///   (the engine may only call this immediately after dispatching the action).
@@ -739,6 +837,7 @@ impl ExecutionState {
         node_key: NodeKey,
         wake_at: Option<DateTime<Utc>>,
         wait_wake: Option<WaitWake>,
+        wait_signal: Option<WaitSignal>,
     ) -> Result<(), ExecutionError> {
         // Enforce the wake pairing BEFORE any mutation. A `Some(wake_at),
         // None` (or the inverse) desync would persist a timer wake with no
@@ -755,12 +854,29 @@ impl ExecutionState {
                 to: "Waiting (wait_wake/wake_at must be paired)".to_owned(),
             });
         }
+        // Enforce the signal/timer classification BEFORE any mutation. A signal
+        // wait (`wait_wake != Some(Completion)`) MUST carry a persisted
+        // `wait_signal` identity so a targeted Resume can match it; a timer wait
+        // (`wait_wake == Some(Completion)`) MUST NOT — a persisted signal on a
+        // pure timer would let a webhook/approval Resume mis-satisfy it. Same
+        // release-safe typed-error pattern as the wake-pairing guard above.
+        let is_timer_wait = wait_wake == Some(WaitWake::Completion);
+        if is_timer_wait == wait_signal.is_some() {
+            return Err(ExecutionError::InvalidTransition {
+                from: self
+                    .node_states
+                    .get(&node_key)
+                    .map_or_else(|| NodeState::Running.to_string(), |ns| ns.state.to_string()),
+                to: "Waiting (wait_signal must be Some iff a signal wait)".to_owned(),
+            });
+        }
         self.transition_node(node_key.clone(), NodeState::Waiting)?;
         // Stamp or clear the wake instant. `Waiting` with `wake_at ==
         // None` means the park is signal-driven (webhook/approval/
         // execution) with no timeout: only an explicit Resume will satisfy
         // the condition. `wait_wake` records how a timer wake (if any) is to
-        // be read when it fires. Stale failure metadata is cleared for the
+        // be read when it fires; `wait_signal` records the resume-identity a
+        // targeted Resume matches. Stale failure metadata is cleared for the
         // same reason `schedule_node_retry` clears it — a later `Completed`
         // transition must not carry contradictory persisted fields.
         let ns = self
@@ -769,6 +885,7 @@ impl ExecutionState {
             .ok_or(ExecutionError::NodeNotFound(node_key))?;
         ns.next_attempt_at = wake_at;
         ns.wait_wake = wait_wake;
+        ns.wait_signal = wait_signal;
         ns.error_message = None;
         ns.completed_at = None;
         self.version += 1;
@@ -974,6 +1091,7 @@ impl ExecutionState {
             if let Some(ns) = self.node_states.get_mut(&node_key) {
                 ns.next_attempt_at = None;
                 ns.wait_wake = None;
+                ns.wait_signal = None;
             }
         }
         Ok(count)
@@ -1821,8 +1939,17 @@ mod tests {
         state.start_node_attempt(n1.clone()).unwrap();
 
         let wake_at = Utc::now() + chrono::Duration::seconds(30);
+        // A signal+timeout park: the timer is the Timeout deadline and the wait
+        // carries its resume-identity (a webhook callback_id).
         state
-            .park_node(n1.clone(), Some(wake_at), Some(WaitWake::Timeout))
+            .park_node(
+                n1.clone(),
+                Some(wake_at),
+                Some(WaitWake::Timeout),
+                Some(WaitSignal::Webhook {
+                    callback_id: "cb-timeout".to_owned(),
+                }),
+            )
             .expect("Running → Waiting park must succeed");
 
         let ns = state.node_state(n1).unwrap();
@@ -1844,7 +1971,14 @@ mod tests {
         state.start_node_attempt(n1.clone()).unwrap();
 
         state
-            .park_node(n1.clone(), None, None)
+            .park_node(
+                n1.clone(),
+                None,
+                None,
+                Some(WaitSignal::Webhook {
+                    callback_id: "cb-signal-only".to_owned(),
+                }),
+            )
             .expect("Running → Waiting signal-only park must succeed");
 
         let ns = state.node_state(n1).unwrap();
@@ -1853,6 +1987,13 @@ mod tests {
         assert!(
             ns.wait_wake.is_none(),
             "a signal-only park must not carry a wake discriminator"
+        );
+        assert_eq!(
+            ns.wait_signal,
+            Some(WaitSignal::Webhook {
+                callback_id: "cb-signal-only".to_owned(),
+            }),
+            "a signal-only park must persist its resume-identity"
         );
     }
 
@@ -1874,7 +2015,7 @@ mod tests {
 
         // wake_at without a wait_wake meaning is a desync — must be rejected.
         let err = state
-            .park_node(n1.clone(), Some(wake_at), None)
+            .park_node(n1.clone(), Some(wake_at), None, None)
             .expect_err("a Some(wake_at), None park must be rejected");
         assert!(
             matches!(err, ExecutionError::InvalidTransition { .. }),
@@ -1883,7 +2024,7 @@ mod tests {
 
         // The inverse desync (wait_wake without a timer) is equally rejected.
         let err = state
-            .park_node(n1.clone(), None, Some(WaitWake::Timeout))
+            .park_node(n1.clone(), None, Some(WaitWake::Timeout), None)
             .expect_err("a None, Some(wait_wake) park must be rejected");
         assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
 
@@ -1985,6 +2126,164 @@ mod tests {
             ns.wait_wake.is_some(),
             "cleared pair must satisfy the next_attempt_at/wait_wake invariant"
         );
+    }
+
+    /// W-S3a — `wait_signal` round-trips through serde across all three
+    /// variants, and a legacy `NodeExecutionState` JSON that predates the field
+    /// deserializes as `None` (read by the engine as untargetable-by-identity,
+    /// only an untargeted Resume arms it — preserving W-S2b behavior).
+    ///
+    /// **Falsifiability**: drop `#[serde(default)]` from `wait_signal` → the
+    /// legacy-JSON `from_value` errors (missing field) → the test panics.
+    #[test]
+    fn wait_signal_serde_roundtrip_and_legacy_default() {
+        let roundtrip = |signal: WaitSignal| {
+            let mut ns = NodeExecutionState::new();
+            ns.wait_signal = Some(signal.clone());
+            let json = serde_json::to_string(&ns).unwrap();
+            let back: NodeExecutionState = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back.wait_signal,
+                Some(signal),
+                "wait_signal must survive a serde roundtrip"
+            );
+        };
+        roundtrip(WaitSignal::Webhook {
+            callback_id: "cb-1".to_owned(),
+        });
+        roundtrip(WaitSignal::Approval {
+            approver: "boss".to_owned(),
+        });
+        roundtrip(WaitSignal::Execution {
+            execution_id: ExecutionId::new(),
+        });
+
+        // Legacy JSON without the field deserializes as `None`.
+        let legacy = serde_json::json!({
+            "state": "waiting",
+            "attempts": [],
+        });
+        let ns: NodeExecutionState = serde_json::from_value(legacy).unwrap();
+        assert!(
+            ns.wait_signal.is_none(),
+            "legacy rows without wait_signal must deserialize as None"
+        );
+    }
+
+    /// W-S3a — `park_node` persists the resume-identity for a signal wait so a
+    /// later targeted Resume can match it. Covers the signal-only shape
+    /// (`Approval`) here; the signal+timeout shape is covered by
+    /// `park_node_sets_wait_wake`.
+    ///
+    /// **Falsifiability**: drop the `wait_signal` field write from `park_node`
+    /// → `back.wait_signal` is `None` not `Some(Approval{..})` → the assert
+    /// fails.
+    #[test]
+    fn park_node_sets_wait_signal_for_signal_conditions() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+
+        state
+            .park_node(
+                n1.clone(),
+                None,
+                None,
+                Some(WaitSignal::Approval {
+                    approver: "boss".to_owned(),
+                }),
+            )
+            .expect("Running → Waiting signal park must succeed");
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::Waiting);
+        assert_eq!(
+            ns.wait_signal,
+            Some(WaitSignal::Approval {
+                approver: "boss".to_owned(),
+            }),
+            "park_node must persist the Approval resume-identity"
+        );
+    }
+
+    /// W-S3a — a timer-driven wait (`Until` / `Duration`) carries NO
+    /// `wait_signal` (it is satisfied by a timer, never a Resume identity).
+    /// `park_node` records the timer + `Completion` discriminator and leaves
+    /// `wait_signal` `None`.
+    ///
+    /// **Falsifiability**: have `park_node` stamp a `wait_signal` on the timer
+    /// path → the `is_none()` assert fails; or relax the classification guard
+    /// so a `Completion` wake with a `Some(wait_signal)` is accepted → the
+    /// rejection test below stops catching it.
+    #[test]
+    fn park_node_no_wait_signal_for_timer() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+        let wake_at = Utc::now() + chrono::Duration::seconds(30);
+
+        state
+            .park_node(n1.clone(), Some(wake_at), Some(WaitWake::Completion), None)
+            .expect("Running → Waiting timer park must succeed");
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::Waiting);
+        assert_eq!(ns.next_attempt_at, Some(wake_at));
+        assert_eq!(ns.wait_wake, Some(WaitWake::Completion));
+        assert!(
+            ns.wait_signal.is_none(),
+            "a timer wait must not carry a resume-identity"
+        );
+    }
+
+    /// W-S3a — `park_node` REJECTS an inconsistent signal/timer classification
+    /// with a typed error and leaves the node untouched. A signal wait
+    /// (`wait_wake != Some(Completion)`) with no persisted identity would be
+    /// untargetable; a timer wait (`wait_wake == Some(Completion)`) with a
+    /// persisted identity would let a webhook/approval Resume mis-satisfy a
+    /// pure timer. Both are load-bearing guards, not debug-only asserts.
+    ///
+    /// **Falsifiability**: drop the classification guard from `park_node` →
+    /// both `park_node` calls return `Ok`, the node becomes `Waiting` with an
+    /// inconsistent (`wait_wake`, `wait_signal`) shape → both `expect_err`
+    /// flip → RED.
+    #[test]
+    fn park_node_rejects_signal_classification_desync() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+        let wake_at = Utc::now() + chrono::Duration::seconds(30);
+
+        // Signal-only park (wait_wake None) with NO identity — must be rejected.
+        let err = state
+            .park_node(n1.clone(), None, None, None)
+            .expect_err("a signal park with no wait_signal must be rejected");
+        assert!(
+            matches!(err, ExecutionError::InvalidTransition { .. }),
+            "the classification desync must surface as a typed InvalidTransition, got {err:?}"
+        );
+
+        // Timer park (wait_wake Completion) WITH an identity — must be rejected.
+        let err = state
+            .park_node(
+                n1.clone(),
+                Some(wake_at),
+                Some(WaitWake::Completion),
+                Some(WaitSignal::Webhook {
+                    callback_id: "cb".to_owned(),
+                }),
+            )
+            .expect_err("a timer park with a wait_signal must be rejected");
+        assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
+
+        // The guard ran before any mutation: the node is still Running, never
+        // parked, and carries no stale wait metadata.
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(
+            ns.state,
+            NodeState::Running,
+            "a rejected park must leave the node untouched (still Running)"
+        );
+        assert!(ns.next_attempt_at.is_none());
+        assert!(ns.wait_wake.is_none());
+        assert!(ns.wait_signal.is_none());
     }
 
     /// `total_retries` round-trips and starts

--- a/crates/storage-port/src/dto/control.rs
+++ b/crates/storage-port/src/dto/control.rs
@@ -2,6 +2,40 @@
 use crate::Scope;
 use serde::{Deserialize, Serialize};
 
+/// Which parked signal wait a [`ControlCommand::Resume`] targets.
+///
+/// A storage-port-level mirror of the engine's persisted resume-identity
+/// (`nebula_execution::state::WaitSignal`). It lives here — below the execution
+/// crate — because the control-queue DTO cannot depend on `nebula-execution`;
+/// the engine matches a `ResumeTarget` against a parked node's `WaitSignal` by
+/// kind + identity. Carrying the kind (not a bare string) is the structural
+/// safety control: a webhook Resume can never match an approval gate.
+///
+/// `ControlMsg.resume_target == None` means an untargeted Resume — it arms
+/// every signal-driven wait of the execution (the W-S2b behavior), preserved
+/// for back-compat and for callers that do not yet target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+#[non_exhaustive]
+pub enum ResumeTarget {
+    /// Target a webhook wait by its author-declared callback label.
+    Webhook {
+        /// Must equal the parked `WaitSignal::Webhook::callback_id`.
+        callback_id: String,
+    },
+    /// Target an approval gate by approver identity.
+    Approval {
+        /// Must equal the parked `WaitSignal::Approval::approver`.
+        approver: String,
+    },
+    /// Target an execution-completion wait by the awaited execution id.
+    Execution {
+        /// Must equal the parked `WaitSignal::Execution::execution_id`
+        /// (opaque string form).
+        execution_id: String,
+    },
+}
+
 /// Control commands delivered through the durable outbox.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ControlCommand {
@@ -52,4 +86,17 @@ pub struct ControlMsg {
     pub w3c_traceparent: Option<String>,
     /// Times this row was reclaimed back to `Pending` after a crashed runner.
     pub reclaim_count: u32,
+    /// Which parked signal wait a [`ControlCommand::Resume`] targets (ADR-0099
+    /// W-S3a). `None` is an untargeted Resume (arms every signal wait — the
+    /// W-S2b behavior); `Some(target)` arms only the parked node whose
+    /// persisted `WaitSignal` matches by kind + identity.
+    ///
+    /// `#[serde(default)]` so legacy queue payloads that predate the field
+    /// deserialize as `None`. W-S3a threads this in-memory from the control
+    /// consumer to `dispatch_resume`; the durable backends do not yet persist a
+    /// column for it (no producer exists), so the SQL-backed `claim_pending`
+    /// paths reconstruct it as `None`. Durable carry is W-S3c (with the real
+    /// schema work).
+    #[serde(default)]
+    pub resume_target: Option<ResumeTarget>,
 }

--- a/crates/storage-port/src/dto/mod.rs
+++ b/crates/storage-port/src/dto/mod.rs
@@ -16,7 +16,7 @@ mod trigger_dedup;
 mod webhook;
 mod workflow;
 
-pub use control::{ControlCommand, ControlMsg};
+pub use control::{ControlCommand, ControlMsg, ResumeTarget};
 pub use execution::{ExecutionRecord, NewExecution};
 pub use idempotency::CachedRecord;
 pub use identity::{

--- a/crates/storage-port/tests/batch.rs
+++ b/crates/storage-port/tests/batch.rs
@@ -39,6 +39,7 @@ fn builder_carries_outbox_and_journal() {
         scope: Scope::new("w", "o"),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     let je = JournalEntry {
         seq: None,

--- a/crates/storage-port/tests/dto.rs
+++ b/crates/storage-port/tests/dto.rs
@@ -43,11 +43,13 @@ fn control_msg_roundtrips_with_typed_16_byte_id() {
         scope: Scope::new("ws_1", "org_1"),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     let s = serde_json::to_string(&msg).expect("serialize");
     let back: ControlMsg = serde_json::from_str(&s).expect("deserialize");
     assert_eq!(back.id, [7u8; 16]);
     assert_eq!(back.command, ControlCommand::Cancel);
+    assert_eq!(back.resume_target, None);
 }
 
 #[test]

--- a/crates/storage/migrations/postgres/0034_port_control_queue_resume_target.sql
+++ b/crates/storage/migrations/postgres/0034_port_control_queue_resume_target.sql
@@ -1,0 +1,11 @@
+-- ADR-0099 W-S3a: durable resume-target carry on port_control_queue.
+--
+-- resume_target stores the serialized ResumeTarget JSON as TEXT.
+-- NULL on rows written before this migration → deserializes as None.
+-- Existing rows (non-Resume commands) also deserialize as None, which is
+-- correct: only Resume commands carry a non-null target.
+--
+-- Down: ALTER TABLE port_control_queue DROP COLUMN resume_target;
+
+ALTER TABLE port_control_queue
+    ADD COLUMN resume_target TEXT;

--- a/crates/storage/migrations/sqlite/0034_port_control_queue_resume_target.sql
+++ b/crates/storage/migrations/sqlite/0034_port_control_queue_resume_target.sql
@@ -1,0 +1,12 @@
+-- ADR-0099 W-S3a: durable resume-target carry on port_control_queue.
+--
+-- resume_target stores the serialized ResumeTarget JSON (a TEXT column).
+-- NULL on rows written before this migration → deserializes as None.
+-- Existing rows (non-Resume commands) also deserialize as None, which is
+-- correct: only Resume commands carry a non-null target.
+--
+-- Down (manual): SQLite has no DROP COLUMN before 3.35; recreate the
+-- table without the column if a rollback is needed.
+
+ALTER TABLE port_control_queue
+    ADD COLUMN resume_target TEXT;

--- a/crates/storage/src/postgres/control_queue.rs
+++ b/crates/storage/src/postgres/control_queue.rs
@@ -122,6 +122,9 @@ impl ControlQueue for PgControlQueue {
                     ),
                     w3c_traceparent: row.try_get("w3c_traceparent").map_err(conn_err)?,
                     reclaim_count: row.try_get::<i32, _>("reclaim_count").map_err(conn_err)? as u32,
+                    // No durable column for the resume target yet (W-S3a threads
+                    // it in-memory from the control consumer; durable = W-S3c).
+                    resume_target: None,
                 })
             })
             .collect()

--- a/crates/storage/src/postgres/control_queue.rs
+++ b/crates/storage/src/postgres/control_queue.rs
@@ -10,7 +10,7 @@
 use std::time::Duration;
 
 use chrono::Utc;
-use nebula_storage_port::dto::{ControlMsg, JournalEntry};
+use nebula_storage_port::dto::{ControlMsg, JournalEntry, ResumeTarget};
 use nebula_storage_port::store::{ControlQueue, ExecutionJournalReader, ReclaimOutcome};
 use nebula_storage_port::{Scope, StorageError};
 use sqlx::{PgPool, Row};
@@ -57,11 +57,17 @@ fn decode_id(bytes: &[u8]) -> Result<[u8; 16], StorageError> {
 #[async_trait::async_trait]
 impl ControlQueue for PgControlQueue {
     async fn enqueue(&self, msg: &ControlMsg) -> Result<(), StorageError> {
+        let resume_target_json = msg
+            .resume_target
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
         sqlx::query(
             "INSERT INTO port_control_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
-              w3c_traceparent, reclaim_count) \
-             VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7)",
+              w3c_traceparent, reclaim_count, resume_target) \
+             VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8)",
         )
         .bind(msg.id.as_slice())
         .bind(&msg.execution_id)
@@ -70,6 +76,7 @@ impl ControlQueue for PgControlQueue {
         .bind(msg.command.as_str())
         .bind(msg.w3c_traceparent.as_deref())
         .bind(i32::try_from(msg.reclaim_count).unwrap_or(i32::MAX))
+        .bind(resume_target_json)
         .execute(&self.pool)
         .await
         .map_err(conn_err)?;
@@ -99,7 +106,7 @@ impl ControlQueue for PgControlQueue {
                  FOR UPDATE SKIP LOCKED \
              ) \
              RETURNING id, execution_id, workspace_id, org_id, command, \
-                       w3c_traceparent, reclaim_count",
+                       w3c_traceparent, reclaim_count, resume_target",
         )
         .bind(processor.as_slice())
         .bind(now_ms)
@@ -110,6 +117,13 @@ impl ControlQueue for PgControlQueue {
         rows.into_iter()
             .map(|row| {
                 let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
+                let resume_target: Option<ResumeTarget> = row
+                    .try_get::<Option<String>, _>("resume_target")
+                    .map_err(conn_err)?
+                    .as_deref()
+                    .map(serde_json::from_str)
+                    .transpose()
+                    .map_err(|e| StorageError::Serialization(e.to_string()))?;
                 Ok(ControlMsg {
                     id: decode_id(&id_bytes)?,
                     execution_id: row.try_get("execution_id").map_err(conn_err)?,
@@ -122,9 +136,7 @@ impl ControlQueue for PgControlQueue {
                     ),
                     w3c_traceparent: row.try_get("w3c_traceparent").map_err(conn_err)?,
                     reclaim_count: row.try_get::<i32, _>("reclaim_count").map_err(conn_err)? as u32,
-                    // No durable column for the resume target yet (W-S3a threads
-                    // it in-memory from the control consumer; durable = W-S3c).
-                    resume_target: None,
+                    resume_target,
                 })
             })
             .collect()

--- a/crates/storage/src/postgres/execution.rs
+++ b/crates/storage/src/postgres/execution.rs
@@ -234,11 +234,17 @@ impl ExecutionStore for PgExecutionStore {
         }
 
         for msg in batch.outbox() {
+            let resume_target_json: Option<String> = msg
+                .resume_target
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
             sqlx::query(
                 "INSERT INTO port_control_queue \
                  (id, execution_id, workspace_id, org_id, command, status, \
-                  w3c_traceparent, reclaim_count) \
-                 VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7)",
+                  w3c_traceparent, reclaim_count, resume_target) \
+                 VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8)",
             )
             .bind(msg.id.as_slice())
             .bind(&msg.execution_id)
@@ -247,6 +253,7 @@ impl ExecutionStore for PgExecutionStore {
             .bind(msg.command.as_str())
             .bind(msg.w3c_traceparent.as_deref())
             .bind(i32::try_from(msg.reclaim_count).unwrap_or(i32::MAX))
+            .bind(resume_target_json)
             .execute(&mut *tx)
             .await
             .map_err(conn_err)?;

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -55,7 +55,10 @@ CREATE TABLE IF NOT EXISTS port_control_queue (
     reclaim_count   INTEGER NOT NULL DEFAULT 0,
     processed_by    BYTEA,
     processed_at_ms BIGINT,
-    error_message   TEXT
+    error_message   TEXT,
+    -- ADR-0099 W-S3a: kind-aware resume targeting (serialized ResumeTarget
+    -- JSON; NULL when None). NULL on legacy rows → deserialized as None.
+    resume_target   TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_port_control_queue_pending

--- a/crates/storage/src/sqlite/control_queue.rs
+++ b/crates/storage/src/sqlite/control_queue.rs
@@ -130,6 +130,9 @@ impl ControlQueue for SqliteControlQueue {
                 ),
                 w3c_traceparent: row.try_get("w3c_traceparent").map_err(conn_err)?,
                 reclaim_count: row.try_get::<i64, _>("reclaim_count").map_err(conn_err)? as u32,
+                // No durable column for the resume target yet (W-S3a threads it
+                // in-memory from the control consumer; durable carry is W-S3c).
+                resume_target: None,
             });
         }
         tx.commit().await.map_err(conn_err)?;

--- a/crates/storage/src/sqlite/control_queue.rs
+++ b/crates/storage/src/sqlite/control_queue.rs
@@ -9,7 +9,7 @@
 
 use std::time::Duration;
 
-use nebula_storage_port::dto::{ControlMsg, JournalEntry};
+use nebula_storage_port::dto::{ControlMsg, JournalEntry, ResumeTarget};
 use nebula_storage_port::store::{ControlQueue, ExecutionJournalReader, ReclaimOutcome};
 use nebula_storage_port::{Scope, StorageError};
 use sqlx::{Row, SqlitePool};
@@ -56,11 +56,17 @@ fn decode_id(bytes: &[u8]) -> Result<[u8; 16], StorageError> {
 #[async_trait::async_trait]
 impl ControlQueue for SqliteControlQueue {
     async fn enqueue(&self, msg: &ControlMsg) -> Result<(), StorageError> {
+        let resume_target_json = msg
+            .resume_target
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
         sqlx::query(
             "INSERT INTO port_control_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
-              w3c_traceparent, reclaim_count) \
-             VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?)",
+              w3c_traceparent, reclaim_count, resume_target) \
+             VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?)",
         )
         .bind(msg.id.as_slice())
         .bind(&msg.execution_id)
@@ -69,6 +75,7 @@ impl ControlQueue for SqliteControlQueue {
         .bind(msg.command.as_str())
         .bind(msg.w3c_traceparent.as_deref())
         .bind(i64::from(msg.reclaim_count))
+        .bind(resume_target_json)
         .execute(&self.pool)
         .await
         .map_err(conn_err)?;
@@ -83,7 +90,7 @@ impl ControlQueue for SqliteControlQueue {
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
         let rows = sqlx::query(
             "SELECT id, execution_id, workspace_id, org_id, command, \
-                    w3c_traceparent, reclaim_count \
+                    w3c_traceparent, reclaim_count, resume_target \
              FROM port_control_queue WHERE status = 'Pending' \
              ORDER BY id LIMIT ?",
         )
@@ -120,6 +127,13 @@ impl ControlQueue for SqliteControlQueue {
             if !won {
                 continue;
             }
+            let resume_target: Option<ResumeTarget> = row
+                .try_get::<Option<String>, _>("resume_target")
+                .map_err(conn_err)?
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
             claimed.push(ControlMsg {
                 id,
                 execution_id: row.try_get("execution_id").map_err(conn_err)?,
@@ -130,9 +144,7 @@ impl ControlQueue for SqliteControlQueue {
                 ),
                 w3c_traceparent: row.try_get("w3c_traceparent").map_err(conn_err)?,
                 reclaim_count: row.try_get::<i64, _>("reclaim_count").map_err(conn_err)? as u32,
-                // No durable column for the resume target yet (W-S3a threads it
-                // in-memory from the control consumer; durable carry is W-S3c).
-                resume_target: None,
+                resume_target,
             });
         }
         tx.commit().await.map_err(conn_err)?;

--- a/crates/storage/src/sqlite/execution.rs
+++ b/crates/storage/src/sqlite/execution.rs
@@ -239,11 +239,17 @@ impl ExecutionStore for SqliteExecutionStore {
 
         // Outbox append: raw 16-byte ULID id (no UTF-8-of-ULID hack).
         for msg in batch.outbox() {
+            let resume_target_json: Option<String> = msg
+                .resume_target
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
             sqlx::query(
                 "INSERT INTO port_control_queue \
                  (id, execution_id, workspace_id, org_id, command, status, \
-                  w3c_traceparent, reclaim_count) \
-                 VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?)",
+                  w3c_traceparent, reclaim_count, resume_target) \
+                 VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?)",
             )
             .bind(msg.id.as_slice())
             .bind(&msg.execution_id)
@@ -252,6 +258,7 @@ impl ExecutionStore for SqliteExecutionStore {
             .bind(msg.command.as_str())
             .bind(msg.w3c_traceparent.as_deref())
             .bind(i64::from(msg.reclaim_count))
+            .bind(resume_target_json)
             .execute(&mut *tx)
             .await
             .map_err(conn_err)?;

--- a/crates/storage/src/sqlite/schema.sql
+++ b/crates/storage/src/sqlite/schema.sql
@@ -53,7 +53,10 @@ CREATE TABLE IF NOT EXISTS port_control_queue (
     reclaim_count   INTEGER NOT NULL DEFAULT 0,
     processed_by    BLOB,
     processed_at_ms INTEGER,
-    error_message   TEXT
+    error_message   TEXT,
+    -- ADR-0099 W-S3a: kind-aware resume targeting (serialized ResumeTarget
+    -- JSON; NULL when None). NULL on legacy rows → deserialized as None.
+    resume_target   TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_port_control_queue_pending

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -28,10 +28,10 @@ use harness::{
     assert_idempotency_store_first_writer, assert_job_dispatch_fencing,
     assert_job_dispatch_routes_by_plugin, assert_job_dispatch_routes_by_plugin_superset,
     assert_journal_visibility_and_scope, assert_live_lease_blocks_acquire,
-    assert_save_with_published_version_is_atomic, assert_stale_fencing_is_fenced_out,
-    assert_trigger_dedup_first_writer, assert_trigger_dedup_is_scoped,
-    assert_webhook_activation_and_scope, assert_webhook_system_surface,
-    assert_workflow_store_contract, skip_reason,
+    assert_resume_target_survives_queue_round_trip, assert_save_with_published_version_is_atomic,
+    assert_stale_fencing_is_fenced_out, assert_trigger_dedup_first_writer,
+    assert_trigger_dedup_is_scoped, assert_webhook_activation_and_scope,
+    assert_webhook_system_surface, assert_workflow_store_contract, skip_reason,
 };
 use rstest::rstest;
 use std::future::Future;
@@ -95,6 +95,10 @@ matrix!(
 matrix!(
     control_queue_outbox_and_fencing,
     assert_control_queue_outbox_and_fencing
+);
+matrix!(
+    resume_target_survives_queue_round_trip,
+    assert_resume_target_survives_queue_round_trip
 );
 matrix!(
     journal_visibility_and_scope,

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -24,8 +24,8 @@ use std::sync::Arc;
 use nebula_core::PluginKey;
 use nebula_storage_port::dto::{
     CachedRecord, ControlCommand, ControlMsg, DispatchKind, JobDispatchMsg, JournalEntry,
-    NewExecution, TriggerDedupRow, WebhookActivationRecord, WebhookMode, WorkflowRecord,
-    WorkflowVersionRecord,
+    NewExecution, ResumeTarget, TriggerDedupRow, WebhookActivationRecord, WebhookMode,
+    WorkflowRecord, WorkflowVersionRecord,
 };
 use nebula_storage_port::store::{
     ControlQueue, ExecutionJournalReader, ExecutionStore, IdempotencyGuard, IdempotencyStore,
@@ -1281,6 +1281,129 @@ pub async fn assert_control_queue_outbox_and_fencing(backend: &dyn Backend) {
         .mark_completed(&[42u8; 16], &runner_a)
         .await
         .expect("mark_completed (claimant)");
+}
+
+/// A `ControlMsg` whose `resume_target` is `Some(ResumeTarget::Webhook{..})`
+/// survives an enqueue→claim round-trip through the durable queue intact.
+///
+/// This is the structural fix for ADR-0099 W-S3a: closing the confused-deputy
+/// bug on the durable path requires the column to exist on both enqueue and
+/// claim. A `None` target also round-trips correctly (backward compatibility
+/// with legacy rows).
+///
+/// **Falsifiability**: before the `resume_target TEXT` column was added to
+/// `port_control_queue`, `claim_pending` hardcoded `resume_target: None` and
+/// the `Some(target)` assertion failed → RED.
+pub async fn assert_resume_target_survives_queue_round_trip(backend: &dyn Backend) {
+    let store = backend.execution_store().await;
+    let queue = backend.control_queue().await;
+    let s = scope_a();
+    store
+        .create(&s, "exe_rt", "wf_rt", serde_json::json!({}))
+        .await
+        .expect("create execution for resume-target round-trip");
+    let token = store
+        .acquire_lease(&s, "exe_rt", "holder", std::time::Duration::from_secs(30))
+        .await
+        .expect("acquire_lease")
+        .unwrap_or_else(|| panic!("[{}] lease for resume-target test", backend.name()));
+
+    let webhook_target = ResumeTarget::Webhook {
+        callback_id: "cb-round-trip".to_owned(),
+    };
+    let resume_msg = ControlMsg {
+        id: [77u8; 16],
+        execution_id: "exe_rt".into(),
+        command: ControlCommand::Resume,
+        scope: s.clone(),
+        w3c_traceparent: None,
+        reclaim_count: 0,
+        resume_target: Some(webhook_target.clone()),
+    };
+    let batch = TransitionBatch::builder()
+        .scope(s.clone())
+        .execution_id("exe_rt")
+        .expected_version(0)
+        .fencing(token)
+        .new_state(serde_json::json!({"s": "waiting"}))
+        .outbox(vec![resume_msg])
+        .build()
+        .expect("batch for resume-target round-trip");
+    store
+        .commit(batch)
+        .await
+        .expect("commit for resume-target round-trip");
+
+    let runner = [9u8; 16];
+    let claimed = queue
+        .claim_pending(&runner, 16)
+        .await
+        .expect("claim_pending for resume-target round-trip");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] the outbox Resume must be claimable",
+        backend.name()
+    );
+    assert_eq!(
+        claimed[0].resume_target,
+        Some(webhook_target),
+        "[{}] resume_target must survive the enqueue→claim round-trip intact \
+         (kind + identity both preserved)",
+        backend.name()
+    );
+
+    // A second message with no target must also round-trip correctly
+    // (backward-compatibility: legacy rows and non-Resume commands have NULL).
+    store
+        .create(&s, "exe_rt2", "wf_rt", serde_json::json!({}))
+        .await
+        .expect("create second execution");
+    let token2 = store
+        .acquire_lease(&s, "exe_rt2", "holder", std::time::Duration::from_secs(30))
+        .await
+        .expect("acquire_lease 2")
+        .unwrap_or_else(|| panic!("[{}] lease 2 for resume-target test", backend.name()));
+    let null_msg = ControlMsg {
+        id: [78u8; 16],
+        execution_id: "exe_rt2".into(),
+        command: ControlCommand::Cancel,
+        scope: s.clone(),
+        w3c_traceparent: None,
+        reclaim_count: 0,
+        resume_target: None,
+    };
+    let batch2 = TransitionBatch::builder()
+        .scope(s.clone())
+        .execution_id("exe_rt2")
+        .expected_version(0)
+        .fencing(token2)
+        .new_state(serde_json::json!({"s": "cancelling"}))
+        .outbox(vec![null_msg])
+        .build()
+        .expect("batch 2");
+    store.commit(batch2).await.expect("commit 2");
+    // First, drain the already-claimed row above to avoid re-claiming it.
+    queue
+        .mark_completed(&[77u8; 16], &runner)
+        .await
+        .expect("mark_completed first row");
+    let claimed2 = queue
+        .claim_pending(&runner, 16)
+        .await
+        .expect("claim_pending 2");
+    assert_eq!(
+        claimed2.len(),
+        1,
+        "[{}] the null-target message must be claimable",
+        backend.name()
+    );
+    assert_eq!(
+        claimed2[0].resume_target,
+        None,
+        "[{}] a None resume_target must round-trip as None (legacy compat)",
+        backend.name()
+    );
 }
 
 /// Journal entries appended by a `commit` are readable in order, and a

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -701,6 +701,7 @@ pub async fn assert_atomic_triple(backend: &dyn Backend) {
         scope: s.clone(),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     let je = JournalEntry {
         seq: None,
@@ -1222,6 +1223,7 @@ pub async fn assert_control_queue_outbox_and_fencing(backend: &dyn Backend) {
         scope: s.clone(),
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     let batch = TransitionBatch::builder()
         .scope(s.clone())

--- a/crates/tenancy/tests/cross_tenant_denial.rs
+++ b/crates/tenancy/tests/cross_tenant_denial.rs
@@ -439,6 +439,7 @@ async fn cross_tenant_control_enqueue_is_stamped_with_bound_scope() {
         scope: scope_b(), // forged target tenant
         w3c_traceparent: None,
         reclaim_count: 0,
+        resume_target: None,
     };
     tenant_a.enqueue(&attack).await.expect("A enqueue");
 


### PR DESCRIPTION
## What

The keystone of the **W-S3** epic (ADR-0099 inbound resume transport). W-S2b's resume is **untargeted** — it arms every signal-`Waiting` node — and the parked node never persists which `WaitCondition` it waited on. W-S3a fixes both so the (still test-only-reachable) Resume path is **correct-by-identity before any production producer exists**, structurally closing two confused-deputy bugs (one Resume satisfying a sibling wait; a webhook Resume satisfying an Approval gate).

## Changes

- **Persist a typed `WaitSignal`** enum (`Webhook{callback_id}` / `Approval{approver}` / `Execution{execution_id}`, identity-only — no payload/message) as `#[serde(default)] Option<WaitSignal>` on `NodeExecutionState` (JSONB, **no SQL migration**; legacy rows → `None`). Set at park, cleared on every wait-resolution/terminal path. `park_node` grows a `wait_signal` param with a **typed release-safe invariant**: `wait_signal.is_some()` IFF the wait is signal-driven (classified independently of `wait_wake`/`wake_at`) — desync returns `ExecutionError`, state untouched.
- **Extract `arm_signal_waits_under_lease(predicate)`** from the two previously-inlined arm sites (the Paused under-lease satisfy-CAS and the live-loop `ResumeSignalled` self-arm). Both reuse it; the #856 own-the-lease-before-RMW invariant is preserved (the helper mutates only in-memory state; each caller owns its lease + commit).
- **`ControlMsg.resume_target: Option<ResumeTarget>`** (serde-default) threaded through `dispatch_resume` + the control consumer. The arm predicate matches by `WaitSignal` identity, **kind-aware**: a Webhook target arms only a Webhook `WaitSignal` with an equal `callback_id`, **never** an Approval/Execution (kind-confusion safety rule); a malformed Execution id parses-fails closed. `resume_target == None` keeps the legacy all-arm behaviour (W-S2b preserved). `ResumeTarget` lives in storage-port (below execution); threaded **in-memory only** — the durable column lands in a later slice with the producer (no migration here).

## Scope (W-S3a only)

No producer, no resume-token store, no no-live recovery, no reclaim-affinity — those are the later W-S3 slices (b/c/d), held for owner sign-off. This slice is internal/additive/reversible (serde-default field, no migration, no public API, no attacker surface).

## Verification

- Reviewed: **spec-complete** + **code-quality clean** + **ASYNC-GATE PASS** (arm-extraction preserves the lease invariant for both callers; arm-set preserved; the kind discriminator proven load-bearing by red-on-revert).
- **582 engine+execution+storage-port tests green**; clippy `-D warnings`, fmt, rustdoc `-D warnings`, `cargo check --workspace --all-features --tests` all clean (DTO ripple resolved across api/worker/server/storage/tenancy, no half-migration).
- Red-first tests: targeted Resume arms only the matching callback; webhook Resume does NOT satisfy an Approval gate (kind); Execution targeting + parse-fail-fails-closed; untargeted keeps legacy all-arm.

Builds on #861. Part of ADR-0099 W-S3; durable design record: vault `project_adr0099_wait_state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Workflows can now be resumed from specific waiting conditions individually—webhook callbacks, approval gates, and execution dependencies—rather than resuming all conditions simultaneously, enabling finer-grained execution control. Untargeted resumes preserve legacy behavior for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->