### PR TITLE
feat(engine): W-S3b — no-live-owner Running-resume recovery + Resume reclaim-budget exemption (ADR-0099)

### DIFF
--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -79,6 +79,23 @@ use crate::{
     event::ExecutionEvent,
 };
 
+/// Three-way discriminant returned by [`EngineControlDispatch::read_status_discriminated`].
+///
+/// Separates the two PERMANENT outcomes (no row, corrupt row) from a transient
+/// backend read error so callers can ack-drop permanent states and defer
+/// (redeliver) on transient store failures instead of silently losing a valid
+/// command.
+#[derive(Debug)]
+enum StatusRead {
+    /// The execution row exists and its `status` field deserialised cleanly.
+    Present(ExecutionStatus),
+    /// No row was found for this `execution_id` in this `scope` (permanent).
+    Absent,
+    /// The row exists but its state is unreadable: the `status` field is
+    /// missing or failed to deserialise (permanent corruption).
+    Corrupt,
+}
+
 /// Engine-owned [`ControlDispatch`] implementation.
 ///
 /// Holds a shared [`WorkflowEngine`] plus a scoped [`ExecutionStore`]
@@ -146,6 +163,50 @@ impl EngineControlDispatch {
                     "execution {execution_id}: persisted state has no `status` field"
                 ))),
             },
+        }
+    }
+
+    /// Like [`Self::read_status`] but returns a [`StatusRead`] discriminant
+    /// instead of collapsing all failures into `Err`.
+    ///
+    /// The returned `Err` means a **transient** backend failure: the
+    /// `ExecutionStore::get` call itself returned an error (network blip,
+    /// lock timeout, connection pool exhausted, etc.). The caller MUST NOT
+    /// ack-drop on `Err`; it should defer the command so B1 reclaim can
+    /// redeliver once the store recovers.
+    ///
+    /// `Ok(StatusRead::Absent)` and `Ok(StatusRead::Corrupt)` are PERMANENT:
+    /// no amount of redelivery will change the outcome. Ack-dropping them is
+    /// safe (and correct — it prevents forever-redelivery on a moot command).
+    ///
+    /// This is intentionally NOT used by `dispatch_start` / `dispatch_restart`
+    /// / `dispatch_cancel`, which propagate the read error via `?` so a
+    /// transient store failure on those paths surfaces in the consumer's
+    /// `mark_failed` (the right outcome for a non-Resume orphan or restart).
+    /// Only the Resume path (where the command is attacker-facing and an
+    /// absent/corrupt id must not be retried forever) uses this discriminant.
+    async fn read_status_discriminated(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<StatusRead, ControlDispatchError> {
+        let record = match self.execution.get(scope, &execution_id.to_string()).await {
+            Ok(Some(r)) => r,
+            Ok(None) => return Ok(StatusRead::Absent),
+            Err(e) => {
+                // Transient backend error — the caller must Defer, not ack-drop.
+                return Err(ControlDispatchError::Deferred(format!(
+                    "execution {execution_id}: transient store read error during Resume dispatch: \
+                     {e}"
+                )));
+            },
+        };
+        match record.state.get("status") {
+            Some(s) => match serde_json::from_value::<ExecutionStatus>(s.clone()) {
+                Ok(status) => Ok(StatusRead::Present(status)),
+                Err(_) => Ok(StatusRead::Corrupt),
+            },
+            None => Ok(StatusRead::Corrupt),
         }
     }
 
@@ -383,12 +444,12 @@ impl EngineControlDispatch {
                      {holder}; Resume deferred for B1 reclaim"
                 )))
             },
