### PR TITLE
fix(storage): align pg schema.sql lease + idempotency columns with migration 0027 + the adapter

### DIFF
--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS port_executions (
     state               JSONB NOT NULL,
     version             BIGINT NOT NULL DEFAULT 0,
     lease_holder        TEXT,
-    lease_expires_at    TIMESTAMPTZ,
+    lease_expires_at_ms BIGINT,                    -- ms since epoch, NULL = no lease
     fencing_generation  BIGINT NOT NULL DEFAULT 0,
     created_at          TIMESTAMPTZ NOT NULL,
     updated_at          TIMESTAMPTZ NOT NULL
@@ -70,18 +70,19 @@ CREATE TABLE IF NOT EXISTS port_idempotency_marks (
 
 -- Durable idempotent-replay response cache (ADR-0048). `cache_key` is
 -- already tenant-namespaced by the caller; first writer wins via
--- INSERT ... ON CONFLICT DO NOTHING. `expires_at` drives the sweep.
+-- INSERT ... ON CONFLICT DO NOTHING. `expires_at_ms` drives the sweep.
 CREATE TABLE IF NOT EXISTS port_idempotency_cache (
-    cache_key   TEXT PRIMARY KEY,
-    status      INTEGER NOT NULL,
-    headers     BYTEA NOT NULL,
-    body        BYTEA NOT NULL,
-    fingerprint BYTEA NOT NULL,
-    expires_at  TIMESTAMPTZ NOT NULL
+    cache_key     TEXT PRIMARY KEY,
+    status        INTEGER NOT NULL,
+    headers       BYTEA NOT NULL,
+    body          BYTEA NOT NULL,
+    fingerprint   BYTEA NOT NULL,
+    expires_at    TEXT NOT NULL,            -- RFC 3339, returned verbatim
+    expires_at_ms BIGINT NOT NULL           -- ms since epoch, sweep predicate
 );
 
 CREATE INDEX IF NOT EXISTS idx_port_idempotency_cache_expiry
-    ON port_idempotency_cache (expires_at);
+    ON port_idempotency_cache (expires_at_ms);
 
 -- Webhook activation lookup: incoming webhook → owning trigger. Scoped per
 -- tenant. ADR-0096 added workflow_id / webhook_mode / token_hash (mirrors


### PR DESCRIPTION
## What

`crates/storage/src/postgres/schema.sql` — the DDL that provisions a from-scratch / conformance postgres pool (it does **not** layer the numbered migrations) — had drifted from the canonical `migrations/postgres/0027_port_adapter_schema.sql` and from the running adapter on two epoch-millis columns. A fresh pg DB built from schema.sql was broken; the migrations README requires the two to stay in sync.

## Fix (both confirmed against the adapter)

- **`port_executions`**: `lease_expires_at TIMESTAMPTZ` → `lease_expires_at_ms BIGINT`. `postgres/execution.rs` (`acquire_lease`/`renew_lease`/`release_lease`, lines 281/295/321/353/376) reads/writes `lease_expires_at_ms` as an i64 epoch-millis column — a SELECT against the TIMESTAMPTZ `lease_expires_at` column would fail.
- **`port_idempotency_cache`**: `expires_at TIMESTAMPTZ` → `expires_at TEXT` (RFC 3339, returned verbatim) **+ add the missing `expires_at_ms BIGINT`** (sweep predicate), and point the expiry index at `expires_at_ms`. `postgres/idempotency_store.rs` INSERTs both columns and DELETE-sweeps on `expires_at_ms`; schema.sql was missing the column entirely and had the wrong type on `expires_at`.

Both table bodies now **diff-clean against 0027**. The sqlite schema.sql/0027 pair was already consistent (verified). The remaining "schema.sql ahead of 0027" deltas (`resume_target`, webhook `token_hash`/`webhook_mode`/`workflow_id`/`spec_trigger_id`, the job-dispatch + trigger-dedup tables) are later migrations' cumulative additions — correct, left untouched.

## Why no behavior change

The running code (the numbered migrations + the adapter) is already correct; only the from-scratch schema.sql DDL was wrong. Docs/schema-consistency fix.

## Verification

- Both `port_executions` and `port_idempotency_cache` bodies now diff-clean vs `migrations/postgres/0027`.
- `cargo check -p nebula-storage` clean; **312 storage tests green** (sqlite + in_memory; pg conformance skip-clean without `DATABASE_URL`). pre-push CI-mirror (clippy-full, crate-diff-gate) green.

Independent of the ADR-0099 wait-state branches; flagged during the W-S3b review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema for timestamp handling in lease expiration and idempotency cache management. Modified how temporal data is stored and indexed across multiple backend tables to consolidate timestamp representation strategies. This ensures consistent handling of time-based expiration tracking throughout the database layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->