-            Err(e) => match self.read_status(scope, execution_id).await {
+            Err(e) => match self.read_status_discriminated(scope, execution_id).await {
                 // Row missing: a forged / garbage / corrupt id, or a row deleted
                 // mid-recovery. Ack-DROP (not Deferred) so the row is consumed
                 // rather than redelivered forever against a non-existent
                 // execution — the only forever-redeliver leak this path closes.
-                Ok(None) => {
+                Ok(StatusRead::Absent) => {
                     tracing::warn!(
                         %execution_id,
                         recovery_error = %e,
@@ -398,7 +459,7 @@ impl EngineControlDispatch {
                     );
                     Ok(())
                 },
-                Ok(Some(status))
+                Ok(StatusRead::Present(status))
                     if status.is_terminal() || matches!(status, ExecutionStatus::Cancelling) =>
                 {
                     tracing::info!(
@@ -410,7 +471,7 @@ impl EngineControlDispatch {
                     );
                     Ok(())
                 },
-                Ok(Some(status)) => {
+                Ok(StatusRead::Present(status)) => {
                     // Same distinct target as the live-owner defer above: a
                     // sustained rate here flags a non-resolving Resume that the
                     // reclaim budget no longer terminalizes.
@@ -431,20 +492,43 @@ impl EngineControlDispatch {
                          status={status}; Resume deferred for B1 reclaim"
                     )))
                 },
-                // Status unreadable / unparseable: a corrupt row can never be
-                // recovered, so ack-DROP rather than churn it through reclaim
-                // forever (same forever-redeliver-leak closure as the missing-row
-                // arm).
-                Err(read_err) => {
+                // Permanent corruption — ack-DROP to close the forever-redeliver
+                // leak (same as the `Absent` arm above: a corrupt row can never
+                // be recovered).
+                Ok(StatusRead::Corrupt) => {
                     tracing::warn!(
                         %execution_id,
                         recovery_error = %e,
-                        read_error = %read_err,
                         "dispatch_resume: no-live-owner recovery failed and the status re-read \
                          is unreadable/unparseable (corrupt row); ack-dropping the Resume to \
                          avoid forever-redelivery"
                     );
                     Ok(())
+                },
+                // Transient backend read error on the re-read — the execution may
+                // still be valid and non-terminal. Defer so B1 reclaim redelivers
+                // once the store recovers; do NOT ack-drop a valid Resume.
+                Err(deferred) => {
+                    tracing::warn!(
+                        target: "engine::wait::resume_recovery",
+                        %execution_id,
+                        recovery_error = %e,
+                        re_read_error = %deferred,
+                        "dispatch_resume: no-live-owner recovery failed and the status re-read \
+                         also hit a transient store error; deferring Resume conservatively for \
+                         B1 reclaim"
+                    );
+                    self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                        execution_id,
+                        reason: format!(
+                            "recovery did not land ({e}); re-read transient error: {deferred}"
+                        ),
+                    });
+                    Err(ControlDispatchError::Deferred(format!(
+                        "execution {execution_id} no-live-owner recovery did not land ({e}); \
+                         status re-read transient error ({deferred}); Resume deferred \
+                         conservatively for B1 reclaim"
+                    )))
                 },
             },
         }
@@ -493,9 +577,14 @@ impl ControlDispatch for EngineControlDispatch {
         // consumed) rather than `Rejected` (which would record a noisy Failed
         // row) or any error that redelivers — this closes the only
         // forever-redeliver leak on the Resume path (ADR-0099 W-S3b).
-        let status = match self.read_status(scope, execution_id).await {
-            Ok(Some(status)) => status,
-            Ok(None) => {
+        //
+        // IMPORTANT: only `StatusRead::Absent` (no row) and `StatusRead::Corrupt`
+        // (permanent bad state) are ack-dropped. A transient backend read error
+        // (`Err`) propagates as `Deferred` — a store blip during a VALID Resume
+        // must never be silently discarded (Codex P2, ADR-0099 W-S3b).
+        let status = match self.read_status_discriminated(scope, execution_id).await {
+            Ok(StatusRead::Present(status)) => status,
+            Ok(StatusRead::Absent) => {
                 tracing::warn!(
                     %execution_id,
                     "dispatch_resume: execution not found (forged/garbage id or pruned row); \
@@ -503,14 +592,28 @@ impl ControlDispatch for EngineControlDispatch {
                 );
                 return Ok(());
             },
-            Err(read_err) => {
+            Ok(StatusRead::Corrupt) => {
                 tracing::warn!(
                     %execution_id,
-                    read_error = %read_err,
                     "dispatch_resume: execution status unreadable/unparseable (corrupt row); \
                      ack-dropping the moot Resume to avoid forever-redelivery"
                 );
                 return Ok(());
+            },
+            Err(deferred) => {
+                // Transient backend read error — the execution may be VALID.
+                // Defer so B1 reclaim redelivers once the store recovers.
+                tracing::warn!(
+                    %execution_id,
+                    deferred_reason = %deferred,
+                    "dispatch_resume: transient store error reading execution status; \
+                     deferring Resume for B1 reclaim (not ack-dropping — may be a valid Resume)"
+                );
+                self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                    execution_id,
+                    reason: format!("transient store read error: {deferred}"),
+                });
+                return Err(deferred);
             },
         };
         match status {

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -35,9 +35,14 @@
 //!   loop's resume channel via `WorkflowEngine::resume_live` (W-S2b) and gates the ack on the
 //!   loop's DURABLE self-arm (P1#1): the loop checkpoints the arm under its own lease and replies
 //!   with the outcome. The row is acked only when the arm durably landed (`Armed`) or there was
-//!   nothing to arm (`NothingToArm`); a failed arm checkpoint, a gone loop, an ack timeout, or no
-//!   live entry (cross-runner / just-paused) → `Deferred` for B1 reclaim, each with a distinct
-//!   `ResumeDeferred` reason. Redelivery is idempotent.
+//!   nothing to arm (`NothingToArm`); a failed arm checkpoint, a gone loop, or an ack timeout →
+//!   `Deferred` for B1 reclaim, each with a distinct `ResumeDeferred` reason. No live entry on
+//!   this runner (`NoLiveEntry` — a crashed parking runner with a TTL-expired lease, or
+//!   cross-runner) is RECOVERED via `recover_running_resume` (W-S3b): the execution lease is the
+//!   dead-vs-live oracle — `satisfy_running_signal_waits` arms the matching wait under a
+//!   free/expired lease and re-drives, or `Deferred`s when a live owner holds the lease elsewhere;
+//!   a recovery against an absent/corrupt row is ack-dropped (no forever-redelivery). Redelivery
+//!   is idempotent.
 //!
 //! - **Cancel / Terminate** always signal the engine's cancel registry (except for orphan commands,
 //!   which are [`ControlDispatchError::Rejected`]). The underlying
@@ -276,6 +281,174 @@ impl EngineControlDispatch {
             },
         }
     }
+
+    /// Recover a no-live-owner `Running` execution whose `Resume` reached
+    /// [`Self::dispatch_resume`]'s `NoLiveEntry` arm (ADR-0099 W-S3b).
+    ///
+    /// `NoLiveEntry` means the live-frontier resume channel found no
+    /// `RunningEntry` on this runner — either the parking runner crashed with a
+    /// now-TTL-expired lease, or the Resume landed on a different runner than
+    /// the (possibly still live) owner. [`WorkflowEngine::satisfy_running_signal_waits`]
+    /// uses the execution lease as the dead-vs-live oracle: it acquires the
+    /// lease (free / TTL-expired ⇒ crashed, no owner) and arms the matching
+    /// signal wait(s) under it, or returns [`EngineError::Leased`] (a real owner
+    /// is alive elsewhere ⇒ defer). On a successful arm we re-drive via
+    /// [`Self::drive_armed_resume`], whose Phase-0b completes the armed wait and
+    /// which itself Defers on a non-terminal drive (keeping the Resume
+    /// redeliverable when the lease holder is a still-crashed runner).
+    ///
+    /// Outcome → control-queue ack mapping:
+    ///
+    /// - `Satisfied` (recovered) → `drive_armed_resume` (ack on terminal,
+    ///   `Deferred` on a non-terminal drive).
+    /// - `NothingToSatisfy` → ack: no matching parked wait to recover (already
+    ///   armed / completed / a different node) — an idempotent no-op.
+    /// - `ExecutionNotResumable` → ack: a concurrent cancel/terminate moved the
+    ///   execution off a resumable status under the lease; the Resume is moot.
+    /// - `Leased` → `Deferred`: a live owner elsewhere — B1 reclaim redelivers.
+    /// - any other error → re-read the persisted status:
+    ///   - row missing (`Ok(None)`) → **ack-drop**: a forged / garbage / corrupt
+    ///     id, or a row deleted mid-recovery, is moot. Acking (not `Deferred`)
+    ///     closes the only forever-redeliver leak (the row would otherwise cycle
+    ///     through B1 reclaim forever against a non-existent execution).
+    ///   - status unreadable / unparseable (`Err`) → **ack-drop** for the same
+    ///     reason: a corrupt row can never be recovered, so redelivering it
+    ///     forever is pure churn.
+    ///   - terminal / `Cancelling` → ack: a concurrent actor owns the outcome.
+    ///   - still non-terminal → `Deferred`: the wait may still be pending; B1
+    ///     reclaim redelivers.
+    async fn recover_running_resume(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        resume_target: Option<ResumeTarget>,
+    ) -> Result<(), ControlDispatchError> {
+        match self
+            .engine
+            .satisfy_running_signal_waits(scope, execution_id, resume_target.as_ref())
+            .await
+        {
+            Ok(SatisfyOutcome::Satisfied(recovered_count)) => {
+                tracing::info!(
+                    %execution_id,
+                    recovered_count,
+                    "dispatch_resume: no-live-owner recovery armed the signal wait(s) under a \
+                     dead/expired lease; driving the recovered execution"
+                );
+                // Phase-0b completes the armed wait; a non-terminal drive Defers
+                // (keeps the Resume redeliverable for B1 reclaim).
+                self.drive_armed_resume(scope, execution_id).await
+            },
+            Ok(SatisfyOutcome::NothingToSatisfy) => {
+                tracing::info!(
+                    %execution_id,
+                    "dispatch_resume: no-live-owner recovery found no matching parked signal \
+                     wait to arm (already armed / completed / different node); acking as \
+                     idempotent no-op"
+                );
+                Ok(())
+            },
+            Ok(SatisfyOutcome::ExecutionNotResumable) => {
+                tracing::info!(
+                    %execution_id,
+                    "dispatch_resume: execution left a resumable status before no-live-owner \
+                     recovery could arm (concurrent cancel/terminate); acking Resume as \
+                     idempotent no-op"
+                );
+                Ok(())
+            },
+            Err(EngineError::Leased { ref holder, .. }) => {
+                // A live owner holds the lease elsewhere — this is NOT a crashed
+                // runner. Do not double-drive; defer so B1 reclaim redelivers
+                // once the lease frees (or the owner's own resume channel
+                // handles it). Mirrors the `Paused` Leased arm.
+                // Distinct, machine-greppable target so an operator can alert on
+                // a HIGH RATE of recovery deferrals for one `execution_id` — the
+                // budget-blind, non-resolving Resume the reclaim exemption made
+                // invisible to the bulk sweep counts (ADR-0099 W-S3b
+                // observability).
+                tracing::warn!(
+                    target: "engine::wait::resume_recovery",
+                    %execution_id,
+                    %holder,
+                    "dispatch_resume: no-live-owner recovery deferred — execution lease held \
+                     by a live owner elsewhere; leaving control-queue row for B1 reclaim"
+                );
+                self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                    execution_id,
+                    reason: format!("recovery deferred: lease held by live owner {holder}"),
+                });
+                Err(ControlDispatchError::Deferred(format!(
+                    "execution {execution_id} no-live-owner recovery: lease held by live owner \
+                     {holder}; Resume deferred for B1 reclaim"
+                )))
+            },
+            Err(e) => match self.read_status(scope, execution_id).await {
+                // Row missing: a forged / garbage / corrupt id, or a row deleted
+                // mid-recovery. Ack-DROP (not Deferred) so the row is consumed
+                // rather than redelivered forever against a non-existent
+                // execution — the only forever-redeliver leak this path closes.
+                Ok(None) => {
+                    tracing::warn!(
+                        %execution_id,
+                        recovery_error = %e,
+                        "dispatch_resume: no-live-owner recovery failed and the execution row \
+                         is absent (forged/garbage id or deleted mid-recovery); ack-dropping \
+                         the Resume to avoid forever-redelivery"
+                    );
+                    Ok(())
+                },
+                Ok(Some(status))
+                    if status.is_terminal() || matches!(status, ExecutionStatus::Cancelling) =>
+                {
+                    tracing::info!(
+                        %execution_id,
+                        %status,
+                        recovery_error = %e,
+                        "dispatch_resume: no-live-owner recovery did not land but execution is \
+                         now {status}; acking as idempotent"
+                    );
+                    Ok(())
+                },
+                Ok(Some(status)) => {
+                    // Same distinct target as the live-owner defer above: a
+                    // sustained rate here flags a non-resolving Resume that the
+                    // reclaim budget no longer terminalizes.
+                    tracing::warn!(
+                        target: "engine::wait::resume_recovery",
+                        %execution_id,
+                        %status,
+                        recovery_error = %e,
+                        "dispatch_resume: no-live-owner recovery did not land and execution is \
+                         still non-terminal ({status}); deferring Resume for B1 reclaim"
+                    );
+                    self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                        execution_id,
+                        reason: format!("recovery did not land ({e}); status={status}"),
+                    });
+                    Err(ControlDispatchError::Deferred(format!(
+                        "execution {execution_id} no-live-owner recovery did not land ({e}); \
+                         status={status}; Resume deferred for B1 reclaim"
+                    )))
+                },
+                // Status unreadable / unparseable: a corrupt row can never be
+                // recovered, so ack-DROP rather than churn it through reclaim
+                // forever (same forever-redeliver-leak closure as the missing-row
+                // arm).
+                Err(read_err) => {
+                    tracing::warn!(
+                        %execution_id,
+                        recovery_error = %e,
+                        read_error = %read_err,
+                        "dispatch_resume: no-live-owner recovery failed and the status re-read \
+                         is unreadable/unparseable (corrupt row); ack-dropping the Resume to \
+                         avoid forever-redelivery"
+                    );
+                    Ok(())
+                },
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -312,10 +485,35 @@ impl ControlDispatch for EngineControlDispatch {
         execution_id: ExecutionId,
         resume_target: Option<ResumeTarget>,
     ) -> Result<(), ControlDispatchError> {
-        match self.read_status(scope, execution_id).await? {
-            None => Err(ControlDispatchError::Rejected(format!(
-                "execution {execution_id} not found — resume command orphaned"
-            ))),
+        // A Resume is attacker-facing (a webhook/approval callback) and does no
+        // work of its own. Unlike Start/Cancel/Restart — whose orphan is a
+        // producer bug surfaced as `Rejected` (→ Failed) — a Resume to an
+        // unknown / unreadable execution is MOOT: a forged, garbage, or corrupt
+        // id can never resume anything. Ack-DROP it (`Ok(())`, the row is
+        // consumed) rather than `Rejected` (which would record a noisy Failed
+        // row) or any error that redelivers — this closes the only
+        // forever-redeliver leak on the Resume path (ADR-0099 W-S3b).
+        let status = match self.read_status(scope, execution_id).await {
+            Ok(Some(status)) => status,
+            Ok(None) => {
+                tracing::warn!(
+                    %execution_id,
+                    "dispatch_resume: execution not found (forged/garbage id or pruned row); \
+                     ack-dropping the moot Resume"
+                );
+                return Ok(());
+            },
+            Err(read_err) => {
+                tracing::warn!(
+                    %execution_id,
+                    read_error = %read_err,
+                    "dispatch_resume: execution status unreadable/unparseable (corrupt row); \
+                     ack-dropping the moot Resume to avoid forever-redelivery"
+                );
+                return Ok(());
+            },
+        };
+        match status {
             // `Running`: a signal wait parked with a `timeout` keeps the row
             // `Running` with a LIVE frontier loop on the timeout timer (W-S2b).
             // The durable satisfy-CAS path cannot be used here — it would
@@ -334,11 +532,22 @@ impl ControlDispatch for EngineControlDispatch {
             // `ResumeDeferred` reason so the cause is observable. Deferring is
             // always safe: Resume redelivery is idempotent.
             //
-            // No-live-owner recovery (`NoLiveEntry`) keeps today's behavior:
-            // defer for B1 reclaim. Recovering a `Running` execution that has no
-            // live loop on ANY runner is a future (W-S3) slice.
-            Some(ExecutionStatus::Running) => {
-                match self.engine.resume_live(execution_id, resume_target).await {
+            // No-live-owner recovery (`NoLiveEntry`): a `Running` execution
+            // with no live loop on THIS runner is recovered via
+            // `recover_running_resume` — the execution lease is the
+            // dead-vs-live oracle (a free/TTL-expired lease ⇒ the parking
+            // runner crashed ⇒ arm under the dead lease and re-drive; a live
+            // lease elsewhere ⇒ a real owner is driving ⇒ defer). Only a
+            // genuine Resume reaches this arm and recovers; a plain
+            // crash-recovery re-drive (worker sink / `dispatch_start` /
+            // `dispatch_restart`) re-enters `resume_execution` WITHOUT arming,
+            // so it re-parks rather than auto-completing (ADR-0099 W-S3b).
+            ExecutionStatus::Running => {
+                match self
+                    .engine
+                    .resume_live(execution_id, resume_target.clone())
+                    .await
+                {
                     ResumeDelivery::Acked(ResumeOutcome::Armed { count }) => {
                         tracing::info!(
                             %execution_id,
@@ -370,22 +579,23 @@ impl ControlDispatch for EngineControlDispatch {
                         execution_id,
                         "live frontier did not confirm the self-arm within the ack timeout",
                     ),
-                    ResumeDelivery::NoLiveEntry => Self::defer_running_resume(
-                        &self.engine,
-                        execution_id,
-                        "Running with no live frontier on this runner (cross-runner or just-paused)",
-                    ),
+                    ResumeDelivery::NoLiveEntry => {
+                        // No live loop on this runner. Recover via the lease
+                        // dead-vs-live oracle (crashed parking runner with a
+                        // TTL-expired lease, OR cross-runner) instead of an
+                        // unconditional defer (ADR-0099 W-S3b).
+                        self.recover_running_resume(scope, execution_id, resume_target)
+                            .await
+                    },
                 }
             },
-            Some(
-                ExecutionStatus::Cancelling
-                | ExecutionStatus::Completed
-                | ExecutionStatus::Failed
-                | ExecutionStatus::Cancelled
-                | ExecutionStatus::TimedOut,
-            ) => Ok(()),
+            ExecutionStatus::Cancelling
+            | ExecutionStatus::Completed
+            | ExecutionStatus::Failed
+            | ExecutionStatus::Cancelled
+            | ExecutionStatus::TimedOut => Ok(()),
             // `Created`: no signal-driven waits exist yet — drive directly.
-            Some(ExecutionStatus::Created) => self.drive(scope, execution_id).await,
+            ExecutionStatus::Created => self.drive(scope, execution_id).await,
             // `Paused`: the execution is suspended awaiting an external signal.
             // Arm all signal-driven waits (Waiting{next_attempt_at == None}
             // → Waiting{next_attempt_at = now}) via durable CAS BEFORE re-driving;
@@ -414,7 +624,7 @@ impl ControlDispatch for EngineControlDispatch {
             //   Acking unconditionally here would permanently drop the Resume when a
             //   lease TTL-expiry causes a FencedOut (surfaced as CasConflict) while
             //   the execution is still Paused — bounded lost-Resume.
-            Some(ExecutionStatus::Paused) => {
+            ExecutionStatus::Paused => {
                 match self
                     .engine
                     .satisfy_signal_waits(scope, execution_id, resume_target.as_ref())

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2738,6 +2738,131 @@ impl WorkflowEngine {
         outcome
     }
 
+    /// Recover a no-live-owner **`Running`** execution by arming its signal
+    /// waits under a freshly-acquired lease — the structural sibling of
+    /// [`Self::satisfy_signal_waits`] for the crash-recovery path (ADR-0099
+    /// W-S3b).
+    ///
+    /// A signal wait parked WITH a timeout keeps its execution `Running` (the
+    /// timeout timer lives on the parking runner's `wait_heap`). When that
+    /// runner crashes, its in-process frontier loop is gone but the durable row
+    /// stays `Running` with the wait node still parked. A `Resume` for such an
+    /// execution reaches [`WorkflowEngine::resume_live`] with no live
+    /// `RunningEntry` on this runner ([`ResumeDelivery::NoLiveEntry`]) — either
+    /// the parking runner crashed with a now-TTL-expired lease, or the Resume
+    /// landed on a different runner than the (possibly still live) owner. This
+    /// method distinguishes the two and recovers only the genuinely no-live case.
+    ///
+    /// The lease IS the dead-vs-live oracle, exactly as in `satisfy_signal_waits`:
+    ///
+    /// - [`EngineError::Leased`] — the lease is still LIVE elsewhere, so a real
+    ///   owner is actively driving this execution. We must NOT touch the row;
+    ///   the caller defers (B1 reclaim redelivers once the lease frees, or the
+    ///   live owner's own resume channel handles it). This is the cross-runner /
+    ///   not-yet-crashed case.
+    /// - lease acquired (free, or TTL-expired ⇒ the parking runner crashed and
+    ///   no owner remains) — proceed. We arm the matching signal wait(s) under
+    ///   the owned lease via the SAME [`Self::satisfy_signal_waits_under_lease`]
+    ///   inner the `Paused` path uses, so the version-CAS + fencing commit and
+    ///   the kind-aware [`arm_signal_waits_under_lease`] targeting are identical.
+    ///   A targeted recovery (`Some(resume_target)`) arms ONLY the matching
+    ///   node; an untargeted one arms every signal wait. The caller then
+    ///   re-drives via `drive_armed_resume`, whose Phase-0b completes the armed
+    ///   wait on the main port.
+    ///
+    /// The own-the-lease-before-read-modify-write invariant (#856) is preserved:
+    /// the lease is held across the whole inner commit and released best-effort
+    /// only afterwards (mirroring `satisfy_signal_waits`), so a stale token can
+    /// never be manufactured from persisted metadata.
+    ///
+    /// # Security
+    ///
+    /// Only a genuine `Resume` calls this method — `dispatch_resume`'s
+    /// `NoLiveEntry` arm. A plain crash-recovery re-drive (the worker sink /
+    /// `dispatch_start` / `dispatch_restart`) re-enters `resume_execution`
+    /// WITHOUT arming, so it re-parks the wait rather than auto-completing it.
+    /// That is the same structural discriminator `satisfy_signal_waits`
+    /// enforces for the `Paused` case, extended to the `Running` case here.
+    ///
+    /// # Returns / Errors
+    ///
+    /// Same [`SatisfyOutcome`] / [`EngineError`] contract as
+    /// [`Self::satisfy_signal_waits`] (it shares the inner): `Satisfied(n)` /
+    /// `NothingToSatisfy` / `ExecutionNotResumable` on success; `Leased` (live
+    /// owner — defer) / `PlanningFailed` / `CasConflict` / `CheckpointFailed`
+    /// on error.
+    pub(crate) async fn satisfy_running_signal_waits(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        resume_target: Option<&ResumeTarget>,
+    ) -> Result<SatisfyOutcome, EngineError> {
+        let Some(stores) = &self.stores else {
+            // Library mode (no storage) — signal-park recovery is a no-op.
+            return Ok(SatisfyOutcome::NothingToSatisfy);
+        };
+
+        let id = execution_id.to_string();
+        let holder = self.instance_id.to_string();
+
+        // Acquire the execution lease before the read-modify-write — the
+        // dead-vs-live oracle. A free or TTL-expired lease (the parking runner
+        // crashed) is acquirable here; a lease still LIVE elsewhere returns
+        // `None` ⇒ `Leased`, so the caller defers and lets the real owner drive.
+        let lease_token = stores
+            .execution
+            .acquire_lease(scope, &id, &holder, self.lease_ttl)
+            .await
+            .map_err(|e| {
+                EngineError::PlanningFailed(format!(
+                    "satisfy_running_signal_waits: acquire lease for {execution_id}: {e}"
+                ))
+            })?;
+        let Some(lease_token) = lease_token else {
+            tracing::warn!(
+                %execution_id,
+                %holder,
+                "satisfy_running_signal_waits: execution lease held by another runner \
+                 (live owner elsewhere); deferring Resume recovery (will redeliver)"
+            );
+            return Err(EngineError::Leased {
+                execution_id,
+                holder,
+            });
+        };
+
+        // Lease acquired (crashed owner / no live frontier) — recover under
+        // mutual exclusion through the SAME inner the Paused path uses.
+        let outcome = self
+            .satisfy_signal_waits_under_lease(
+                stores,
+                scope,
+                execution_id,
+                &id,
+                lease_token,
+                resume_target,
+            )
+            .await;
+
+        // Release the lease best-effort (mirror `satisfy_signal_waits`): the
+        // commit already wrote the new fencing generation, so a release failure
+        // leaves the lease to expire at TTL (the correct fail-safe).
+        if let Err(e) = stores
+            .execution
+            .release_lease(scope, &id, lease_token)
+            .await
+        {
+            tracing::warn!(
+                %execution_id,
+                error = %e,
+                "satisfy_running_signal_waits: best-effort lease release failed \
+                 (will expire at TTL)"
+            );
+        }
+
+        outcome
+    }
+
     /// Inner read-modify-write under an already-held lease.
     ///
     /// Extracted so the lease release in `satisfy_signal_waits` is guaranteed

--- a/crates/engine/tests/wait_recovery.rs
+++ b/crates/engine/tests/wait_recovery.rs
@@ -1,0 +1,974 @@
+//! Integration tests for ADR-0099 **W-S3b** — no-live-owner `Running`-resume
+//! recovery.
+//!
+//! A signal wait parked WITH a `timeout` keeps its execution **`Running`** (the
+//! parking runner's frontier loop sits on the timeout timer). If that runner
+//! crashes, its in-process loop is gone but the durable row stays `Running` with
+//! the wait still parked. A `Resume` for such an execution reaches
+//! `dispatch_resume`'s `Running` arm → `resume_live` finds NO live `RunningEntry`
+//! → `ResumeDelivery::NoLiveEntry`. W-S3b RECOVERS that case via
+//! `recover_running_resume` → `WorkflowEngine::satisfy_running_signal_waits`,
+//! using the execution lease as the dead-vs-live oracle:
+//!
+//! - lease free / TTL-expired (the parking runner crashed) ⇒ arm the matching
+//!   signal wait(s) under the dead lease and re-drive to completion;
+//! - lease still LIVE elsewhere (a real owner is driving) ⇒ `Deferred`, never a
+//!   double-drive;
+//! - a forged / absent / corrupt id ⇒ ack-drop (no forever-redelivery).
+//!
+//! ## Security invariant (explicitly tested)
+//!
+//! Only a genuine `Resume` recovers a no-live-owner wait. A plain crash-recovery
+//! re-drive (the worker sink / `dispatch_start` re-entering `resume_execution`)
+//! must NOT complete the wait — it re-parks instead. That is the same structural
+//! discriminator W-S2 enforces for the `Paused` case, extended to `Running` here.
+//!
+//! ## Timing model
+//!
+//! The engine's `wait_heap` deadlines are wall-clock (`chrono::Utc`), not tokio
+//! timers, so `tokio::time::pause`/`advance` cannot drive them. Mirroring
+//! `wait_timeout.rs`, these tests use real, short durations with a generous
+//! outer `tokio::time::timeout` safety bound; lease-TTL crash recovery uses the
+//! in-mem store's 1s clamp floor under real time.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, ControlDispatchError,
+    DataPassingPolicy, EngineControlDispatch, ExecutionEvent, InProcessRunner, WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
+use nebula_storage_port::{
+    dto::{ResumeTarget, WorkflowVersionRecord},
+    store::{ExecutionStore, WorkflowVersionStore},
+};
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Action stubs ──────────────────────────────────────────────────────────────
+
+macro_rules! static_action_impl {
+    ($ty:ty, $key:expr, $name:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, "wait_recovery integration test stub")
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+/// Parks on a `Webhook` signal WITH a timeout, so the execution stays `Running`
+/// (live timer) rather than `Paused`. The `callback_id` is fixed per instance so
+/// a targeted recovery `ResumeTarget::Webhook` can match it by identity.
+struct WebhookWaitWithTimeout {
+    callback_id: String,
+    timeout: Duration,
+}
+
+static_action_impl!(
+    WebhookWaitWithTimeout,
+    action_key!("test.wr.webhook_timeout"),
+    "WebhookWaitWithTimeout"
+);
+
+impl StatelessAction for WebhookWaitWithTimeout {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: self.callback_id.clone(),
+            },
+            timeout: Some(self.timeout),
+            partial_output: None,
+        })
+    }
+}
+
+/// A second webhook-wait action key (distinct identity) for the targeted-recovery
+/// mixed-wait test.
+struct WebhookWaitWithTimeoutB {
+    callback_id: String,
+    timeout: Duration,
+}
+
+static_action_impl!(
+    WebhookWaitWithTimeoutB,
+    action_key!("test.wr.webhook_timeout_b"),
+    "WebhookWaitWithTimeoutB"
+);
+
+impl StatelessAction for WebhookWaitWithTimeoutB {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: self.callback_id.clone(),
+            },
+            timeout: Some(self.timeout),
+            partial_output: None,
+        })
+    }
+}
+
+/// Counts invocations and succeeds. The downstream gate probe — tests assert on
+/// the exact count to verify Phase-0b edge activation after recovery.
+struct CountingEcho {
+    invocations: Arc<AtomicU32>,
+}
+
+static_action_impl!(CountingEcho, action_key!("test.wr.echo"), "CountingEcho");
+
+impl StatelessAction for CountingEcho {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+/// A second downstream probe under a distinct key (for the sibling node in the
+/// mixed-wait test).
+struct CountingEchoB {
+    invocations: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingEchoB,
+    action_key!("test.wr.echo_b"),
+    "CountingEchoB"
+);
+
+impl StatelessAction for CountingEchoB {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Shared store bundle ──────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct RecoveryStores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl RecoveryStores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+
+    async fn save_workflow(&self, wf: &WorkflowDefinition) {
+        self.versions
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                WorkflowVersionRecord {
+                    workflow_id: wf.id.to_string(),
+                    number: 0,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(wf).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn persist_created_execution(&self, workflow_id: nebula_core::WorkflowId) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        self.execution
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+                &workflow_id.to_string(),
+                serde_json::to_value(&exec_state).unwrap(),
+            )
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    async fn load_state(&self, execution_id: ExecutionId) -> ExecutionState {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        let s = serde_json::to_string(&record.state).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    async fn persisted_status(&self, execution_id: ExecutionId) -> ExecutionStatus {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
+    }
+}
+
+// ── Engine assembly ──────────────────────────────────────────────────────────
+
+fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
+}
+
+/// Single signal+timeout wait `wait ──main──> downstream`.
+fn build_single_registry(
+    callback_id: &str,
+    timeout: Duration,
+    downstream: &Arc<AtomicU32>,
+) -> Arc<ActionRegistry> {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.webhook_timeout"),
+            "WebhookWaitWithTimeout",
+            "wait_recovery stub",
+        ),
+        WebhookWaitWithTimeout {
+            callback_id: callback_id.to_owned(),
+            timeout,
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.echo"),
+            "CountingEcho",
+            "wait_recovery stub",
+        ),
+        CountingEcho {
+            invocations: Arc::clone(downstream),
+        },
+    );
+    registry
+}
+
+fn make_single_workflow() -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    let wait = node_key!("wait_node");
+    let downstream = node_key!("downstream_node");
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "wait-recovery-single".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(wait.clone(), "WaitNode", "core", "test.wr.webhook_timeout")
+                .unwrap(),
+            NodeDefinition::new(downstream.clone(), "DownstreamNode", "core", "test.wr.echo")
+                .unwrap(),
+        ],
+        connections: vec![Connection::new(wait, downstream)],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+/// Await `NodeParked` for `expected` DISTINCT nodes, so all waits are parked
+/// before a Resume is delivered.
+async fn await_n_parked(
+    events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
+    expected: usize,
+) {
+    use std::collections::HashSet;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut parked: HashSet<nebula_core::NodeKey> = HashSet::new();
+        while parked.len() < expected {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { node_key, .. }) => {
+                    parked.insert(node_key);
+                },
+                Some(_) => continue,
+                None => panic!("event bus closed before all NodeParked"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("engine must emit {expected} distinct NodeParked events"));
+}
+
+/// Park a single signal+timeout wait under "runner A", then crash A (abort its
+/// drive task) so NO live `RunningEntry` remains and the lease is left to expire.
+/// Returns the parked, owner-less `Running` execution id plus the scope. The
+/// caller then delivers a Resume that hits `NoLiveEntry`.
+async fn park_then_crash_owner(
+    stores: &RecoveryStores,
+    engine_a: &Arc<WorkflowEngine>,
+    workflow_id: nebula_core::WorkflowId,
+    events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
+) -> ExecutionId {
+    let execution_id = stores.persist_created_execution(workflow_id).await;
+    let engine_a_h = Arc::clone(engine_a);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task_a =
+        tokio::spawn(async move { engine_a_h.resume_execution(&scope, execution_id).await });
+    await_n_parked(events_rx, 1).await;
+    // Crash runner A immediately after the park: the park checkpoint already
+    // landed before `NodeParked` fired, so the durable row is intact and the
+    // abort drops the `RunningEntry` (no live loop) without racing the timer.
+    task_a.abort();
+    let _ = task_a.await;
+    execution_id
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// **W-S3b — a crashed owner's `Running` Resume recovers via the expired lease.**
+///
+/// Runner A parks a signal+timeout wait (long timeout), then crashes (its drive
+/// task is aborted; no live `RunningEntry`). After the lease TTL expires, a
+/// `dispatch_resume` (on an engine with no live entry for this execution) hits
+/// `NoLiveEntry` → `recover_running_resume` acquires the dead lease, arms the
+/// wait, drives `Waiting → Completed`, runs downstream, and completes.
+///
+/// **Falsifiability**: revert the `NoLiveEntry` arm to the unconditional
+/// `defer_running_resume` → the Resume is never recovered → the execution stays
+/// `Running` (or times out at t=1h), downstream never runs → `Completed` +
+/// `downstream == 1` asserts fail → RED.
+#[tokio::test]
+async fn crashed_owner_resume_recovers_via_expired_lease() {
+    let downstream = Arc::new(AtomicU32::new(0));
+    // Long timeout: recovery must complete via the Resume arm, never via timeout.
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(1); // in-mem clamp floor
+    let heartbeat = Duration::from_millis(300);
+
+    let stores = RecoveryStores::new();
+    let wf = make_single_workflow();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_single_registry("cb-recover", timeout, &downstream))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    let execution_id = park_then_crash_owner(&stores, &engine_a, wf.id, &mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "a signal+timeout wait must keep the crashed execution Running (no live loop)"
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        0,
+        "downstream must be gated while parked"
+    );
+
+    // Wait out the lease TTL so the recovering runner can acquire the dead lease.
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+
+    // A fresh runner B with NO live entry for this execution receives the Resume.
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_single_registry(
+                "cb-recover",
+                timeout,
+                &downstream,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let dispatch_b = EngineControlDispatch::new(Arc::clone(&engine_b), stores.execution.clone());
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        dispatch_b.dispatch_resume(&scope, execution_id, None),
+    )
+    .await
+    .expect("recovery must settle within 10s")
+    .expect("no-live-owner Resume must recover the crashed Running execution");
+
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "the recovered execution must complete after the no-live-owner Resume"
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once after recovery arms+drives the wait"
+    );
+}
+
+/// **W-S3b — a Resume to a still-LIVE owner elsewhere DEFERS, never recovers.**
+///
+/// The execution lease is held (live, NOT TTL-expired) by another runner.
+/// `satisfy_running_signal_waits` returns `Leased`, so `recover_running_resume`
+/// returns `Deferred` (B1 reclaim redelivers once the lease frees) — it must NOT
+/// arm or double-drive the wait.
+///
+/// Mechanics: runner A parks the wait and "crashes" (its drive task is aborted)
+/// WITHOUT the lease TTL expiring — an aborted `resume_execution` drops its
+/// `LeaseGuard` without an explicit release, so the lease stays held until its
+/// (long, 30s) TTL. That is exactly a live-owner-elsewhere shape: the row is
+/// `Running` with no live entry on the recovering runner, but the lease is not
+/// yet acquirable. The Resume then arrives on a runner with no live entry →
+/// `NoLiveEntry` → recovery → the still-held lease blocks the acquire →
+/// `Leased` → `Deferred`.
+///
+/// **Falsifiability**: make `satisfy_running_signal_waits` ignore the held lease
+/// and arm anyway → the Resume would recover under a live owner (double-drive) →
+/// the `Deferred` assertion fails → RED.
+#[tokio::test]
+async fn live_owner_elsewhere_resume_defers() {
+    let downstream = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(30); // long: the held lease stays LIVE for the test
+    let heartbeat = Duration::from_millis(300);
+
+    let stores = RecoveryStores::new();
+    let wf = make_single_workflow();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_single_registry("cb-live", timeout, &downstream))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    // Park + crash A, but DO NOT wait out the (30s) lease TTL — A's lease stays
+    // held, modelling a live owner that has not released the execution.
+    let execution_id = park_then_crash_owner(&stores, &engine_a, wf.id, &mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running
+    );
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    // Runner B (no live entry) receives the Resume → NoLiveEntry → recovery →
+    // satisfy_running_signal_waits sees the still-held lease → Leased → Deferred.
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_single_registry(
+                "cb-live",
+                timeout,
+                &downstream,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let dispatch_b = EngineControlDispatch::new(Arc::clone(&engine_b), stores.execution.clone());
+
+    let result = dispatch_b.dispatch_resume(&scope, execution_id, None).await;
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "a Resume to a live-owner-held execution must Defer, got {result:?}"
+    );
+
+    // The wait must NOT have been armed for completion (no double-drive): a
+    // signal+timeout wait stays `Waiting` with `wait_wake == Timeout` (the arm
+    // would have flipped it to `Completion`), on its future timeout deadline.
+    let state = stores.load_state(execution_id).await;
+    assert!(
+        state
+            .node_states
+            .values()
+            .any(|ns| ns.state == nebula_workflow::NodeState::Waiting
+                && ns.wait_wake == Some(nebula_execution::state::WaitWake::Timeout)),
+        "the wait node must remain Waiting with wait_wake == Timeout (un-armed) after a \
+         deferred (not recovered) Resume; node_states: {:?}",
+        state
+            .node_states
+            .values()
+            .map(|ns| (ns.state, ns.wait_wake))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        0,
+        "downstream must not run while the Resume is deferred behind a live owner"
+    );
+}
+
+/// **W-S3b — a Resume to an unknown execution ACK-DROPS (no forever-redelivery).**
+///
+/// A `Resume` for an id that no execution row exists for is moot (a forged /
+/// garbage / corrupt callback id). `dispatch_resume` must ack-drop it (`Ok(())`,
+/// the control-queue row is consumed) rather than `Deferred` (which would
+/// redeliver against the non-existent execution forever) or `Rejected` (which
+/// would record a noisy Failed row).
+///
+/// **Falsifiability**: revert the not-found arm to `Deferred` (or `Rejected`) →
+/// the `Ok(())` assertion fails → RED. (`Rejected`/`Internal`/any other `Err`
+/// also fails the `is_ok` assertion below.)
+#[tokio::test]
+async fn not_found_resume_acks_drops() {
+    let downstream = Arc::new(AtomicU32::new(0));
+    let stores = RecoveryStores::new();
+    // A workflow exists, but we deliver a Resume for an execution id that was
+    // never created — there is no row for it.
+    let engine = Arc::new(stores.attach(make_engine(build_single_registry(
+        "cb-absent",
+        Duration::from_hours(1),
+        &downstream,
+    ))));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    let unknown = ExecutionId::new();
+    let result = dispatch.dispatch_resume(&scope, unknown, None).await;
+    assert!(
+        result.is_ok(),
+        "a Resume to an unknown execution must ack-drop (Ok), not Deferred/Rejected; got {result:?}"
+    );
+}
+
+/// **W-S3b (Decision-3) — targeted recovery arms ONLY the matching node.**
+///
+/// A no-live-owner `Running` execution has TWO parallel parked signal+timeout
+/// waits of DISTINCT identity (`cb-a` / `cb-b`), each feeding its own downstream.
+/// A TARGETED recovery Resume (`ResumeTarget::Webhook { callback_id: "cb-a" }`)
+/// must arm ONLY `wait_a` — `downstream_a` runs, `downstream_b` stays gated and
+/// `wait_b` stays `Waiting`.
+///
+/// **Falsifiability**: drop the `resume_target` pass-through in
+/// `recover_running_resume` (arm untargeted) → BOTH waits arm → `downstream_b`
+/// runs (== 1) → the `downstream_b == 0` assertion fails → RED.
+#[tokio::test]
+async fn mixed_wait_targeted_recovery_arms_only_match() {
+    let downstream_a = Arc::new(AtomicU32::new(0));
+    let downstream_b = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(1);
+    let heartbeat = Duration::from_millis(300);
+
+    // Two distinct webhook waits + two distinct downstreams.
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.webhook_timeout"),
+            "WebhookWaitWithTimeout",
+            "wait_recovery stub",
+        ),
+        WebhookWaitWithTimeout {
+            callback_id: "cb-a".to_owned(),
+            timeout,
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.webhook_timeout_b"),
+            "WebhookWaitWithTimeoutB",
+            "wait_recovery stub",
+        ),
+        WebhookWaitWithTimeoutB {
+            callback_id: "cb-b".to_owned(),
+            timeout,
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.echo"),
+            "CountingEcho",
+            "wait_recovery stub",
+        ),
+        CountingEcho {
+            invocations: Arc::clone(&downstream_a),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.echo_b"),
+            "CountingEchoB",
+            "wait_recovery stub",
+        ),
+        CountingEchoB {
+            invocations: Arc::clone(&downstream_b),
+        },
+    );
+
+    let now = chrono::Utc::now();
+    let wait_a = node_key!("wait_a");
+    let wait_b = node_key!("wait_b");
+    let down_a = node_key!("down_a");
+    let down_b = node_key!("down_b");
+    let wf = WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "wait-recovery-mixed".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(wait_a.clone(), "WaitA", "core", "test.wr.webhook_timeout")
+                .unwrap(),
+            NodeDefinition::new(wait_b.clone(), "WaitB", "core", "test.wr.webhook_timeout_b")
+                .unwrap(),
+            NodeDefinition::new(down_a.clone(), "DownA", "core", "test.wr.echo").unwrap(),
+            NodeDefinition::new(down_b.clone(), "DownB", "core", "test.wr.echo_b").unwrap(),
+        ],
+        connections: vec![
+            Connection::new(wait_a, down_a),
+            Connection::new(wait_b, down_b),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+
+    let stores = RecoveryStores::new();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(make_engine(registry).with_event_bus(event_bus))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    // Park BOTH waits under runner A, then crash A.
+    let execution_id = stores.persist_created_execution(wf.id).await;
+    let engine_a_h = Arc::clone(&engine_a);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task_a =
+        tokio::spawn(async move { engine_a_h.resume_execution(&scope, execution_id).await });
+    await_n_parked(&mut events_rx, 2).await;
+    task_a.abort();
+    let _ = task_a.await;
+
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running
+    );
+
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+
+    // Recover with a TARGETED Resume for cb-a only.
+    let registry_b = Arc::new(ActionRegistry::new());
+    registry_b.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.webhook_timeout"),
+            "WebhookWaitWithTimeout",
+            "wait_recovery stub",
+        ),
+        WebhookWaitWithTimeout {
+            callback_id: "cb-a".to_owned(),
+            timeout,
+        },
+    );
+    registry_b.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.webhook_timeout_b"),
+            "WebhookWaitWithTimeoutB",
+            "wait_recovery stub",
+        ),
+        WebhookWaitWithTimeoutB {
+            callback_id: "cb-b".to_owned(),
+            timeout,
+        },
+    );
+    registry_b.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.echo"),
+            "CountingEcho",
+            "wait_recovery stub",
+        ),
+        CountingEcho {
+            invocations: Arc::clone(&downstream_a),
+        },
+    );
+    registry_b.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wr.echo_b"),
+            "CountingEchoB",
+            "wait_recovery stub",
+        ),
+        CountingEchoB {
+            invocations: Arc::clone(&downstream_b),
+        },
+    );
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(registry_b))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let dispatch_b = EngineControlDispatch::new(Arc::clone(&engine_b), stores.execution.clone());
+
+    // The targeted recovery arms cb-a and re-drives. Because cb-b (NOT armed)
+    // stays `Waiting` with its live 1h timer, the recovery drive parks cb-b and
+    // sits on that timer rather than returning — exactly the correct behavior
+    // (runner B is now the live owner of cb-b). So spawn the dispatch and observe
+    // the SELECTIVE effect (cb-a completed, cb-b untouched) without waiting for
+    // the whole execution to settle.
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let dispatch_task = tokio::spawn(async move {
+        dispatch_b
+            .dispatch_resume(
+                &scope,
+                execution_id,
+                Some(ResumeTarget::Webhook {
+                    callback_id: "cb-a".to_owned(),
+                }),
+            )
+            .await
+    });
+
+    // Poll (bounded) until cb-a's downstream has run — the targeted arm landed.
+    let recovered = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if downstream_a.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        recovered.is_ok(),
+        "the targeted wait (cb-a) must be armed and its downstream must run within 10s"
+    );
+
+    assert_eq!(
+        downstream_b.load(Ordering::SeqCst),
+        0,
+        "the SIBLING wait (cb-b) must NOT be armed by a cb-a-targeted recovery — \
+         targeting arms only the kind+identity match"
+    );
+
+    // cb-b must remain `Waiting` (the targeted recovery left it parked on its
+    // own live timer).
+    let state = stores.load_state(execution_id).await;
+    let waiting_count = state
+        .node_states
+        .values()
+        .filter(|ns| ns.state == nebula_workflow::NodeState::Waiting)
+        .count();
+    assert_eq!(
+        waiting_count, 1,
+        "exactly one wait (cb-b) must remain Waiting after the targeted recovery"
+    );
+
+    // The recovery drive is still sitting on cb-b's 1h timer; abort it (the test
+    // has proven the selective arm).
+    dispatch_task.abort();
+    let _ = dispatch_task.await;
+}
+
+/// **W-S3b (SECURITY) — a crash-recovery re-drive WITHOUT a Resume does NOT
+/// satisfy the wait.**
+///
+/// A crashed-`Running` signal+timeout execution recovered by a plain re-drive
+/// (the worker-sink / `dispatch_start` path: `resume_execution` re-entry, which
+/// does NOT short-circuit on `Running`) must NOT complete the signal wait — only
+/// a genuine `dispatch_resume` arms it. The re-drive re-seeds the timer and
+/// re-parks; with a long timeout the wait stays `Waiting` and downstream stays
+/// gated.
+///
+/// **Falsifiability**: wire `satisfy_running_signal_waits` (or any arm-for-
+/// completion) into the worker-sink/`dispatch_start` re-drive path → the re-drive
+/// auto-completes the wait → downstream runs (== 1) → the `== 0` assertion before
+/// the genuine Resume fails → RED.
+#[tokio::test]
+async fn crash_recovery_redrive_without_resume_does_not_satisfy() {
+    let downstream = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(1);
+    let heartbeat = Duration::from_millis(300);
+
+    let stores = RecoveryStores::new();
+    let wf = make_single_workflow();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_single_registry("cb-redrive", timeout, &downstream))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    let execution_id = park_then_crash_owner(&stores, &engine_a, wf.id, &mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running
+    );
+
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+
+    // Crash-recovery re-drive (NO Resume): the worker sink / dispatch_start path
+    // re-enters `resume_execution` directly. It must re-park the signal wait, NOT
+    // complete it. We bound it: a healthy re-park returns promptly (it parks on
+    // the live timer and exits the synchronous drive once the frontier yields).
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_single_registry(
+                "cb-redrive",
+                timeout,
+                &downstream,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let engine_b_h = Arc::clone(&engine_b);
+    let scope_b = nebula_engine::store_seam::single_tenant_scope();
+    let task_b =
+        tokio::spawn(async move { engine_b_h.resume_execution(&scope_b, execution_id).await });
+
+    // The re-drive re-parks the signal wait on its (live, 1h) timer and then
+    // sits on it — so `task_b` does NOT return. Give the re-drive ample time to
+    // run its frontier (it would have auto-completed the wait by now IF the
+    // re-drive path armed signal waits), then assert it did NOT.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        0,
+        "a crash-recovery re-drive (no Resume) must NOT complete the signal wait — \
+         downstream must stay gated until a genuine Resume arrives"
+    );
+    let state = stores.load_state(execution_id).await;
+    assert!(
+        state
+            .node_states
+            .values()
+            .any(|ns| ns.state == nebula_workflow::NodeState::Waiting
+                && ns.next_attempt_at.is_some_and(|at| at > chrono::Utc::now())),
+        "the wait node must remain Waiting on its FUTURE timeout timer after a crash-recovery \
+         re-drive (re-parked, not armed-for-completion / auto-completed)"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "the re-driven execution must stay Running (re-parked), not Completed"
+    );
+
+    // The re-drive is still sitting on the 1h timer; abort it (the long timeout
+    // never fires within the test).
+    task_b.abort();
+    let _ = task_b.await;
+}

--- a/crates/engine/tests/wait_recovery.rs
+++ b/crates/engine/tests/wait_recovery.rs
@@ -35,7 +35,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, OnceLock,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
     time::Duration,
 };
@@ -56,12 +56,106 @@ use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_metrics::MetricsRegistry;
 use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
 use nebula_storage_port::{
-    dto::{ResumeTarget, WorkflowVersionRecord},
+    FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome,
+    dto::{ExecutionRecord, ResumeTarget, WorkflowVersionRecord},
     store::{ExecutionStore, WorkflowVersionStore},
 };
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
 };
+
+// ── Fault-injecting ExecutionStore wrapper (Codex P2 red test) ───────────────
+
+/// Wraps a real `ExecutionStore` and injects a `StorageError::Connection` on
+/// `get` calls when `fail_reads` is set. All other methods delegate
+/// transparently, so the engine's write-path and lease management remain
+/// functional.
+///
+/// Used in `transient_store_error_during_resume_defers_not_drops` to prove that
+/// a transient backend blip during the idempotency read does NOT silently drop a
+/// valid `Resume` (Codex P2, ADR-0099 W-S3b).
+#[derive(Debug)]
+struct FaultInjectingExecutionStore {
+    inner: Arc<InMemoryExecutionStore>,
+    /// When `true`, `get` returns `StorageError::Connection` instead of
+    /// forwarding to `inner`.
+    fail_reads: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for FaultInjectingExecutionStore {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
+        if self.fail_reads.load(Ordering::SeqCst) {
+            return Err(StorageError::Connection(
+                "injected transient store read failure (Codex P2 test)".to_owned(),
+            ));
+        }
+        self.inner.get(scope, id).await
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        self.inner.acquire_lease(scope, id, holder, ttl).await
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
 
 // ── Action stubs ──────────────────────────────────────────────────────────────
 
@@ -971,4 +1065,148 @@ async fn crash_recovery_redrive_without_resume_does_not_satisfy() {
     // never fires within the test).
     task_b.abort();
     let _ = task_b.await;
+}
+
+/// **W-S3b (Codex P2) — a TRANSIENT store read error during `dispatch_resume`
+/// returns `Deferred`, NOT `Ok(())` (ack-drop).**
+///
+/// `dispatch_resume` must distinguish between:
+/// - `StatusRead::Absent` (no row): PERMANENT → ack-drop is correct
+/// - `StatusRead::Corrupt` (bad state): PERMANENT → ack-drop is correct
+/// - backend `get` fails (transient): NOT permanent → must `Deferred` so B1
+///   reclaim redelivers after the store recovers; silently dropping a valid
+///   Resume here is data loss.
+///
+/// The test wires a `FaultInjectingExecutionStore` that injects a
+/// `StorageError::Connection` on `get` calls. Before the fault is injected,
+/// a real execution is parked and crashed (so the status would be `Running`
+/// on a healthy read). With the fault active, `dispatch_resume` MUST return
+/// `Err(Deferred)`, not `Ok(())`.
+///
+/// **Falsifiability**: revert `read_status_discriminated` to `read_status`
+/// (which collapses transient `Err` into ack-drop in the caller) → the test
+/// asserts `is_err()` but gets `Ok(())` → RED.
+#[tokio::test]
+async fn transient_store_error_during_resume_defers_not_drops() {
+    let downstream = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(1);
+    let heartbeat = Duration::from_millis(300);
+
+    // Use the real in-memory store for the engine's own internals, then wrap it
+    // for the dispatch's idempotency-read so we can inject faults on `get` alone.
+    let inner_execution = Arc::new(InMemoryExecutionStore::new());
+    let fail_reads = Arc::new(AtomicBool::new(false));
+    let fault_store: Arc<dyn ExecutionStore> = Arc::new(FaultInjectingExecutionStore {
+        inner: Arc::clone(&inner_execution),
+        fail_reads: Arc::clone(&fail_reads),
+    });
+
+    // Build a RecoveryStores bundle that shares the same inner execution store
+    // with the fault-injecting wrapper, so engine writes are real but dispatch
+    // reads go through the fault wrapper.
+    let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&inner_execution));
+    let versions = InMemoryWorkflowVersionStore::new();
+    let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+    let stores = RecoveryStores {
+        execution: Arc::clone(&inner_execution),
+        journal,
+        node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+        checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+        idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+        workflow: Arc::new(workflow),
+        versions: Arc::new(versions),
+    };
+
+    let wf = make_single_workflow();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_single_registry("cb-fault", timeout, &downstream))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    // Park under runner A, then crash it (the lease will expire after TTL).
+    let execution_id = park_then_crash_owner(&stores, &engine_a, wf.id, &mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "parking must keep the execution Running"
+    );
+
+    // Wait out the lease TTL so the recovering runner could acquire the dead
+    // lease (we want to confirm the fault fires BEFORE we get that far).
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+
+    // Build runner B and give it the FAULT-INJECTING store for its dispatch's
+    // idempotency read. The engine itself still uses the real inner store so
+    // its internals (lease, commit) work normally — we only break the
+    // `get`-for-status path.
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_single_registry(
+                "cb-fault",
+                timeout,
+                &downstream,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    // Wire the fault store into the dispatch (not the engine). The engine's
+    // internal store is clean; only `read_status_discriminated` inside the
+    // dispatch sees the fault.
+    let dispatch_b = EngineControlDispatch::new(Arc::clone(&engine_b), Arc::clone(&fault_store));
+
+    // Activate the fault AFTER setup so none of the park/persist calls are
+    // affected, then deliver the Resume.
+    fail_reads.store(true, Ordering::SeqCst);
+
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let result = dispatch_b.dispatch_resume(&scope, execution_id, None).await;
+
+    // The transient store error MUST Defer — not silently drop the Resume.
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "a transient store read error during dispatch_resume must return Deferred (redeliverable), \
+         not Ok (ack-drop); got: {result:?}"
+    );
+
+    // Downstream must stay gated — the Resume was not delivered.
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        0,
+        "downstream must NOT run when the Resume is Deferred due to a transient store error"
+    );
+
+    // Lift the fault and confirm that a healthy re-delivery (B1 reclaim redeliver)
+    // now succeeds — proving the row was not consumed.
+    fail_reads.store(false, Ordering::SeqCst);
+    let recovery_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        dispatch_b.dispatch_resume(&scope, execution_id, None),
+    )
+    .await
+    .expect("re-delivery must settle within 10s");
+
+    assert!(
+        recovery_result.is_ok(),
+        "a re-delivered Resume after the store recovers must succeed; got: {recovery_result:?}"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "the execution must complete on successful re-delivery"
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once after the successful re-delivery"
+    );
 }

--- a/crates/storage/src/inmem/control_queue.rs
+++ b/crates/storage/src/inmem/control_queue.rs
@@ -222,7 +222,15 @@ impl ControlQueue for InMemoryControlQueue {
             if !stale {
                 continue;
             }
-            if q.reclaim_count >= max_reclaim_count {
+            // A `Resume` row is EXEMPT from the exhaust budget (ADR-0099 W-S3b):
+            // a Resume does no work of its own and cannot poison-loop, so the
+            // budget must never force-Fail it — engine liveness (`acquire_lease`)
+            // and the wait's own timeout are the only terminal authorities. It
+            // keeps redelivering past `reclaim_count >= max` (mirrors the SQL
+            // backends' `command <> 'Resume'` exhaust guard + `OR command =
+            // 'Resume'` redeliver widening) rather than wedging in `Processing`.
+            let is_resume = q.msg.command == nebula_storage_port::dto::ControlCommand::Resume;
+            if q.reclaim_count >= max_reclaim_count && !is_resume {
                 q.status = "Failed".to_string();
                 q.error_message = Some(format!(
                     "reclaim exhausted: presumed dead after {} reclaims",

--- a/crates/storage/src/postgres/control_queue.rs
+++ b/crates/storage/src/postgres/control_queue.rs
@@ -190,12 +190,19 @@ impl ControlQueue for PgControlQueue {
         let cutoff_ms = Utc::now()
             .timestamp_millis()
             .saturating_sub(reclaim_after.as_millis() as i64);
+        // A `command = 'Resume'` row is EXEMPT from the exhaust budget
+        // (ADR-0099 W-S3b): a Resume does no work of its own and cannot
+        // poison-loop, so the budget must never force-Fail it. Engine liveness
+        // (`acquire_lease`) and the wait's own timeout are the only terminal
+        // authorities for a parked Resume. The REDELIVER branch widens to keep
+        // an exempt Resume redelivering (observably) past `reclaim_count >= max`
+        // rather than wedging in `Processing`.
         let exhausted = sqlx::query(
             "UPDATE port_control_queue \
              SET status = 'Failed', \
                  error_message = 'reclaim exhausted: presumed dead' \
              WHERE status = 'Processing' AND processed_at_ms < $1 \
-               AND reclaim_count >= $2",
+               AND reclaim_count >= $2 AND command <> 'Resume'",
         )
         .bind(cutoff_ms)
         .bind(i32::try_from(max_reclaim_count).unwrap_or(i32::MAX))
@@ -203,12 +210,16 @@ impl ControlQueue for PgControlQueue {
         .await
         .map_err(conn_err)?
         .rows_affected();
+        // `OR command = 'Resume'` is the budget-exemption complement of the
+        // exhaust branch (ADR-0099 W-S3b): an exempt Resume at
+        // `reclaim_count >= max` would otherwise match neither branch and stay
+        // stuck `Processing` forever; this keeps it redeliverable.
         let reclaimed = sqlx::query(
             "UPDATE port_control_queue \
              SET status = 'Pending', reclaim_count = reclaim_count + 1, \
                  processed_by = NULL, processed_at_ms = NULL \
              WHERE status = 'Processing' AND processed_at_ms < $1 \
-               AND reclaim_count < $2",
+               AND (reclaim_count < $2 OR command = 'Resume')",
         )
         .bind(cutoff_ms)
         .bind(i32::try_from(max_reclaim_count).unwrap_or(i32::MAX))

--- a/crates/storage/src/sqlite/control_queue.rs
+++ b/crates/storage/src/sqlite/control_queue.rs
@@ -199,12 +199,20 @@ impl ControlQueue for SqliteControlQueue {
             - i64::try_from(reclaim_after.as_millis()).unwrap_or(i64::MAX);
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
         // Exhausted rows (past the reclaim budget) → Failed.
+        //
+        // A `command = 'Resume'` row is EXEMPT (ADR-0099 W-S3b): a Resume does
+        // no work of its own and cannot poison-loop, so the reclaim budget must
+        // never force-Fail it. Engine liveness (`acquire_lease`'s dead-vs-live
+        // oracle) and the wait's own timeout are the only terminal authorities
+        // for a parked Resume. The paired REDELIVER branch widens to catch the
+        // exempt Resume at `reclaim_count >= max`, so it keeps redelivering
+        // (observably) rather than wedging in `Processing`.
         let exhausted = sqlx::query(
             "UPDATE port_control_queue \
              SET status = 'Failed', \
                  error_message = 'reclaim exhausted: presumed dead' \
              WHERE status = 'Processing' AND processed_at_ms < ? \
-               AND reclaim_count >= ?",
+               AND reclaim_count >= ? AND command <> 'Resume'",
         )
         .bind(cutoff)
         .bind(i64::from(max_reclaim_count))
@@ -212,13 +220,18 @@ impl ControlQueue for SqliteControlQueue {
         .await
         .map_err(conn_err)?
         .rows_affected();
-        // Remaining stale rows → back to Pending, bump reclaim_count.
+        // Remaining stale rows → back to Pending, bump reclaim_count. A
+        // `command = 'Resume'` row redelivers regardless of `reclaim_count`
+        // (the `OR command = 'Resume'` clause), the budget-exemption complement
+        // of the exhaust branch above (ADR-0099 W-S3b) — without it an exempt
+        // Resume at `reclaim_count >= max` would match neither branch and stay
+        // stuck `Processing` forever.
         let reclaimed = sqlx::query(
             "UPDATE port_control_queue \
              SET status = 'Pending', reclaim_count = reclaim_count + 1, \
                  processed_by = NULL, processed_at_ms = NULL \
              WHERE status = 'Processing' AND processed_at_ms < ? \
-               AND reclaim_count < ?",
+               AND (reclaim_count < ? OR command = 'Resume')",
         )
         .bind(cutoff)
         .bind(i64::from(max_reclaim_count))

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -28,6 +28,7 @@ use harness::{
     assert_idempotency_store_first_writer, assert_job_dispatch_fencing,
     assert_job_dispatch_routes_by_plugin, assert_job_dispatch_routes_by_plugin_superset,
     assert_journal_visibility_and_scope, assert_live_lease_blocks_acquire,
+    assert_non_resume_row_still_exhausts, assert_resume_row_exempt_from_reclaim_budget,
     assert_resume_target_survives_queue_round_trip, assert_save_with_published_version_is_atomic,
     assert_stale_fencing_is_fenced_out, assert_trigger_dedup_first_writer,
     assert_trigger_dedup_is_scoped, assert_webhook_activation_and_scope,
@@ -99,6 +100,14 @@ matrix!(
 matrix!(
     resume_target_survives_queue_round_trip,
     assert_resume_target_survives_queue_round_trip
+);
+matrix!(
+    resume_row_exempt_from_reclaim_budget,
+    assert_resume_row_exempt_from_reclaim_budget
+);
+matrix!(
+    non_resume_row_still_exhausts,
+    assert_non_resume_row_still_exhausts
 );
 matrix!(
     journal_visibility_and_scope,

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -1406,6 +1406,193 @@ pub async fn assert_resume_target_survives_queue_round_trip(backend: &dyn Backen
     );
 }
 
+/// Enqueue a single control row of `command` and drive its `reclaim_count`
+/// up to `target_count` by repeated claim → reclaim cycles, leaving it
+/// `Processing` (just-claimed) at `reclaim_count == target_count`.
+///
+/// Each cycle claims the (Pending) row, then sweeps with a budget above the
+/// current count so the REDELIVER branch fires (`Processing → Pending`,
+/// `reclaim_count += 1`). The cutoff is wall-clock (`chrono`), so — like the
+/// `refresh_claim_*` reclaim tests for this same layer — a short real sleep
+/// makes the just-claimed row reliably stale; `tokio::time::pause` cannot drive
+/// the SQL backends' `chrono::Utc::now()` cutoff. Returns the row id so the
+/// caller can keep claiming it.
+async fn enqueue_and_climb_reclaim_count(
+    backend: &dyn Backend,
+    command: ControlCommand,
+    target_count: u32,
+) -> [u8; 16] {
+    let queue = backend.control_queue().await;
+    let s = scope_a();
+    let row_id = [
+        0xC1,
+        0xA1,
+        0x33,
+        0x44,
+        0x55,
+        0x66,
+        0x77,
+        0x88,
+        command as u8,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+    let msg = ControlMsg {
+        id: row_id,
+        execution_id: "exe_reclaim".into(),
+        command,
+        scope: s.clone(),
+        w3c_traceparent: None,
+        reclaim_count: 0,
+        resume_target: None,
+    };
+    queue.enqueue(&msg).await.expect("enqueue reclaim row");
+
+    let runner = [0xCC_u8; 16];
+    for cycle in 0..target_count {
+        let claimed = queue
+            .claim_pending(&runner, 16)
+            .await
+            .expect("claim during climb");
+        assert!(
+            claimed.iter().any(|m| m.id == row_id),
+            "[{}] the reclaim row must be claimable on climb cycle {cycle}",
+            backend.name()
+        );
+        // Make the just-claimed row stale against the wall-clock cutoff.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        // Budget strictly above the current count so this row REDELIVERS
+        // (Processing → Pending, reclaim_count += 1) rather than exhausting.
+        queue
+            .reclaim_stuck(std::time::Duration::ZERO, target_count + 1)
+            .await
+            .expect("reclaim during climb");
+    }
+    // Re-claim so the assertion sweep sees it `Processing` at the target count.
+    let claimed = queue
+        .claim_pending(&runner, 16)
+        .await
+        .expect("final claim at target count");
+    let row = claimed
+        .iter()
+        .find(|m| m.id == row_id)
+        .unwrap_or_else(|| panic!("[{}] reclaim row must be re-claimable", backend.name()));
+    assert_eq!(
+        row.reclaim_count,
+        target_count,
+        "[{}] the row must reach reclaim_count == {target_count} before the assertion sweep",
+        backend.name()
+    );
+    row_id
+}
+
+/// **ADR-0099 W-S3b** — a `command = 'Resume'` row at `reclaim_count == max`,
+/// past `reclaim_after`, is EXEMPT from the reclaim budget: the exhaust sweep
+/// must NOT Fail it; it stays redeliverable (`Processing → Pending`) so a later
+/// claim still delivers it. Engine liveness + the wait's own timeout are the
+/// only terminal authorities for a parked Resume.
+///
+/// Observable through the trait alone: after the assertion sweep, a fresh
+/// `claim_pending` still returns the Resume row (a Failed row is terminal and
+/// would never be claimable again).
+///
+/// **Falsifiability**: revert the `command <> 'Resume'` exhaust guard (and its
+/// `OR command = 'Resume'` redeliver complement) → the row at `reclaim_count >=
+/// max` is force-Failed → the post-sweep `claim_pending` finds nothing → the
+/// "still claimable" assertion fails → RED.
+pub async fn assert_resume_row_exempt_from_reclaim_budget(backend: &dyn Backend) {
+    let max_reclaim_count = 2;
+    let row_id =
+        enqueue_and_climb_reclaim_count(backend, ControlCommand::Resume, max_reclaim_count).await;
+    let queue = backend.control_queue().await;
+
+    // The assertion sweep: the Resume row is now `Processing` at
+    // `reclaim_count == max`, past `reclaim_after`. The budget would normally
+    // exhaust it (→ Failed); the exemption must redeliver it instead.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let outcome = queue
+        .reclaim_stuck(std::time::Duration::ZERO, max_reclaim_count)
+        .await
+        .expect("assertion reclaim sweep");
+    assert_eq!(
+        outcome.exhausted,
+        0,
+        "[{}] a Resume row at reclaim_count == max must NOT be exhausted (Failed); \
+         it is budget-exempt",
+        backend.name()
+    );
+
+    // The exempt Resume stays redeliverable: a fresh claim still delivers it.
+    let runner = [0xAB; 16];
+    let claimed = queue
+        .claim_pending(&runner, 16)
+        .await
+        .expect("claim after the assertion sweep");
+    let row = claimed.iter().find(|m| m.id == row_id);
+    assert!(
+        row.is_some(),
+        "[{}] a budget-exempt Resume row must stay redeliverable after the exhaust \
+         sweep (still claimable), not be Failed",
+        backend.name()
+    );
+    assert!(
+        row.is_some_and(|m| m.reclaim_count > max_reclaim_count),
+        "[{}] the redelivered Resume row's reclaim_count must keep climbing past max \
+         (observable stuck-Resume signal), got {:?}",
+        backend.name(),
+        row.map(|m| m.reclaim_count)
+    );
+}
+
+/// **ADR-0099 W-S3b** — the exemption is Resume-ONLY: a non-Resume row
+/// (`Start` / `Cancel`) at `reclaim_count >= max`, past `reclaim_after`, still
+/// EXHAUSTS to `Failed` (the budget remains the terminal authority for rows that
+/// do real work and can poison-loop).
+///
+/// Observable through the trait alone: after the assertion sweep, a fresh
+/// `claim_pending` finds nothing (a Failed row is terminal, never re-claimable).
+///
+/// **Falsifiability**: widen the exemption to cover non-Resume commands → the
+/// `Start` row at `reclaim_count >= max` redelivers instead of failing → the
+/// post-sweep `claim_pending` returns it → the "must be Failed (not claimable)"
+/// assertion fails → RED.
+pub async fn assert_non_resume_row_still_exhausts(backend: &dyn Backend) {
+    let max_reclaim_count = 2;
+    let row_id =
+        enqueue_and_climb_reclaim_count(backend, ControlCommand::Start, max_reclaim_count).await;
+    let queue = backend.control_queue().await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let outcome = queue
+        .reclaim_stuck(std::time::Duration::ZERO, max_reclaim_count)
+        .await
+        .expect("assertion reclaim sweep");
+    assert_eq!(
+        outcome.exhausted,
+        1,
+        "[{}] a non-Resume row at reclaim_count >= max must be exhausted (Failed) — \
+         the exemption is Resume-only",
+        backend.name()
+    );
+
+    // A Failed row is terminal: it must NOT be claimable again.
+    let runner = [0xCD; 16];
+    let claimed = queue
+        .claim_pending(&runner, 16)
+        .await
+        .expect("claim after the assertion sweep");
+    assert!(
+        claimed.iter().all(|m| m.id != row_id),
+        "[{}] an exhausted non-Resume row must be Failed (terminal), never re-claimable",
+        backend.name()
+    );
+}
+
 /// Journal entries appended by a `commit` are readable in order, and a
 /// cross-tenant read yields an empty journal (never another tenant's
 /// entries).


### PR DESCRIPTION
## What

ADR-0099 **W-S3b**: recover a Resume that targets a `Running` execution whose owner crashed (no live frontier), and stop the reclaim budget from permanently dropping a Resume that is legitimately still pending. Both are producer-less (unreachable in prod until W-S3d), correctness-hardening before the inbound-resume transport lands.

## Changes

- **No-live-owner recovery** (`satisfy_running_signal_waits`, engine): the structural sibling of `satisfy_signal_waits`. Acquires the execution lease as the dead-vs-live oracle — `Ok(None)`=live owner elsewhere ⇒ `Leased` ⇒ Deferred (no double-drive); `Ok(Some)`=free/TTL-expired ⇒ the previous owner is dead (gen-bump fences its corpse) ⇒ arm the signal wait for completion under the freshly-owned lease (reuses `satisfy_signal_waits_under_lease` + the W-S3a kind-aware `arm_signal_waits_under_lease`, passing `resume_target` through), checkpoint under the held lease (#856 own-the-lease-before-RMW preserved), then `drive_armed_resume`. Wired at `dispatch_resume`'s `NoLiveEntry` arm. Outcomes: recovered ⇒ ack; `Leased` ⇒ Deferred; **not-found / unreadable-status ⇒ ack-drop** (Resume-only; Start/Cancel/Restart keep Rejected). **Security parity:** only a genuine Resume arms — a worker-sink / start crash re-drive re-parks without satisfying.
- **Resume reclaim-budget exemption** (storage, all 3 backends): a `command='Resume'` row is never force-Failed by the reclaim budget — the engine `acquire_lease` is the SOLE liveness authority and the wait's own timeout bounds a wedged execution. Complementary pair: EXHAUST `AND command<>'Resume'`, REDELIVER `OR command='Resume'`. **No new column, no migration, no trait-signature change.** The earlier-considered identity-bridge + cross-table reclaim join were designed out (liveness has one home).
- **Observability:** both recovery-defer paths emit `ResumeDeferred` + a machine-greppable `engine::wait::resume_recovery` warn keyed by `execution_id`, so a budget-blind Resume that recycles without resolving is visible.

## Verification

- Reviewed: **spec-complete** + **code-quality APPROVE** + **ASYNC-GATE PASS** + concurrency (own-the-lease-across-RMW, crashed-vs-live discriminator + corpse fencing, two-recoverer race idempotency, security non-satisfy, bounded budget loop, not-found ack-drop) — all clean.
- **887 engine+execution+storage tests green**; clippy `-D warnings`, fmt, rustdoc, `cargo check --workspace --all-features --tests` clean.
- Red-first: crashed-owner recovers; live-owner-elsewhere defers; not-found ack-drops; mixed-wait targeted recovery arms only the match; crash-redrive-without-resume does NOT satisfy (security); Resume row exempt from reclaim budget (backends); non-Resume still exhausts.

## ⚠️ One deliberate contract semantic for sign-off

This slice makes one reclaim-contract decision: **a `command='Resume'` control row is never force-Failed by the reclaim budget; engine liveness (the lease oracle) + the wait's own timeout are the only terminal authorities.** Narrow, reversible (one-line SQL predicate per backend), unreachable until the W-S3d producer. Flagging it explicitly per the architecture review.

Scope: NO producer, NO resume-token store, NO migration (W-S3c/d). Builds on #862. Durable design record: vault `project_adr0099_wait_state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recovery of running executions following unexpected runner crashes using lease-based detection
  * Eliminated infinite retry loops on corrupted or missing execution records
  * Improved control queue handling to prevent recovery attempts from being exhausted prematurely

* **Tests**
  * Added comprehensive integration tests for execution recovery and control queue scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->