### PR TITLE
feat(api): W-S3d — webhook→Resume producer (attacker-facing) (ADR-0099)

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -225,6 +225,13 @@ pub(crate) struct ExecutionStoreBundle {
     /// in-memory store on a durable backend silently breaks the round-trip:
     /// the engine writes to the pool; the producer reads from a different empty store.
     resume_token_store: Arc<dyn nebula_storage_port::store::ResumeTokenStore>,
+    /// Resume producer (W-S3d Option B1) — the atomic consume+enqueue seam the
+    /// `POST /resume` handler uses. MUST share the SAME backend pool / shared
+    /// state as `execution_store` and `control_queue` so the token DELETE and the
+    /// `Resume` INSERT commit in one transaction. A mismatched pool would split
+    /// the burn and the enqueue across two backends — exactly the durability gap
+    /// this seam closes.
+    resume_producer: Arc<dyn nebula_storage_port::store::ResumeProducer>,
 }
 
 /// Build the execution-store bundle for the configured backend.
@@ -284,6 +291,9 @@ fn build_memory_execution_stores() -> Result<ExecutionStoreBundle, TransportInit
     // Resume-token store shares the same SharedState as the exec_store so that
     // tokens committed via TransitionBatch are visible to the POST /resume handler.
     let resume_token_store = exec_store.resume_token_store();
+    // Resume producer shares the SAME SharedState (token map + control queue) so
+    // the consume + enqueue happen under one lock.
+    let resume_producer = exec_store.resume_producer();
     let node_results = InMemoryNodeResultStore::new();
     let workflow_versions = InMemoryWorkflowVersionStore::new();
     let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
@@ -301,6 +311,7 @@ fn build_memory_execution_stores() -> Result<ExecutionStoreBundle, TransportInit
         control_queue: Arc::new(control_queue),
         trigger_dedup_inbox: Some(Arc::new(trigger_dedup_inbox)),
         resume_token_store: Arc::new(resume_token_store),
+        resume_producer: Arc::new(resume_producer),
     })
 }
 
@@ -316,8 +327,9 @@ async fn build_sqlite_execution_stores(
 ) -> Result<ExecutionStoreBundle, TransportInitError> {
     use nebula_storage::InMemoryNodeResultStore;
     use nebula_storage::sqlite::{
-        SqliteControlQueue, SqliteExecutionStore, SqliteJournalReader, SqliteResumeTokenStore,
-        SqliteTriggerDedupInbox, SqliteWorkflowStore, SqliteWorkflowVersionStore, init_schema,
+        SqliteControlQueue, SqliteExecutionStore, SqliteJournalReader, SqliteResumeProducer,
+        SqliteResumeTokenStore, SqliteTriggerDedupInbox, SqliteWorkflowStore,
+        SqliteWorkflowVersionStore, init_schema,
     };
     use sqlx::sqlite::{
         SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
@@ -376,7 +388,10 @@ async fn build_sqlite_execution_stores(
         trigger_dedup_inbox: Some(Arc::new(SqliteTriggerDedupInbox::new(pool.clone()))),
         // Same pool as the execution store: tokens minted by TransitionBatch must be
         // readable by the POST /resume handler's consume call on the same pool.
-        resume_token_store: Arc::new(SqliteResumeTokenStore::new(pool)),
+        resume_token_store: Arc::new(SqliteResumeTokenStore::new(pool.clone())),
+        // Same pool again: the producer's token DELETE and control-queue INSERT
+        // must commit in one transaction against the execution-store backend.
+        resume_producer: Arc::new(SqliteResumeProducer::new(pool)),
     })
 }
 
@@ -388,8 +403,9 @@ async fn build_pg_execution_stores(
 ) -> Result<ExecutionStoreBundle, TransportInitError> {
     use nebula_storage::InMemoryNodeResultStore;
     use nebula_storage::postgres::{
-        PgControlQueue, PgExecutionStore, PgJournalReader, PgResumeTokenStore, PgTriggerDedupInbox,
-        PgWorkflowStore, PgWorkflowVersionStore, init_schema as pg_init_schema,
+        PgControlQueue, PgExecutionStore, PgJournalReader, PgResumeProducer, PgResumeTokenStore,
+        PgTriggerDedupInbox, PgWorkflowStore, PgWorkflowVersionStore,
+        init_schema as pg_init_schema,
     };
     use sqlx::postgres::PgPoolOptions;
 
@@ -436,7 +452,10 @@ async fn build_pg_execution_stores(
         // `WebhookIngressTransport::prepare_state` is only installed when `Some`.
         trigger_dedup_inbox: Some(Arc::new(PgTriggerDedupInbox::new(pool.clone()))),
         // Same pool as the execution store — see SQLite arm for rationale.
-        resume_token_store: Arc::new(PgResumeTokenStore::new(pool)),
+        resume_token_store: Arc::new(PgResumeTokenStore::new(pool.clone())),
+        // Same pool again: the producer's DELETE + control-queue INSERT commit
+        // in one transaction against the execution-store backend.
+        resume_producer: Arc::new(PgResumeProducer::new(pool)),
     })
 }
 
@@ -683,6 +702,7 @@ pub(crate) fn default_state(
         control_queue,
         trigger_dedup_inbox,
         resume_token_store,
+        resume_producer,
     } = execution_bundle;
 
     let mut state = AppState::new(
@@ -724,6 +744,7 @@ pub(crate) fn default_state(
         nebula_api::transport::webhook::ResumeHandlerComponents::with_defaults();
     state = state
         .with_resume_token_store(resume_token_store)
+        .with_resume_producer(resume_producer)
         .with_resume_handler_components(resume_components);
 
     Ok(state)

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -219,6 +219,12 @@ pub(crate) struct ExecutionStoreBundle {
     journal_reader: Arc<dyn nebula_storage_port::store::ExecutionJournalReader>,
     control_queue: Arc<dyn nebula_storage_port::store::ControlQueue>,
     trigger_dedup_inbox: Option<Arc<dyn nebula_storage_port::store::TriggerDedupInbox>>,
+    /// Resume-token store — must share the same backend pool as `execution_store`
+    /// so that tokens minted by the engine (via `TransitionBatch`) are visible to
+    /// the `POST /resume` handler's `consume` call.  Using an independent
+    /// in-memory store on a durable backend silently breaks the round-trip:
+    /// the engine writes to the pool; the producer reads from a different empty store.
+    resume_token_store: Arc<dyn nebula_storage_port::store::ResumeTokenStore>,
 }
 
 /// Build the execution-store bundle for the configured backend.
@@ -275,6 +281,9 @@ fn build_memory_execution_stores() -> Result<ExecutionStoreBundle, TransportInit
     // control queue and journal — `new(&exec_store)` must be called BEFORE
     // `Arc::new(exec_store)` moves ownership.
     let trigger_dedup_inbox = InMemoryTriggerDedupInbox::new(&exec_store);
+    // Resume-token store shares the same SharedState as the exec_store so that
+    // tokens committed via TransitionBatch are visible to the POST /resume handler.
+    let resume_token_store = exec_store.resume_token_store();
     let node_results = InMemoryNodeResultStore::new();
     let workflow_versions = InMemoryWorkflowVersionStore::new();
     let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
@@ -291,6 +300,7 @@ fn build_memory_execution_stores() -> Result<ExecutionStoreBundle, TransportInit
         journal_reader: Arc::new(journal),
         control_queue: Arc::new(control_queue),
         trigger_dedup_inbox: Some(Arc::new(trigger_dedup_inbox)),
+        resume_token_store: Arc::new(resume_token_store),
     })
 }
 
@@ -306,8 +316,8 @@ async fn build_sqlite_execution_stores(
 ) -> Result<ExecutionStoreBundle, TransportInitError> {
     use nebula_storage::InMemoryNodeResultStore;
     use nebula_storage::sqlite::{
-        SqliteControlQueue, SqliteExecutionStore, SqliteJournalReader, SqliteTriggerDedupInbox,
-        SqliteWorkflowStore, SqliteWorkflowVersionStore, init_schema,
+        SqliteControlQueue, SqliteExecutionStore, SqliteJournalReader, SqliteResumeTokenStore,
+        SqliteTriggerDedupInbox, SqliteWorkflowStore, SqliteWorkflowVersionStore, init_schema,
     };
     use sqlx::sqlite::{
         SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
@@ -363,7 +373,10 @@ async fn build_sqlite_execution_stores(
         // Without this `Some`, the `if let Some(dedup)` guard in prepare_state is never
         // taken and webhook rows are spawned without the durable dedup fence — exactly
         // backwards for a durable backend.
-        trigger_dedup_inbox: Some(Arc::new(SqliteTriggerDedupInbox::new(pool))),
+        trigger_dedup_inbox: Some(Arc::new(SqliteTriggerDedupInbox::new(pool.clone()))),
+        // Same pool as the execution store: tokens minted by TransitionBatch must be
+        // readable by the POST /resume handler's consume call on the same pool.
+        resume_token_store: Arc::new(SqliteResumeTokenStore::new(pool)),
     })
 }
 
@@ -375,8 +388,8 @@ async fn build_pg_execution_stores(
 ) -> Result<ExecutionStoreBundle, TransportInitError> {
     use nebula_storage::InMemoryNodeResultStore;
     use nebula_storage::postgres::{
-        PgControlQueue, PgExecutionStore, PgJournalReader, PgTriggerDedupInbox, PgWorkflowStore,
-        PgWorkflowVersionStore, init_schema as pg_init_schema,
+        PgControlQueue, PgExecutionStore, PgJournalReader, PgResumeTokenStore, PgTriggerDedupInbox,
+        PgWorkflowStore, PgWorkflowVersionStore, init_schema as pg_init_schema,
     };
     use sqlx::postgres::PgPoolOptions;
 
@@ -421,7 +434,9 @@ async fn build_pg_execution_stores(
         control_queue: Arc::new(PgControlQueue::new(pool.clone())),
         // Same rationale as the SQLite arm: durable dispatch in
         // `WebhookIngressTransport::prepare_state` is only installed when `Some`.
-        trigger_dedup_inbox: Some(Arc::new(PgTriggerDedupInbox::new(pool))),
+        trigger_dedup_inbox: Some(Arc::new(PgTriggerDedupInbox::new(pool.clone()))),
+        // Same pool as the execution store — see SQLite arm for rationale.
+        resume_token_store: Arc::new(PgResumeTokenStore::new(pool)),
     })
 }
 
@@ -667,6 +682,7 @@ pub(crate) fn default_state(
         journal_reader,
         control_queue,
         trigger_dedup_inbox,
+        resume_token_store,
     } = execution_bundle;
 
     let mut state = AppState::new(
@@ -695,16 +711,15 @@ pub(crate) fn default_state(
 
     // W-S3d: wire the resume-token store and rate-limiter components.
     //
-    // `standalone()` provides a self-contained in-memory store for the
-    // Memory backend.  The SQLite and Postgres backends add real
-    // implementations in their respective `init_schema` / pool paths;
-    // until those are wired the standalone store serves as a safe
-    // dev-mode default (tokens are process-local, lost on restart —
-    // acceptable for the non-durable execution backend).
+    // The store is taken from `execution_bundle` — constructed from the same backend
+    // pool (SQLite/Postgres) or shared in-memory state (Memory) as the execution store.
+    // This ensures tokens minted by the engine's TransitionBatch on the durable pool
+    // are readable by this process's POST /resume handler.  A standalone in-memory store
+    // here would be a silent breakage: the engine writes to the pool, the handler reads
+    // from an empty process-local store, and every valid resume 404s.
     //
-    // `SystemClock` is the production clock; tests inject a `MockClock`
-    // at the handler-components level via `with_resume_handler_components`.
-    let resume_token_store = Arc::new(nebula_storage::InMemoryResumeTokenStore::standalone());
+    // `SystemClock` is the production clock; tests inject a `MockClock` via
+    // `with_resume_handler_components`.
     let resume_components =
         nebula_api::transport::webhook::ResumeHandlerComponents::with_defaults();
     state = state

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -693,6 +693,24 @@ pub(crate) fn default_state(
         state = state.with_trigger_dedup_inbox(inbox);
     }
 
+    // W-S3d: wire the resume-token store and rate-limiter components.
+    //
+    // `standalone()` provides a self-contained in-memory store for the
+    // Memory backend.  The SQLite and Postgres backends add real
+    // implementations in their respective `init_schema` / pool paths;
+    // until those are wired the standalone store serves as a safe
+    // dev-mode default (tokens are process-local, lost on restart —
+    // acceptable for the non-durable execution backend).
+    //
+    // `SystemClock` is the production clock; tests inject a `MockClock`
+    // at the handler-components level via `with_resume_handler_components`.
+    let resume_token_store = Arc::new(nebula_storage::InMemoryResumeTokenStore::standalone());
+    let resume_components =
+        nebula_api::transport::webhook::ResumeHandlerComponents::with_defaults();
+    state = state
+        .with_resume_token_store(resume_token_store)
+        .with_resume_handler_components(resume_components);
+
     Ok(state)
 }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -169,6 +169,11 @@ wiremock = { workspace = true }
 # Dev-only: `tests/wiremock_smoke.rs` — HTTP client + mock server (no full `App` required).
 reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }
 serde_json = { workspace = true }
+# Dev-only: SQLite round-trip test (test 15) needs a pool directly.
+# The `sqlite` feature is already transitively compiled via `nebula-storage/sqlite`;
+# the explicit dev-dep makes `sqlx::sqlite::SqlitePoolOptions` and `sqlx::query`
+# directly nameable in test code.
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 
 [features]
 default = []

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -137,8 +137,8 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // W-S3d: `POST /resume` — attacker-reachable wait-state surface.
     // Mounted BEFORE tenancy middleware (no TenantContext extractor);
     // scope is derived from the consumed token row, not the request.
-    // Uses `AppState` as router state so it can access `resume_token_store`
-    // and `resume_handler_components`.
+    // Uses `AppState` as router state so it can access `resume_producer`
+    // (the atomic consume+enqueue seam) and `resume_handler_components`.
     //
     // `DefaultBodyLimit::max` is applied as a tower layer on this sub-router so
     // axum enforces the cap BEFORE buffering the body — preventing a large-body DoS

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -24,7 +24,7 @@ use crate::{
         security_headers::security_headers_middleware,
     },
     state::AppState,
-    transport::webhook::resume::resume_handler,
+    transport::webhook::resume::{RESUME_BODY_LIMIT_BYTES, resume_handler},
 };
 
 /// Build the main application router with middleware
@@ -139,9 +139,18 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // scope is derived from the consumed token row, not the request.
     // Uses `AppState` as router state so it can access `resume_token_store`
     // and `resume_handler_components`.
+    //
+    // `DefaultBodyLimit::max` is applied as a tower layer on this sub-router so
+    // axum enforces the cap BEFORE buffering the body — preventing a large-body DoS
+    // from reaching the handler.  The handler also checks the cap after buffering
+    // (defense-in-depth for test paths that bypass the layer).
     let routes = routes.merge(
         Router::new()
-            .route("/resume", axum::routing::post(resume_handler))
+            .route(
+                "/resume",
+                axum::routing::post(resume_handler)
+                    .layer(DefaultBodyLimit::max(RESUME_BODY_LIMIT_BYTES)),
+            )
             .with_state(state.clone()),
     );
 

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -24,6 +24,7 @@ use crate::{
         security_headers::security_headers_middleware,
     },
     state::AppState,
+    transport::webhook::resume::resume_handler,
 };
 
 /// Build the main application router with middleware
@@ -132,6 +133,17 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
         Some(transport) => api_routes.merge(transport.router()),
         None => api_routes,
     };
+
+    // W-S3d: `POST /resume` — attacker-reachable wait-state surface.
+    // Mounted BEFORE tenancy middleware (no TenantContext extractor);
+    // scope is derived from the consumed token row, not the request.
+    // Uses `AppState` as router state so it can access `resume_token_store`
+    // and `resume_handler_components`.
+    let routes = routes.merge(
+        Router::new()
+            .route("/resume", axum::routing::post(resume_handler))
+            .with_state(state.clone()),
+    );
 
     // Internal routes (webhook activation — E3): /internal/v1/...
     // Mounted on the plain axum `Router` so they never appear in

--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -338,7 +338,7 @@ pub async fn with_memory_store_parts(
 }
 
 /// Build a [`CredentialService`] over an in-memory store but with an **external
-/// [`StateSource`]** backed by `provider`, whose resolution bridge (ADR-0051) is
+/// `StateSource`** backed by `provider`, whose resolution bridge (ADR-0051) is
 /// not yet wired — every resolution path then fails closed with
 /// `ExternalSourceNotWired`. The test fixture for the wrong-source guard.
 ///

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -485,6 +485,23 @@ pub struct AppState {
     /// Set via [`AppState::with_resume_token_store`].
     pub resume_token_store: Option<Arc<dyn nebula_storage_port::store::ResumeTokenStore>>,
 
+    /// Resume producer for the W-S3d webhook→Resume path (`POST /resume`).
+    ///
+    /// `peek` is a read-only lookup (reject wrong-kind / expired tokens, surface
+    /// storage faults as `503`); `consume_and_enqueue_resume` burns the token
+    /// and enqueues the `Resume` in ONE transaction, closing the consume-then-
+    /// enqueue durability gap (a failed enqueue rolls back, leaving the token
+    /// live for retry).
+    ///
+    /// Like `resume_token_store`, this is the **undecorated** (global) store —
+    /// the lookup is hash-keyed with no tenant parameter; scope is read FROM the
+    /// row (confused-deputy boundary = the absence of any tenant extractor on
+    /// the resume handler).
+    ///
+    /// When `None`, `POST /resume` returns `503 Service Unavailable`.
+    /// Set via [`AppState::with_resume_producer`].
+    pub resume_producer: Option<Arc<dyn nebula_storage_port::store::ResumeProducer>>,
+
     /// Rate limiters + clock for the W-S3d `POST /resume` handler.
     ///
     /// Bundled as [`crate::transport::webhook::resume::ResumeHandlerComponents`]
@@ -558,6 +575,7 @@ impl AppState {
             resource_registrars: None,
             resource_status: None,
             resume_token_store: None,
+            resume_producer: None,
             resume_handler_components: None,
         }
     }
@@ -959,58 +977,6 @@ impl AppState {
             use nebula_storage_port::StorageError;
             let unavailable = matches!(e, StorageError::Internal(_) | StorageError::Connection(_));
             to_api_err(unavailable, e.to_string())
-        })
-    }
-
-    /// Enqueue a targeted `ControlCommand::Resume` derived from a
-    /// `ResumeTokenRow` (W-S3d).
-    ///
-    /// Scope-from-row: the enqueued message is stamped with `row.scope` via
-    /// a freshly-bound `ScopedControlQueue`.  The caller MUST NOT supply a
-    /// request-derived scope — the only accepted source is the consumed row.
-    ///
-    /// `w3c_traceparent` carries the inbound W3C trace context so the engine's
-    /// downstream span can be linked to the caller's distributed trace.  Pass
-    /// `None` when the request carried no valid `traceparent` header.
-    ///
-    /// Rationale for a separate method (not reusing `enqueue_control_scoped`):
-    /// `enqueue_control_scoped` hard-codes `resume_target: None` and is typed
-    /// around `ExecutionId`; this method carries the `ResumeTarget` and uses
-    /// the row's string execution id, keeping the two paths structurally
-    /// distinct.
-    pub(crate) async fn enqueue_resume_from_row(
-        &self,
-        row: &nebula_storage_port::dto::resume_token::ResumeTokenRow,
-        target: nebula_storage_port::dto::ResumeTarget,
-        w3c_traceparent: Option<String>,
-    ) -> Result<(), ApiError> {
-        let queue = ScopedControlQueue::new(Arc::clone(&self.control_queue), row.scope.clone());
-        let msg = nebula_storage_port::dto::ControlMsg {
-            id: *uuid::Uuid::new_v4().as_bytes(),
-            execution_id: row.execution_id.clone(),
-            command: nebula_storage_port::dto::ControlCommand::Resume,
-            scope: row.scope.clone(),
-            w3c_traceparent,
-            reclaim_count: 0,
-            resume_target: Some(target),
-        };
-        queue.enqueue(&msg).await.map_err(|e| {
-            use nebula_storage_port::StorageError;
-            // Infrastructure faults → 503 (transient; caller should retry);
-            // other write failures → 500 (logic or schema bug).
-            match e {
-                StorageError::Internal(_) | StorageError::Connection(_) => {
-                    ApiError::ServiceUnavailable(format!(
-                        "control-queue backend unavailable while enqueuing Resume \
-                         for execution {}: {e}",
-                        row.execution_id
-                    ))
-                },
-                other => ApiError::Internal(format!(
-                    "failed to enqueue Resume for execution {}: {other}",
-                    row.execution_id
-                )),
-            }
         })
     }
 
@@ -1451,6 +1417,22 @@ impl AppState {
         store: Arc<dyn nebula_storage_port::store::ResumeTokenStore>,
     ) -> Self {
         self.resume_token_store = Some(store);
+        self
+    }
+
+    /// Attach the resume producer for the W-S3d webhook→Resume path
+    /// (`POST /resume`) — the atomic consume+enqueue seam (ADR-0099 Option B1).
+    ///
+    /// Must be the **undecorated** (global) producer backed by the SAME pool /
+    /// shared state as the execution store and control queue, so the token
+    /// DELETE and the `Resume` INSERT commit in one transaction. When `None`,
+    /// `POST /resume` returns `503 Service Unavailable`.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_resume_producer(
+        mut self,
+        producer: Arc<dyn nebula_storage_port::store::ResumeProducer>,
+    ) -> Self {
+        self.resume_producer = Some(producer);
         self
     }
 

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -469,6 +469,33 @@ pub struct AppState {
     /// production from the same `nebula_resource::Manager` the engine is
     /// built with.
     pub resource_status: Option<Arc<dyn nebula_engine::EngineResourceStatus>>,
+
+    /// Resume-token store for the W-S3d webhook→Resume producer
+    /// (`POST /resume`).
+    ///
+    /// The **undecorated** (global) store — `consume` is a hash-keyed
+    /// atomic delete with no tenant parameter; scope is read FROM the
+    /// returned row (confused-deputy boundary is the absence of any
+    /// tenant extractor on the resume handler).  Setting a
+    /// `ScopedResumeTokenStore` here would be incorrect: the decorator
+    /// adds per-scope filtering that the consume primitive intentionally
+    /// lacks (`ResumeTokenStore` doc: "no `scope` parameter by design").
+    ///
+    /// When `None`, `POST /resume` returns `503 Service Unavailable`.
+    /// Set via [`AppState::with_resume_token_store`].
+    pub resume_token_store: Option<Arc<dyn nebula_storage_port::store::ResumeTokenStore>>,
+
+    /// Rate limiters + clock for the W-S3d `POST /resume` handler.
+    ///
+    /// Bundled as [`crate::transport::webhook::resume::ResumeHandlerComponents`]
+    /// so the three `WebhookRateLimiter` instances (IP / global / tenant)
+    /// and the injectable clock are wired at the composition root rather
+    /// than constructed per-request.  When `None`, `POST /resume` returns
+    /// `503 Service Unavailable` (same fail-closed convention as
+    /// `resume_token_store`).  Set via
+    /// [`AppState::with_resume_handler_components`].
+    pub resume_handler_components:
+        Option<crate::transport::webhook::resume::ResumeHandlerComponents>,
 }
 
 impl AppState {
@@ -530,6 +557,8 @@ impl AppState {
             resource_repo: None,
             resource_registrars: None,
             resource_status: None,
+            resume_token_store: None,
+            resume_handler_components: None,
         }
     }
 
@@ -922,13 +951,61 @@ impl AppState {
             scope: scope.clone(),
             w3c_traceparent: w3c.as_ref().map(|c| c.traceparent().to_owned()),
             reclaim_count: 0,
-            // No targeted-Resume producer yet (W-S3d); enqueue untargeted.
+            // Untargeted Resume — the W-S3d targeted producer uses
+            // `enqueue_resume_from_row` instead.
             resume_target: None,
         };
         queue.enqueue(&msg).await.map_err(|e| {
             use nebula_storage_port::StorageError;
             let unavailable = matches!(e, StorageError::Internal(_) | StorageError::Connection(_));
             to_api_err(unavailable, e.to_string())
+        })
+    }
+
+    /// Enqueue a targeted `ControlCommand::Resume` derived from a
+    /// `ResumeTokenRow` (W-S3d).
+    ///
+    /// Scope-from-row: the enqueued message is stamped with `row.scope` via
+    /// a freshly-bound `ScopedControlQueue`.  The caller MUST NOT supply a
+    /// request-derived scope — the only accepted source is the consumed row.
+    ///
+    /// Rationale for a separate method (not reusing `enqueue_control_scoped`):
+    /// `enqueue_control_scoped` hard-codes `resume_target: None` and is typed
+    /// around `ExecutionId`; this method carries the `ResumeTarget` and uses
+    /// the row's string execution id, keeping the two paths structurally
+    /// distinct.
+    pub(crate) async fn enqueue_resume_from_row(
+        &self,
+        row: &nebula_storage_port::dto::resume_token::ResumeTokenRow,
+        target: nebula_storage_port::dto::ResumeTarget,
+    ) -> Result<(), ApiError> {
+        let queue = ScopedControlQueue::new(Arc::clone(&self.control_queue), row.scope.clone());
+        let msg = nebula_storage_port::dto::ControlMsg {
+            id: *uuid::Uuid::new_v4().as_bytes(),
+            execution_id: row.execution_id.clone(),
+            command: nebula_storage_port::dto::ControlCommand::Resume,
+            scope: row.scope.clone(),
+            w3c_traceparent: None,
+            reclaim_count: 0,
+            resume_target: Some(target),
+        };
+        queue.enqueue(&msg).await.map_err(|e| {
+            use nebula_storage_port::StorageError;
+            // Infrastructure faults → 503 (transient; caller should retry);
+            // other write failures → 500 (logic or schema bug).
+            match e {
+                StorageError::Internal(_) | StorageError::Connection(_) => {
+                    ApiError::ServiceUnavailable(format!(
+                        "control-queue backend unavailable while enqueuing Resume \
+                         for execution {}: {e}",
+                        row.execution_id
+                    ))
+                },
+                other => ApiError::Internal(format!(
+                    "failed to enqueue Resume for execution {}: {other}",
+                    row.execution_id
+                )),
+            }
         })
     }
 
@@ -1354,6 +1431,34 @@ impl AppState {
         status: Arc<dyn nebula_engine::EngineResourceStatus>,
     ) -> Self {
         self.resource_status = Some(status);
+        self
+    }
+
+    /// Attach the resume-token store for the W-S3d webhook→Resume
+    /// producer (`POST /resume`).
+    ///
+    /// Must be the **undecorated** (global) store — consume is
+    /// hash-keyed with no tenant parameter; scope comes FROM the row.
+    /// When `None`, `POST /resume` returns `503 Service Unavailable`.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_resume_token_store(
+        mut self,
+        store: Arc<dyn nebula_storage_port::store::ResumeTokenStore>,
+    ) -> Self {
+        self.resume_token_store = Some(store);
+        self
+    }
+
+    /// Attach rate-limiters + clock for the W-S3d `POST /resume` handler.
+    ///
+    /// When `None`, `POST /resume` returns `503 Service Unavailable`.
+    /// Wire at the composition root alongside `with_resume_token_store`.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_resume_handler_components(
+        mut self,
+        components: crate::transport::webhook::resume::ResumeHandlerComponents,
+    ) -> Self {
+        self.resume_handler_components = Some(components);
         self
     }
 }

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -969,8 +969,9 @@ impl AppState {
             scope: scope.clone(),
             w3c_traceparent: w3c.as_ref().map(|c| c.traceparent().to_owned()),
             reclaim_count: 0,
-            // Untargeted Resume — the W-S3d targeted producer uses
-            // `enqueue_resume_from_row` instead.
+            // Untargeted Resume — the W-S3d targeted `/resume` producer builds
+            // its own targeted `ControlMsg` via
+            // `ResumeProducer::consume_and_enqueue_resume` instead.
             resume_target: None,
         };
         queue.enqueue(&msg).await.map_err(|e| {

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -969,6 +969,10 @@ impl AppState {
     /// a freshly-bound `ScopedControlQueue`.  The caller MUST NOT supply a
     /// request-derived scope — the only accepted source is the consumed row.
     ///
+    /// `w3c_traceparent` carries the inbound W3C trace context so the engine's
+    /// downstream span can be linked to the caller's distributed trace.  Pass
+    /// `None` when the request carried no valid `traceparent` header.
+    ///
     /// Rationale for a separate method (not reusing `enqueue_control_scoped`):
     /// `enqueue_control_scoped` hard-codes `resume_target: None` and is typed
     /// around `ExecutionId`; this method carries the `ResumeTarget` and uses
@@ -978,6 +982,7 @@ impl AppState {
         &self,
         row: &nebula_storage_port::dto::resume_token::ResumeTokenRow,
         target: nebula_storage_port::dto::ResumeTarget,
+        w3c_traceparent: Option<String>,
     ) -> Result<(), ApiError> {
         let queue = ScopedControlQueue::new(Arc::clone(&self.control_queue), row.scope.clone());
         let msg = nebula_storage_port::dto::ControlMsg {
@@ -985,7 +990,7 @@ impl AppState {
             execution_id: row.execution_id.clone(),
             command: nebula_storage_port::dto::ControlCommand::Resume,
             scope: row.scope.clone(),
-            w3c_traceparent: None,
+            w3c_traceparent,
             reclaim_count: 0,
             resume_target: Some(target),
         };

--- a/crates/api/src/transport/webhook/mod.rs
+++ b/crates/api/src/transport/webhook/mod.rs
@@ -32,6 +32,7 @@ pub mod key;
 pub mod provider;
 pub mod ratelimit;
 pub(super) mod replay;
+pub(crate) mod resume;
 pub(crate) mod routing;
 pub mod secret_resolver;
 pub(super) mod signature;
@@ -47,6 +48,7 @@ pub use events::{TriggerLifecycleBus, TriggerLifecycleEvent, TriggerLifecycleEve
 pub use key::WebhookKey;
 pub use provider::EndpointProviderImpl;
 pub use ratelimit::{RateLimitExceeded, WebhookRateLimiter};
+pub use resume::ResumeHandlerComponents;
 pub use secret_resolver::{CredentialBackedWebhookSecretResolver, mint_whsec};
 pub use spec_lookup::TriggerStoreSpecLookup;
 pub use transport::{

--- a/crates/api/src/transport/webhook/resume.rs
+++ b/crates/api/src/transport/webhook/resume.rs
@@ -1,0 +1,380 @@
+//! W-S3d — Webhook-callback resume producer.
+//!
+//! `POST /resume` is the ONLY attacker-reachable wait-state surface.
+//! Design invariants (all enforced structurally, not by discipline):
+//!
+//! - **Scope-from-row**: no `TenantContext` extractor; the only scope in
+//!   the enqueued `ControlMsg` is `row.scope`, read from the consumed
+//!   token row.  A reviewer verifies by the ABSENCE of a tenant extractor.
+//! - **Body inert**: the request body is capped and discarded; no field
+//!   from it ever reaches the `ControlMsg`.
+//! - **Uniform 404**: absent / expired / consumed / forged / wrong-kind →
+//!   all return the byte-identical `ApiError::NotFound` ProblemDetails.
+//!   No 401, no 410, no existence-revealing messages.
+//! - **No bearer in logs/traces**: the bearer is hashed and dropped;
+//!   only `execution_id`, `scope`, and `wait_kind` are logged on success.
+//!
+//! ## Pipeline order (mirrors `dispatch_inner` ordering in `dispatch.rs`)
+//!
+//! 1. Body cap → 413
+//! 2. Extract bearer from `Authorization: Bearer <token>` → uniform 404 on
+//!    missing/wrong-scheme/empty (NOT 401 — do not reveal auth was attempted)
+//! 3. Per-IP rate-limit → 429 + `Retry-After` (BEFORE any store hit)
+//! 4. Global rate-limit → 429 (BEFORE any store hit)
+//! 5. Hash bearer; `store.consume(hash)`:
+//!    - `Err` → 503 + `Retry-After` (token unconsumed; abuse-case 15)
+//!    - `Ok(None)` → uniform 404
+//!    - `Ok(Some(row))` → continue
+//! 6. Per-tenant rate-limit (key = `row.scope.credential_owner_id()`) → 429;
+//!    token is already burned (accepted, documented)
+//! 7. Kind-match: `Webhook` → `ResumeTarget::Webhook{callback_id}`; `_` → 404
+//! 8. Expiry check via injectable clock; expired or malformed → 404, no enqueue
+//! 9. Enqueue `ControlCommand::Resume` via `enqueue_resume_from_row` → 202 / 503
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use nebula_action::Clock;
+use nebula_storage_port::dto::ResumeTarget;
+use nebula_storage_port::dto::resume_token::{ResumeTokenWaitKind, TokenHash};
+use tracing::{debug, warn};
+
+use super::ratelimit::WebhookRateLimiter;
+use super::token::token_hash;
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Small body cap for `POST /resume`.
+///
+/// v1 has no meaningful request body — the resume intent is fully carried
+/// by the bearer token.  Any body beyond this limit is rejected 413; the
+/// cap prevents a large body from consuming read buffers.
+const RESUME_BODY_LIMIT_BYTES: usize = 4 * 1024; // 4 KiB
+
+/// Rate-limit defaults for the three `POST /resume` tiers.
+///
+/// Kept conservative relative to the webhook ingress defaults because
+/// `/resume` tokens are per-execution (scarce) while webhook keys are
+/// per-trigger (potentially high-fan-out).
+const DEFAULT_RESUME_IP_RPM: u64 = 60;
+const DEFAULT_RESUME_GLOBAL_RPM: u64 = 600;
+const DEFAULT_RESUME_TENANT_RPM: u64 = 120;
+
+/// Fixed key for the global (IP-agnostic) rate-limit bucket.
+const RESUME_GLOBAL_RL_KEY: &str = "resume:global";
+
+/// Shared components for the `POST /resume` handler.
+///
+/// Cloned cheaply (all internals behind `Arc`) and stored in the axum
+/// `Router` state.
+#[derive(Clone)]
+pub struct ResumeHandlerComponents {
+    /// Per-IP rate limiter — keyed on client IP.  Checked BEFORE any
+    /// store hit (step 3).
+    pub ip_rate_limiter: WebhookRateLimiter,
+    /// Global backstop rate limiter — keyed on the fixed
+    /// `RESUME_GLOBAL_RL_KEY` constant.  IP-trust-independent
+    /// anti-enumeration backstop (step 4).
+    pub global_rate_limiter: WebhookRateLimiter,
+    /// Per-tenant rate limiter — keyed on `Scope::credential_owner_id()`,
+    /// checked post-consume (step 6).  Token is already burned at this
+    /// point; see W-S3d spec note.
+    pub tenant_rate_limiter: WebhookRateLimiter,
+    /// Injectable clock — used for expiry comparison (step 8).
+    pub clock: Arc<dyn Clock>,
+}
+
+impl std::fmt::Debug for ResumeHandlerComponents {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResumeHandlerComponents")
+            .field("ip_rate_limiter", &self.ip_rate_limiter)
+            .field("global_rate_limiter", &self.global_rate_limiter)
+            .field("tenant_rate_limiter", &self.tenant_rate_limiter)
+            .field("clock", &"Arc<dyn Clock>")
+            .finish()
+    }
+}
+
+impl ResumeHandlerComponents {
+    /// Construct with default RPM settings and a [`nebula_action::SystemClock`].
+    ///
+    /// Use this at production composition roots.  For tests inject a
+    /// [`nebula_action::MockClock`] via [`Self::with_clock`].
+    #[must_use]
+    pub fn with_defaults() -> Self {
+        Self {
+            ip_rate_limiter: WebhookRateLimiter::new(DEFAULT_RESUME_IP_RPM),
+            global_rate_limiter: WebhookRateLimiter::new(DEFAULT_RESUME_GLOBAL_RPM),
+            tenant_rate_limiter: WebhookRateLimiter::new(DEFAULT_RESUME_TENANT_RPM),
+            clock: Arc::new(nebula_action::SystemClock::new()),
+        }
+    }
+
+    /// Override the clock with a test-injectable implementation.
+    ///
+    /// Intended for tests that must control expiry comparison.
+    #[must_use]
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+}
+
+/// Axum handler for `POST /resume`.
+///
+/// See module-level doc for the full pipeline order.
+///
+/// # Security notes
+///
+/// - No tenant extractor — scope comes from the consumed row only.
+/// - Bearer token is hashed immediately; the plaintext never escapes this fn.
+/// - All failure paths that could reveal token existence produce uniform 404.
+pub(crate) async fn resume_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    // Components are None-gated at the call site (router mounting); by the
+    // time this handler runs they are always Some.  The absence is a
+    // composition-root bug surfaced at startup, not a per-request concern.
+    let Some(components) = state.resume_handler_components.as_ref() else {
+        warn!("resume_handler called without ResumeHandlerComponents wired — composition-root bug");
+        return (StatusCode::SERVICE_UNAVAILABLE, "").into_response();
+    };
+    let Some(token_store) = state.resume_token_store.as_ref() else {
+        warn!("resume_handler called without resume_token_store wired — composition-root bug");
+        return (StatusCode::SERVICE_UNAVAILABLE, "").into_response();
+    };
+
+    // Step 1 — body cap.
+    if body.len() > RESUME_BODY_LIMIT_BYTES {
+        debug!(
+            size = body.len(),
+            cap = RESUME_BODY_LIMIT_BYTES,
+            "resume: body exceeds cap"
+        );
+        return (StatusCode::PAYLOAD_TOO_LARGE, "").into_response();
+    }
+    // Body is dropped; it never reaches downstream logic.
+    drop(body);
+
+    // Step 2 — extract bearer from `Authorization: Bearer <token>`.
+    // Missing header, wrong scheme, or empty token → uniform 404.
+    // NOT 401 — do not reveal that authentication was even attempted.
+    let bearer_token = match extract_bearer(&headers) {
+        Some(t) => t,
+        None => return uniform_not_found(),
+    };
+
+    // Step 3 — per-IP rate-limit BEFORE any store hit.
+    let client_ip = peer_addr.ip().to_string();
+    if let Err(exceeded) = components.ip_rate_limiter.check(&client_ip).await {
+        debug!(
+            ip = %client_ip,
+            retry_after = exceeded.retry_after_secs,
+            "resume: per-IP rate limit exceeded"
+        );
+        return rate_limit_429(exceeded.retry_after_secs);
+    }
+
+    // Step 4 — global rate-limit BEFORE any store hit.
+    if let Err(exceeded) = components
+        .global_rate_limiter
+        .check(RESUME_GLOBAL_RL_KEY)
+        .await
+    {
+        debug!(
+            retry_after = exceeded.retry_after_secs,
+            "resume: global rate limit exceeded"
+        );
+        return rate_limit_429(exceeded.retry_after_secs);
+    }
+
+    // Step 5 — hash and consume.
+    // bearer_token / hash deliberately excluded from all log fields.
+    let raw_hash = token_hash(&bearer_token);
+    // bearer_token is dropped here — never logged or stored past this point.
+    drop(bearer_token);
+
+    // SHA-256 always produces exactly 32 bytes; the `Err` arm is an
+    // implementation-bug guard that can never fire in practice.
+    let Ok(token_hash_value) = TokenHash::try_from_bytes(raw_hash.to_vec()) else {
+        warn!("resume: SHA-256 produced unexpected hash length — implementation bug");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "").into_response();
+    };
+
+    let consumed_row = match token_store.consume(&token_hash_value).await {
+        // Storage error → 503 so the caller can retry; the token is
+        // unconsumed on a transient storage fault (abuse-case 15).
+        Err(storage_err) => {
+            warn!(
+                error = %storage_err,
+                "resume: storage error on consume — returning 503 (token unconsumed)"
+            );
+            return service_unavailable_with_retry_after();
+        },
+        // Absent, forged, or already-consumed → uniform 404.
+        Ok(None) => return uniform_not_found(),
+        Ok(Some(row)) => row,
+    };
+
+    // Step 6 — per-tenant rate-limit (post-consume; token already burned).
+    let tenant_key = consumed_row.scope.credential_owner_id();
+    if let Err(exceeded) = components.tenant_rate_limiter.check(&tenant_key).await {
+        debug!(
+            tenant_id = %tenant_key,
+            retry_after = exceeded.retry_after_secs,
+            "resume: per-tenant rate limit exceeded (token consumed)"
+        );
+        return rate_limit_429(exceeded.retry_after_secs);
+    }
+
+    // Step 7 — kind-match (fail-closed).
+    // `ResumeTokenWaitKind` is `#[non_exhaustive]`; equality to `Webhook` is
+    // the only admissible kind at this endpoint.  All other variants — Approval,
+    // and any future variant added to the non-exhaustive enum without recompiling
+    // this crate — fall to the `else` branch and return a uniform 404.
+    let resume_target = if consumed_row.wait_kind == ResumeTokenWaitKind::Webhook {
+        ResumeTarget::Webhook {
+            callback_id: consumed_row.callback_label.clone(),
+        }
+    } else {
+        debug!(
+            execution_id = %consumed_row.execution_id,
+            wait_kind = ?consumed_row.wait_kind,
+            "resume: token wait_kind does not match Webhook; returning 404 (fail-closed)"
+        );
+        return uniform_not_found();
+    };
+
+    // Step 8 — expiry check via injectable clock (fail-closed on parse failure).
+    if let Some(expires_at_str) = consumed_row.expires_at.as_deref() {
+        if let Ok(expiry) = parse_rfc3339_as_system_time(expires_at_str) {
+            let now = components.clock.now();
+            if now >= expiry {
+                debug!(
+                    execution_id = %consumed_row.execution_id,
+                    expires_at = %expires_at_str,
+                    "resume: token expired (consumed, no enqueue)"
+                );
+                return uniform_not_found();
+            }
+        } else {
+            // Malformed RFC-3339 — fail-closed; token is already consumed.
+            warn!(
+                execution_id = %consumed_row.execution_id,
+                expires_at = %expires_at_str,
+                "resume: malformed expires_at — fail-closed (token consumed, no enqueue)"
+            );
+            return uniform_not_found();
+        }
+    }
+
+    // Step 9 — enqueue.
+    // Log only non-secret fields; bearer/hash never appear here.
+    debug!(
+        execution_id = %consumed_row.execution_id,
+        scope = ?consumed_row.scope,
+        wait_kind = "Webhook",
+        "resume: enqueuing ControlCommand::Resume"
+    );
+
+    match state
+        .enqueue_resume_from_row(&consumed_row, resume_target)
+        .await
+    {
+        Ok(()) => (StatusCode::ACCEPTED, "").into_response(),
+        Err(api_err) => {
+            warn!(
+                execution_id = %consumed_row.execution_id,
+                error = %api_err,
+                "resume: failed to enqueue ControlCommand::Resume"
+            );
+            match api_err {
+                ApiError::ServiceUnavailable(_) => service_unavailable_with_retry_after(),
+                _ => (StatusCode::INTERNAL_SERVER_ERROR, "").into_response(),
+            }
+        },
+    }
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Extract a bearer token from the `Authorization` header.
+///
+/// Returns `None` for:
+/// - Missing header
+/// - Any scheme other than `Bearer` (case-insensitive)
+/// - Empty token after stripping the scheme prefix
+fn extract_bearer(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get(axum::http::header::AUTHORIZATION)?;
+    let header_str = value.to_str().ok()?;
+    let token = header_str
+        .strip_prefix("Bearer ")
+        .or_else(|| header_str.strip_prefix("bearer "))
+        .unwrap_or_else(|| {
+            // Try case-insensitive split for other capitalizations.
+            let lower = header_str.to_ascii_lowercase();
+            if lower.starts_with("bearer ") {
+                &header_str[7..]
+            } else {
+                ""
+            }
+        });
+    if token.is_empty() {
+        return None;
+    }
+    Some(token.to_owned())
+}
+
+/// Parse an RFC-3339 timestamp string to `SystemTime`.
+///
+/// Returns `Err(())` on any parse failure — callers must fail-closed.
+fn parse_rfc3339_as_system_time(ts: &str) -> Result<std::time::SystemTime, ()> {
+    // Use `humantime` which is already in the workspace via nebula-core.
+    // Alternatively parse via chrono which is available workspace-wide.
+    // We use chrono::DateTime::parse_from_rfc3339 → convert to SystemTime.
+    use std::time::{Duration, UNIX_EPOCH};
+    let parsed = chrono::DateTime::parse_from_rfc3339(ts).map_err(|_| ())?;
+    let unix_secs = parsed.timestamp();
+    let unix_nanos = parsed.timestamp_subsec_nanos();
+    if unix_secs < 0 {
+        return Err(());
+    }
+    let duration = Duration::new(unix_secs as u64, unix_nanos);
+    Ok(UNIX_EPOCH + duration)
+}
+
+/// Uniform 404 response — byte-identical for all "not found" cases.
+/// Absent / expired / consumed / forged / wrong-kind all produce this.
+fn uniform_not_found() -> Response {
+    ApiError::NotFound("not found".to_string()).into_response()
+}
+
+/// 429 response with `Retry-After` header (seconds as string).
+fn rate_limit_429(retry_after_secs: u64) -> Response {
+    let mut response = ApiError::RateLimitExceeded.into_response();
+    if let Ok(value) = retry_after_secs.to_string().parse() {
+        response.headers_mut().insert("retry-after", value);
+    }
+    response
+}
+
+/// 503 response with a fixed 60-second `Retry-After` hint (storage fault).
+fn service_unavailable_with_retry_after() -> Response {
+    let mut response =
+        ApiError::ServiceUnavailable("resume token store unavailable; retry".to_string())
+            .into_response();
+    if let Ok(value) = "60".parse() {
+        response.headers_mut().insert("retry-after", value);
+    }
+    response
+}

--- a/crates/api/src/transport/webhook/resume.rs
+++ b/crates/api/src/transport/webhook/resume.rs
@@ -25,10 +25,12 @@
 //!    - `Err` → 503 + `Retry-After` (token unconsumed; abuse-case 15)
 //!    - `Ok(None)` → uniform 404
 //!    - `Ok(Some(row))` → continue
-//! 6. Per-tenant rate-limit (key = `row.scope.credential_owner_id()`) → 429;
+//! 6. Kind-match: `Webhook` → `ResumeTarget::Webhook{callback_id}`; `_` → 404
+//!    (before per-tenant RL: wrong-kind/expired tokens must not 429 on an exhausted tenant)
+//! 7. Expiry check via injectable clock; expired or malformed → 404, no enqueue
+//!    (before per-tenant RL: same oracle-avoidance rationale as step 6)
+//! 8. Per-tenant rate-limit (key = `row.scope.credential_owner_id()`) → 429;
 //!    token is already burned (accepted, documented)
-//! 7. Kind-match: `Webhook` → `ResumeTarget::Webhook{callback_id}`; `_` → 404
-//! 8. Expiry check via injectable clock; expired or malformed → 404, no enqueue
 //! 9. Enqueue `ControlCommand::Resume` via `enqueue_resume_from_row` → 202 / 503
 
 use std::net::SocketAddr;
@@ -36,7 +38,7 @@ use std::sync::Arc;
 
 use axum::{
     body::Bytes,
-    extract::{ConnectInfo, State},
+    extract::{ConnectInfo, Extension, State},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
@@ -48,14 +50,23 @@ use tracing::{debug, warn};
 use super::ratelimit::WebhookRateLimiter;
 use super::token::token_hash;
 use crate::error::ApiError;
+use crate::middleware::InboundW3cTraceContext;
 use crate::state::AppState;
 
 /// Small body cap for `POST /resume`.
 ///
-/// v1 has no meaningful request body — the resume intent is fully carried
-/// by the bearer token.  Any body beyond this limit is rejected 413; the
-/// cap prevents a large body from consuming read buffers.
-const RESUME_BODY_LIMIT_BYTES: usize = 4 * 1024; // 4 KiB
+/// v1 has no meaningful request body — the resume intent is fully carried by the
+/// bearer token.  Any body beyond this limit is rejected at two layers:
+///
+/// 1. The `axum::extract::DefaultBodyLimit::max` tower layer on the `/resume`
+///    sub-router (enforced by axum BEFORE the body is buffered — prevents
+///    large-body DoS from ever reaching the handler).
+/// 2. The in-handler `body.len() > RESUME_BODY_LIMIT_BYTES` check (defense-in-depth
+///    for callers that bypass the tower layer, e.g. `oneshot` tests that inject a
+///    pre-built `Bytes` directly).
+///
+/// `pub(crate)` so `app.rs` can reference it when installing the layer.
+pub(crate) const RESUME_BODY_LIMIT_BYTES: usize = 4 * 1024; // 4 KiB
 
 /// Rate-limit defaults for the three `POST /resume` tiers.
 ///
@@ -83,8 +94,8 @@ pub struct ResumeHandlerComponents {
     /// anti-enumeration backstop (step 4).
     pub global_rate_limiter: WebhookRateLimiter,
     /// Per-tenant rate limiter — keyed on `Scope::credential_owner_id()`,
-    /// checked post-consume (step 6).  Token is already burned at this
-    /// point; see W-S3d spec note.
+    /// checked post-consume after kind-match and expiry (step 8).  Token is
+    /// already burned at this point; see W-S3d spec note.
     pub tenant_rate_limiter: WebhookRateLimiter,
     /// Injectable clock — used for expiry comparison (step 8).
     pub clock: Arc<dyn Clock>,
@@ -136,9 +147,14 @@ impl ResumeHandlerComponents {
 /// - No tenant extractor — scope comes from the consumed row only.
 /// - Bearer token is hashed immediately; the plaintext never escapes this fn.
 /// - All failure paths that could reveal token existence produce uniform 404.
+/// - `traceparent` is forwarded to the `ControlMsg` for distributed trace
+///   continuity; the bearer token is NEVER included in trace fields.
 pub(crate) async fn resume_handler(
     State(state): State<AppState>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    // `Option<Extension<_>>` because `trace_context_middleware` may not be
+    // present in all test harnesses (oneshot without the full middleware stack).
+    w3c_trace: Option<Extension<InboundW3cTraceContext>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
@@ -226,22 +242,16 @@ pub(crate) async fn resume_handler(
         Ok(Some(row)) => row,
     };
 
-    // Step 6 — per-tenant rate-limit (post-consume; token already burned).
-    let tenant_key = consumed_row.scope.credential_owner_id();
-    if let Err(exceeded) = components.tenant_rate_limiter.check(&tenant_key).await {
-        debug!(
-            tenant_id = %tenant_key,
-            retry_after = exceeded.retry_after_secs,
-            "resume: per-tenant rate limit exceeded (token consumed)"
-        );
-        return rate_limit_429(exceeded.retry_after_secs);
-    }
-
-    // Step 7 — kind-match (fail-closed).
+    // Step 6 — kind-match (fail-closed, before per-tenant RL).
     // `ResumeTokenWaitKind` is `#[non_exhaustive]`; equality to `Webhook` is
     // the only admissible kind at this endpoint.  All other variants — Approval,
     // and any future variant added to the non-exhaustive enum without recompiling
     // this crate — fall to the `else` branch and return a uniform 404.
+    //
+    // Ordering invariant: kind-match fires BEFORE per-tenant rate-limit.  A wrong-kind
+    // or expired token on an exhausted tenant must return 404, not 429 — returning 429
+    // would reveal that the token was structurally valid (existence oracle) and would
+    // inconsistently 429 on tokens the tenant cannot resume.
     let resume_target = if consumed_row.wait_kind == ResumeTokenWaitKind::Webhook {
         ResumeTarget::Webhook {
             callback_id: consumed_row.callback_label.clone(),
@@ -255,7 +265,8 @@ pub(crate) async fn resume_handler(
         return uniform_not_found();
     };
 
-    // Step 8 — expiry check via injectable clock (fail-closed on parse failure).
+    // Step 7 — expiry check via injectable clock (fail-closed on parse failure).
+    // Fires BEFORE per-tenant RL for the same oracle-avoidance reason as step 6.
     if let Some(expires_at_str) = consumed_row.expires_at.as_deref() {
         if let Ok(expiry) = parse_rfc3339_as_system_time(expires_at_str) {
             let now = components.clock.now();
@@ -278,17 +289,38 @@ pub(crate) async fn resume_handler(
         }
     }
 
-    // Step 9 — enqueue.
+    // Step 8 — per-tenant rate-limit (post-consume, post-kind-match, post-expiry).
+    // Token is already burned at this point; see W-S3d spec note for why this is
+    // accepted behavior (the alternative — pre-consume per-tenant RL — requires a
+    // tenant lookup before the consume atomic, adding a second DB round-trip and a
+    // TOCTOU window).
+    let tenant_key = consumed_row.scope.credential_owner_id();
+    if let Err(exceeded) = components.tenant_rate_limiter.check(&tenant_key).await {
+        debug!(
+            tenant_id = %tenant_key,
+            retry_after = exceeded.retry_after_secs,
+            "resume: per-tenant rate limit exceeded (token consumed)"
+        );
+        return rate_limit_429(exceeded.retry_after_secs);
+    }
+
+    // Step 9 — enqueue (ControlCommand::Resume via scoped queue).
     // Log only non-secret fields; bearer/hash never appear here.
+    //
+    // Extract the inbound W3C traceparent (set by `trace_context_middleware`
+    // into request extensions) so the engine can link its downstream span to
+    // the caller's distributed trace.  The bearer token NEVER appears here.
+    let traceparent = w3c_trace.map(|Extension(ctx)| ctx.0.traceparent().to_owned());
     debug!(
         execution_id = %consumed_row.execution_id,
         scope = ?consumed_row.scope,
+        has_traceparent = traceparent.is_some(),
         wait_kind = "Webhook",
         "resume: enqueuing ControlCommand::Resume"
     );
 
     match state
-        .enqueue_resume_from_row(&consumed_row, resume_target)
+        .enqueue_resume_from_row(&consumed_row, resume_target, traceparent)
         .await
     {
         Ok(()) => (StatusCode::ACCEPTED, "").into_response(),

--- a/crates/api/src/transport/webhook/resume.rs
+++ b/crates/api/src/transport/webhook/resume.rs
@@ -16,22 +16,38 @@
 //!
 //! ## Pipeline order (mirrors `dispatch_inner` ordering in `dispatch.rs`)
 //!
+//! The burn (token DELETE) and the `Resume` enqueue happen in ONE transaction
+//! ([`nebula_storage_port::store::ResumeProducer::consume_and_enqueue_resume`])
+//! at step 10. Everything before it is non-destructive: a read-only `peek`
+//! (step 6) supplies the row for the kind / expiry checks, so a wrong-kind or
+//! expired token returns 404 WITHOUT burning the token (the prior
+//! consume-first handler burned it first, then 404'd — a wart this fixes).
+//!
 //! 1. Body cap → 413
 //! 2. Extract bearer from `Authorization: Bearer <token>` → uniform 404 on
 //!    missing/wrong-scheme/empty (NOT 401 — do not reveal auth was attempted)
 //! 3. Per-IP rate-limit → 429 + `Retry-After` (BEFORE any store hit)
 //! 4. Global rate-limit → 429 (BEFORE any store hit)
-//! 5. Hash bearer; `store.consume(hash)`:
-//!    - `Err` → 503 + `Retry-After` (token unconsumed; abuse-case 15)
-//!    - `Ok(None)` → uniform 404
-//!    - `Ok(Some(row))` → continue
-//! 6. Kind-match: `Webhook` → `ResumeTarget::Webhook{callback_id}`; `_` → 404
-//!    (before per-tenant RL: wrong-kind/expired tokens must not 429 on an exhausted tenant)
-//! 7. Expiry check via injectable clock; expired or malformed → 404, no enqueue
-//!    (before per-tenant RL: same oracle-avoidance rationale as step 6)
-//! 8. Per-tenant rate-limit (key = `row.scope.credential_owner_id()`) → 429;
-//!    token is already burned (accepted, documented)
-//! 9. Enqueue `ControlCommand::Resume` via `enqueue_resume_from_row` → 202 / 503
+//! 5. Hash bearer → `TokenHash` (bearer dropped here — never logged or stored)
+//! 6. `producer.peek(hash)` (read-only, NO burn):
+//!    - `Err` → 503 + `Retry-After` (token NOT burned; abuse-case 15)
+//!    - `None` → uniform 404
+//!    - `Some(row)` → continue
+//! 7. Kind-match: `Webhook` → `ResumeTarget::Webhook{callback_id}`; `_` → 404
+//!    (NO burn — wart fixed)
+//! 8. Expiry check via injectable clock; expired or malformed → 404 (NO burn)
+//! 9. Build the `ControlMsg` (scope FROM the row, never the request; command
+//!    `Resume`; traceparent from request extensions)
+//! 10. `producer.consume_and_enqueue_resume(hash, &msg)` — atomic burn+enqueue:
+//!     - `Err` → 503 + `Retry-After` (tx rolled back; token LIVE; gap CLOSED)
+//!     - `Ok(false)` → uniform 404 (raced / replayed)
+//!     - `Ok(true)` → continue
+//! 11. Per-tenant rate-limit (key = `row.scope.credential_owner_id()`) — fires
+//!     ONLY on the atomic-delete winner, so a 429 is observable only on a
+//!     request that ALSO burned the token (single-shot per token). Running it on
+//!     the un-burned `peek` row would expose a repeatable 429 = "valid token +
+//!     throttled tenant" oracle the consume-first model never did. → 429 (token
+//!     already burned + `Resume` already enqueued) or 202.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -94,8 +110,9 @@ pub struct ResumeHandlerComponents {
     /// anti-enumeration backstop (step 4).
     pub global_rate_limiter: WebhookRateLimiter,
     /// Per-tenant rate limiter — keyed on `Scope::credential_owner_id()`,
-    /// checked post-consume after kind-match and expiry (step 8).  Token is
-    /// already burned at this point; see W-S3d spec note.
+    /// checked at step 11 ONLY on the atomic consume+enqueue winner.  Token is
+    /// already burned at this point (and the `Resume` already enqueued); see the
+    /// module doc for why this fires post-burn (oracle avoidance).
     pub tenant_rate_limiter: WebhookRateLimiter,
     /// Injectable clock — used for expiry comparison (step 8).
     pub clock: Arc<dyn Clock>,
@@ -165,8 +182,8 @@ pub(crate) async fn resume_handler(
         warn!("resume_handler called without ResumeHandlerComponents wired — composition-root bug");
         return (StatusCode::SERVICE_UNAVAILABLE, "").into_response();
     };
-    let Some(token_store) = state.resume_token_store.as_ref() else {
-        warn!("resume_handler called without resume_token_store wired — composition-root bug");
+    let Some(resume_producer) = state.resume_producer.as_ref() else {
+        warn!("resume_handler called without resume_producer wired — composition-root bug");
         return (StatusCode::SERVICE_UNAVAILABLE, "").into_response();
     };
 
@@ -214,7 +231,7 @@ pub(crate) async fn resume_handler(
         return rate_limit_429(exceeded.retry_after_secs);
     }
 
-    // Step 5 — hash and consume.
+    // Step 5 — hash the bearer.
     // bearer_token / hash deliberately excluded from all log fields.
     let raw_hash = token_hash(&bearer_token);
     // bearer_token is dropped here — never logged or stored past this point.
@@ -227,13 +244,16 @@ pub(crate) async fn resume_handler(
         return (StatusCode::INTERNAL_SERVER_ERROR, "").into_response();
     };
 
-    let consumed_row = match token_store.consume(&token_hash_value).await {
-        // Storage error → 503 so the caller can retry; the token is
-        // unconsumed on a transient storage fault (abuse-case 15).
+    // Step 6 — read-only `peek` (NO burn). The row drives the kind / expiry
+    // checks below; the token is consumed only at step 10, atomically with the
+    // enqueue.
+    let token_row = match resume_producer.peek(&token_hash_value).await {
+        // Storage error → 503 so the caller can retry; the token is NOT burned
+        // on a transient storage fault (abuse-case 15).
         Err(storage_err) => {
             warn!(
                 error = %storage_err,
-                "resume: storage error on consume — returning 503 (token unconsumed)"
+                "resume: storage error on peek — returning 503 (token not burned)"
             );
             return service_unavailable_with_retry_after();
         },
@@ -242,100 +262,114 @@ pub(crate) async fn resume_handler(
         Ok(Some(row)) => row,
     };
 
-    // Step 6 — kind-match (fail-closed, before per-tenant RL).
+    // Step 7 — kind-match (fail-closed, NO burn — wart fixed).
     // `ResumeTokenWaitKind` is `#[non_exhaustive]`; equality to `Webhook` is
     // the only admissible kind at this endpoint.  All other variants — Approval,
     // and any future variant added to the non-exhaustive enum without recompiling
-    // this crate — fall to the `else` branch and return a uniform 404.
+    // this crate — fall to the `else` branch and return a uniform 404 WITHOUT
+    // consuming the token (the prior consume-first handler burned it first).
     //
-    // Ordering invariant: kind-match fires BEFORE per-tenant rate-limit.  A wrong-kind
-    // or expired token on an exhausted tenant must return 404, not 429 — returning 429
-    // would reveal that the token was structurally valid (existence oracle) and would
-    // inconsistently 429 on tokens the tenant cannot resume.
-    let resume_target = if consumed_row.wait_kind == ResumeTokenWaitKind::Webhook {
+    // Ordering invariant: kind-match fires BEFORE the consume.  A wrong-kind or
+    // expired token must return 404, never 429 — returning 429 would reveal that
+    // the token was structurally valid (existence oracle).
+    let resume_target = if token_row.wait_kind == ResumeTokenWaitKind::Webhook {
         ResumeTarget::Webhook {
-            callback_id: consumed_row.callback_label.clone(),
+            callback_id: token_row.callback_label.clone(),
         }
     } else {
         debug!(
-            execution_id = %consumed_row.execution_id,
-            wait_kind = ?consumed_row.wait_kind,
-            "resume: token wait_kind does not match Webhook; returning 404 (fail-closed)"
+            execution_id = %token_row.execution_id,
+            wait_kind = ?token_row.wait_kind,
+            "resume: token wait_kind does not match Webhook; returning 404 (fail-closed, no burn)"
         );
         return uniform_not_found();
     };
 
-    // Step 7 — expiry check via injectable clock (fail-closed on parse failure).
-    // Fires BEFORE per-tenant RL for the same oracle-avoidance reason as step 6.
-    if let Some(expires_at_str) = consumed_row.expires_at.as_deref() {
+    // Step 8 — expiry check via injectable clock (fail-closed on parse failure).
+    // Fires BEFORE the consume; expired / malformed → 404 WITHOUT burning.
+    if let Some(expires_at_str) = token_row.expires_at.as_deref() {
         if let Ok(expiry) = parse_rfc3339_as_system_time(expires_at_str) {
             let now = components.clock.now();
             if now >= expiry {
                 debug!(
-                    execution_id = %consumed_row.execution_id,
+                    execution_id = %token_row.execution_id,
                     expires_at = %expires_at_str,
-                    "resume: token expired (consumed, no enqueue)"
+                    "resume: token expired (no burn, no enqueue)"
                 );
                 return uniform_not_found();
             }
         } else {
-            // Malformed RFC-3339 — fail-closed; token is already consumed.
+            // Malformed RFC-3339 — fail-closed WITHOUT burning the token.
             warn!(
-                execution_id = %consumed_row.execution_id,
+                execution_id = %token_row.execution_id,
                 expires_at = %expires_at_str,
-                "resume: malformed expires_at — fail-closed (token consumed, no enqueue)"
+                "resume: malformed expires_at — fail-closed (no burn, no enqueue)"
             );
             return uniform_not_found();
         }
     }
 
-    // Step 8 — per-tenant rate-limit (post-consume, post-kind-match, post-expiry).
-    // Token is already burned at this point; see W-S3d spec note for why this is
-    // accepted behavior (the alternative — pre-consume per-tenant RL — requires a
-    // tenant lookup before the consume atomic, adding a second DB round-trip and a
-    // TOCTOU window).
-    let tenant_key = consumed_row.scope.credential_owner_id();
+    // Step 9 — build the `Resume` control message.
+    // Scope comes FROM the row (never the request); `traceparent` from the
+    // inbound W3C context (set by `trace_context_middleware` into request
+    // extensions). The bearer token NEVER appears here.
+    let traceparent = w3c_trace.map(|Extension(ctx)| ctx.0.traceparent().to_owned());
+    let resume_msg = nebula_storage_port::dto::ControlMsg {
+        id: *uuid::Uuid::new_v4().as_bytes(),
+        execution_id: token_row.execution_id.clone(),
+        command: nebula_storage_port::dto::ControlCommand::Resume,
+        scope: token_row.scope.clone(),
+        w3c_traceparent: traceparent,
+        reclaim_count: 0,
+        resume_target: Some(resume_target),
+    };
+    debug!(
+        execution_id = %token_row.execution_id,
+        scope = ?token_row.scope,
+        has_traceparent = resume_msg.w3c_traceparent.is_some(),
+        wait_kind = "Webhook",
+        "resume: consuming token + enqueuing ControlCommand::Resume (atomic)"
+    );
+
+    // Step 10 — atomic burn + enqueue in ONE transaction. A transient fault
+    // rolls back: the token stays live and no Resume is enqueued, so a retry
+    // succeeds (the durability gap the consume-then-enqueue handler had).
+    match resume_producer
+        .consume_and_enqueue_resume(&token_hash_value, &resume_msg)
+        .await
+    {
+        // Storage error → 503 (tx rolled back; token LIVE; caller retries).
+        Err(storage_err) => {
+            warn!(
+                execution_id = %token_row.execution_id,
+                error = %storage_err,
+                "resume: storage error on consume_and_enqueue — 503 (tx rolled back; token live)"
+            );
+            return service_unavailable_with_retry_after();
+        },
+        // Zero rows deleted — raced or replayed between peek and consume.
+        Ok(false) => return uniform_not_found(),
+        // Won the atomic delete: token burned AND Resume enqueued.
+        Ok(true) => {},
+    }
+
+    // Step 11 — per-tenant rate-limit, fired ONLY on the atomic-delete winner.
+    // The token is already burned and the Resume already enqueued; a 429 is thus
+    // observable only on a request that ALSO burned the token (single-shot per
+    // token) — byte-identical to the prior post-burn semantics. Running this on
+    // the un-burned `peek` row (step 6) would expose a repeatable 429 oracle
+    // ("valid token + throttled tenant"); see the module doc.
+    let tenant_key = token_row.scope.credential_owner_id();
     if let Err(exceeded) = components.tenant_rate_limiter.check(&tenant_key).await {
         debug!(
             tenant_id = %tenant_key,
             retry_after = exceeded.retry_after_secs,
-            "resume: per-tenant rate limit exceeded (token consumed)"
+            "resume: per-tenant rate limit exceeded (token already burned + enqueued)"
         );
         return rate_limit_429(exceeded.retry_after_secs);
     }
 
-    // Step 9 — enqueue (ControlCommand::Resume via scoped queue).
-    // Log only non-secret fields; bearer/hash never appear here.
-    //
-    // Extract the inbound W3C traceparent (set by `trace_context_middleware`
-    // into request extensions) so the engine can link its downstream span to
-    // the caller's distributed trace.  The bearer token NEVER appears here.
-    let traceparent = w3c_trace.map(|Extension(ctx)| ctx.0.traceparent().to_owned());
-    debug!(
-        execution_id = %consumed_row.execution_id,
-        scope = ?consumed_row.scope,
-        has_traceparent = traceparent.is_some(),
-        wait_kind = "Webhook",
-        "resume: enqueuing ControlCommand::Resume"
-    );
-
-    match state
-        .enqueue_resume_from_row(&consumed_row, resume_target, traceparent)
-        .await
-    {
-        Ok(()) => (StatusCode::ACCEPTED, "").into_response(),
-        Err(api_err) => {
-            warn!(
-                execution_id = %consumed_row.execution_id,
-                error = %api_err,
-                "resume: failed to enqueue ControlCommand::Resume"
-            );
-            match api_err {
-                ApiError::ServiceUnavailable(_) => service_unavailable_with_retry_after(),
-                _ => (StatusCode::INTERNAL_SERVER_ERROR, "").into_response(),
-            }
-        },
-    }
+    (StatusCode::ACCEPTED, "").into_response()
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────

--- a/crates/api/tests/resume_e2e.rs
+++ b/crates/api/tests/resume_e2e.rs
@@ -820,27 +820,26 @@ async fn no_token_in_url_path_route_exists() {
 
     let resp = harness.app.oneshot(get_with_path_param).await.unwrap();
 
-    // Assert the token is NOT in the URL path by proving no successful
-    // response is returned.  The specific error code is intentionally
-    // not pinned to 404: in axum 0.8 the `internal_auth_middleware`
-    // layer wrapping the `/internal/v1/...` sub-router runs even for
-    // unmatched paths (the layer fires before axum's global 404 fallback),
-    // producing 503 "internal auth not configured" for any path that
-    // reaches that middleware without a match.  What matters for the
-    // oracle-free security property is that the response is NEVER
-    // 200 OK or 202 Accepted — there is no `/resume/{token}` route
-    // that could echo the token back to the caller or signal existence.
-    assert_ne!(
+    // The only `/resume` route is an exact-path `POST` (no path parameter), so
+    // `GET /resume/{token}` matches NOTHING.  It falls through to the merged
+    // `/internal/v1` sub-router's `internal_auth_middleware`, which — with no
+    // internal shared token configured in `ApiConfig::for_test` — deterministically
+    // returns `503 SERVICE_UNAVAILABLE` for any unmatched path that reaches it
+    // (`domain::internal::router` layers the middleware over its routes; axum 0.8
+    // applies that layer to the merged fallback).
+    //
+    // We pin the EXACT status rather than a bare `assert_ne!(200)`: the security
+    // property is that `/resume/{token}` matches NO route, and the only proof of
+    // "no match" is that the request lands on the unmatched-path fallback.  If a
+    // `/resume/{token}` route were ever added it would return that route's status
+    // instead (2xx on success — or even a 4xx/5xx of its own, which a bare
+    // `assert_ne!(200)` would silently accept while the URL-borne-token oracle is
+    // live).  Pinning 503 makes any such regression fail this assertion.
+    assert_eq!(
         resp.status(),
-        StatusCode::OK,
-        "GET /resume/{{token}} must not return 200 — no path-parameter route exists that \
-         would echo or signal the token's existence"
-    );
-    assert_ne!(
-        resp.status(),
-        StatusCode::ACCEPTED,
-        "GET /resume/{{token}} must not return 202 — no path-parameter route exists that \
-         would accept the token from the URL path"
+        StatusCode::SERVICE_UNAVAILABLE,
+        "GET /resume/{{token}} must hit the unmatched-path fallback (503), proving no \
+         path-parameter route exists that could echo or accept a URL-borne token"
     );
 }
 

--- a/crates/api/tests/resume_e2e.rs
+++ b/crates/api/tests/resume_e2e.rs
@@ -51,10 +51,10 @@ use nebula_storage::{
 use nebula_storage_port::{
     Scope, StorageError,
     dto::{
-        ControlCommand, ResumeTarget,
+        ControlCommand, ControlMsg, ResumeTarget,
         resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash},
     },
-    store::ResumeTokenStore,
+    store::{ResumeProducer, ResumeTokenStore},
 };
 use tower::ServiceExt;
 
@@ -196,9 +196,10 @@ struct ResumeHarness {
 
 /// Build the standard resume test harness with the given rate-limit components.
 ///
-/// Wires an `InMemoryResumeTokenStore` and `InMemoryControlQueue` whose `Arc`s
-/// are shared with `AppState` so `seed_for_test` writes are visible through
-/// the handler, and `snapshot()` reflects every enqueued `ControlMsg`.
+/// The resume-token store, resume producer, and control queue all share the
+/// `exec_store`'s `SharedState`, so `seed_for_test` writes on `token_store` are
+/// visible to the producer's `peek` / `consume_and_enqueue_resume`, and
+/// `control_queue.snapshot()` reflects every `Resume` the producer enqueues.
 async fn build_resume_harness(components: ResumeHandlerComponents) -> ResumeHarness {
     use nebula_storage::inmem::{
         InMemoryJournalReader, InMemoryNodeResultStore, InMemoryWorkflowStore,
@@ -211,7 +212,10 @@ async fn build_resume_harness(components: ResumeHandlerComponents) -> ResumeHarn
     let node_results = InMemoryNodeResultStore::new();
     let workflow_versions = InMemoryWorkflowVersionStore::new();
     let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
-    let token_store = InMemoryResumeTokenStore::standalone();
+    // Token store + producer over the SAME shared state as the control queue —
+    // built before `exec_store` is moved into the `Arc`.
+    let token_store = exec_store.resume_token_store();
+    let resume_producer = exec_store.resume_producer();
 
     let api_config = ApiConfig::for_test();
     let state = AppState::new(
@@ -227,6 +231,7 @@ async fn build_resume_harness(components: ResumeHandlerComponents) -> ResumeHarn
     .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
     .with_insecure_tenant_rbac_bypass_for_tests()
     .with_resume_token_store(Arc::new(token_store.clone()))
+    .with_resume_producer(Arc::new(resume_producer))
     .with_resume_handler_components(components);
 
     let app = app::build_app(state, &api_config);
@@ -238,31 +243,35 @@ async fn build_resume_harness(components: ResumeHandlerComponents) -> ResumeHarn
     }
 }
 
-/// A `ResumeTokenStore` port whose `consume` always returns a storage error.
+/// A `ResumeProducer` port whose `peek` always returns a storage error.
 ///
-/// Used to assert abuse-case 15: storage transient fault → 503, token unconsumed,
-/// no `ControlMsg` enqueued.
+/// Used to assert abuse-case 15: a transient storage fault on the read-only
+/// `peek` → 503, token NOT burned, no `ControlMsg` enqueued. `consume_and_
+/// enqueue_resume` is never reached on this path; it returns the same error
+/// for completeness.
 #[derive(Debug)]
-struct AlwaysFailTokenStore;
+struct AlwaysFailResumeProducer;
 
 #[async_trait::async_trait]
-impl ResumeTokenStore for AlwaysFailTokenStore {
-    async fn consume(&self, _hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
+impl ResumeProducer for AlwaysFailResumeProducer {
+    async fn peek(&self, _hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
         Err(StorageError::Connection(
             "simulated transient storage failure".to_owned(),
         ))
     }
 
-    async fn revoke_on_terminal(
+    async fn consume_and_enqueue_resume(
         &self,
-        _scope: &Scope,
-        _execution_id: &str,
-    ) -> Result<u64, StorageError> {
-        Ok(0)
+        _hash: &TokenHash,
+        _resume_msg: &ControlMsg,
+    ) -> Result<bool, StorageError> {
+        Err(StorageError::Connection(
+            "simulated transient storage failure".to_owned(),
+        ))
     }
 }
 
-/// Build a harness whose token store always returns a storage error on `consume`.
+/// Build a harness whose resume producer always returns a storage error on `peek`.
 async fn build_failing_store_harness(components: ResumeHandlerComponents) -> ResumeHarness {
     use nebula_storage::inmem::{
         InMemoryJournalReader, InMemoryNodeResultStore, InMemoryWorkflowStore,
@@ -276,7 +285,7 @@ async fn build_failing_store_harness(components: ResumeHandlerComponents) -> Res
     let workflow_versions = InMemoryWorkflowVersionStore::new();
     let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
     // A standalone store is returned in `token_store` for the field but is
-    // never wired into AppState — `AlwaysFailTokenStore` is wired instead.
+    // never wired into AppState — `AlwaysFailResumeProducer` is wired instead.
     let token_store_placeholder = InMemoryResumeTokenStore::standalone();
 
     let api_config = ApiConfig::for_test();
@@ -292,7 +301,7 @@ async fn build_failing_store_harness(components: ResumeHandlerComponents) -> Res
     .with_org_resolver(Arc::new(common::TestOrgResolver))
     .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
     .with_insecure_tenant_rbac_bypass_for_tests()
-    .with_resume_token_store(Arc::new(AlwaysFailTokenStore))
+    .with_resume_producer(Arc::new(AlwaysFailResumeProducer))
     .with_resume_handler_components(components);
 
     let app = app::build_app(state, &api_config);
@@ -498,12 +507,13 @@ async fn forged_bearer_returns_404_no_enqueue() {
     );
 }
 
-/// Test 4 — Expired token (clock past expiry): consumed, 404, no enqueue.
+/// Test 4 — Expired token (clock past expiry): 404, no enqueue, NO BURN.
 ///
-/// Token expiry is checked AFTER consume (step 8 in the pipeline).  The
-/// token is burned but no `ControlMsg` is emitted, and the caller sees 404.
+/// Expiry is checked at step 8 on the read-only `peek` row, BEFORE the consume.
+/// The token is NOT burned (wart fix): the caller sees 404 and the token row
+/// survives, so a subsequent `consume` still returns it.
 #[tokio::test]
-async fn expired_token_consumed_returns_404_no_enqueue() {
+async fn expired_token_returns_404_no_enqueue_no_burn() {
     // Clock at epoch 1001; token expired at epoch 1000.
     let clock = Arc::new(MockClock::at_unix_secs(1_001));
     let harness = build_resume_harness(components_with_clock(clock)).await;
@@ -534,14 +544,25 @@ async fn expired_token_consumed_returns_404_no_enqueue() {
         harness.control_queue.snapshot().is_empty(),
         "expired token must not produce a ControlMsg enqueue"
     );
+    // Wart fix: the token survived (NOT burned). A direct consume still finds it.
+    let survived = harness
+        .token_store
+        .consume(&token_hash_of(bearer))
+        .await
+        .expect("consume must not error");
+    assert!(
+        survived.is_some(),
+        "expired token must NOT be burned by the 404 path (wart fix)"
+    );
 }
 
-/// Test 5 — Malformed `expires_at`: fail-closed → consumed, 404, no enqueue.
+/// Test 5 — Malformed `expires_at`: fail-closed → 404, no enqueue, NO BURN.
 ///
 /// A row with an unparseable `expires_at` string is treated as expired
-/// (fail-closed): the handler returns 404 and does not enqueue a Resume.
+/// (fail-closed): the handler returns 404 and does not enqueue a Resume — and
+/// does not burn the token (checked on the read-only `peek` row, before consume).
 #[tokio::test]
-async fn malformed_expires_at_fails_closed_404_no_enqueue() {
+async fn malformed_expires_at_fails_closed_404_no_enqueue_no_burn() {
     let clock = Arc::new(MockClock::at_now());
     let harness = build_resume_harness(components_with_clock(clock)).await;
 
@@ -570,14 +591,25 @@ async fn malformed_expires_at_fails_closed_404_no_enqueue() {
         harness.control_queue.snapshot().is_empty(),
         "malformed expires_at must not produce a ControlMsg enqueue"
     );
+    let survived = harness
+        .token_store
+        .consume(&token_hash_of(bearer))
+        .await
+        .expect("consume must not error");
+    assert!(
+        survived.is_some(),
+        "malformed-expiry token must NOT be burned by the 404 path (wart fix)"
+    );
 }
 
-/// Test 6 — Kind-confusion: `Approval`-kind row at `POST /resume` → 404, no enqueue.
+/// Test 6 — Kind-confusion: `Approval`-kind row at `POST /resume` → 404, no
+/// enqueue, NO BURN.
 ///
 /// The Webhook endpoint must not resolve an Approval wait.  The `_` arm on the
-/// kind-match in the handler is the structural fail-closed gate.
+/// kind-match in the handler is the structural fail-closed gate, and it fires on
+/// the read-only `peek` row so the token is NOT burned (wart fix).
 #[tokio::test]
-async fn approval_kind_row_at_webhook_endpoint_returns_404_no_enqueue() {
+async fn approval_kind_row_at_webhook_endpoint_returns_404_no_enqueue_no_burn() {
     let clock = Arc::new(MockClock::at_now());
     let harness = build_resume_harness(components_with_clock(clock)).await;
 
@@ -600,6 +632,15 @@ async fn approval_kind_row_at_webhook_endpoint_returns_404_no_enqueue() {
     assert!(
         harness.control_queue.snapshot().is_empty(),
         "Approval-kind token must never enqueue a Resume at the Webhook endpoint"
+    );
+    let survived = harness
+        .token_store
+        .consume(&token_hash_of(bearer))
+        .await
+        .expect("consume must not error");
+    assert!(
+        survived.is_some(),
+        "wrong-kind token must NOT be burned by the 404 path (wart fix)"
     );
 }
 
@@ -746,14 +787,16 @@ async fn global_rate_limit_429_before_db_hit() {
     );
 }
 
-/// Test 10 — Per-tenant rate-limit fires AFTER consume (token already burned).
+/// Test 10 — Per-tenant 429 is single-shot per token (fires post-burn).
 ///
-/// This is documented behavior: once `store.consume()` succeeds and the row
-/// is deleted, the token cannot be "un-burned" even if per-tenant RL fires.
-/// The test asserts the 429 + `Retry-After` and that only ONE Resume was
-/// enqueued (from the first request that passed the tenant RL).
+/// The per-tenant rate-limit fires at step 11, on the atomic consume+enqueue
+/// WINNER — so a 429 is observable only on a request that ALSO burned its token
+/// (and already enqueued its Resume in the same transaction). The token is now
+/// burned: a replay of the same bearer yields 404, not a repeatable 429. This is
+/// the oracle-avoidance property — a 429 can never be replayed against a still-
+/// valid token (which would leak "valid token + throttled tenant").
 #[tokio::test]
-async fn per_tenant_rate_limit_429_post_consume_token_burned() {
+async fn per_tenant_429_still_single_shot() {
     let clock = Arc::new(MockClock::at_now());
     let harness = build_resume_harness(components_tight_tenant_rate_limit(clock)).await;
 
@@ -780,24 +823,46 @@ async fn per_tenant_rate_limit_429_post_consume_token_burned() {
         "first request must pass tenant RL"
     );
 
-    // Second request from a different peer but same tenant is rate-limited post-consume.
+    // Second request, same tenant: wins the atomic burn+enqueue, THEN the tenant
+    // RL fires → 429. The token is burned in the same transaction.
     let resp_second = harness
         .app
+        .clone()
         .oneshot(resume_post(bearer_b, PEER_B))
         .await
         .unwrap();
     assert_eq!(
         resp_second.status(),
         StatusCode::TOO_MANY_REQUESTS,
-        "second same-tenant request must be 429 (post-consume)"
+        "second same-tenant request must be 429 (post-burn)"
     );
     assert!(
         resp_second.headers().contains_key("retry-after"),
         "tenant 429 must include Retry-After header"
     );
 
-    // The first request's Resume was enqueued; the second was blocked after consume.
-    assert_eq!(harness.control_queue.snapshot().len(), 1);
+    // The 429 is single-shot: bearer_b is now burned, so a replay is 404 — a
+    // repeatable 429 against a live token (the throttle oracle) is impossible.
+    let burned = harness
+        .token_store
+        .consume(&token_hash_of(bearer_b))
+        .await
+        .expect("consume must not error");
+    assert!(
+        burned.is_none(),
+        "a 429'd request that won the atomic delete must have burned its token \
+         (single-shot — no repeatable 429 oracle on a still-valid token)"
+    );
+
+    // Both atomic winners enqueued their Resume (the burn and the enqueue are one
+    // transaction — a 429 cannot retroactively un-enqueue an already-committed
+    // Resume). This is strictly safer than the prior post-burn-RL handler, which
+    // burned the token but dropped the Resume — the very gap this seam closes.
+    assert_eq!(
+        harness.control_queue.snapshot().len(),
+        2,
+        "both atomic winners enqueued a Resume (burn+enqueue are one tx)"
+    );
 }
 
 /// Test 11 — No token-in-URL route: `GET /resume/{token}` must not return 200.
@@ -843,11 +908,11 @@ async fn no_token_in_url_path_route_exists() {
     );
 }
 
-/// Test 12 — Storage error on `consume` → 503 + `Retry-After`, ZERO enqueues.
+/// Test 12 — Storage error on `peek` → 503 + `Retry-After`, ZERO enqueues.
 ///
-/// When the token store returns `Err` on `consume`, the token was NOT consumed
-/// (the store never deleted it), so the caller can retry.  The handler must
-/// return 503 with `Retry-After` and must not enqueue anything.
+/// When the producer returns `Err` on the read-only `peek`, no token is burned
+/// (peek never deletes), so the caller can retry.  The handler must return 503
+/// with `Retry-After` and must not enqueue anything.
 #[tokio::test]
 async fn storage_error_returns_503_retry_after_no_enqueue() {
     let clock = Arc::new(MockClock::at_now());
@@ -999,68 +1064,37 @@ async fn bearer_extraction_uniformity_all_variants_return_404() {
     );
 }
 
-// ── FIX-1 regression: SQLite backend round-trip ───────────────────────────────
+// ── Option B1 (W-S3d) — atomic ResumeProducer round-trip + durability gate ────────
 
-/// Test 15 — SQLite backend round-trip: token minted into `SqliteResumeTokenStore`
-/// is consumable by a producer wired to the SAME pool.
-///
-/// This test proves the P1 correctness fix (FIX 1): on durable backends the
-/// `resume_token_store` wired into `AppState` must share the same pool as the
-/// execution store that mints tokens.  A standalone in-memory store would silently
-/// serve empty lookups while the engine persists to the pool.
-///
-/// The test bypasses `TransitionBatch` by inserting the token row directly via
-/// `sqlx::query` — this is intentional: we want to test the store + producer
-/// integration without needing a full execution store + engine path.
-#[tokio::test]
-async fn sqlite_backend_round_trip_durable_token_is_consumable() {
-    use nebula_storage::inmem::{
-        InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
-        InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
-    };
-    use nebula_storage::sqlite::{SqliteResumeTokenStore, init_schema};
-
-    // ── 1. Build a shared in-memory SQLite pool + apply schema ────────────────
-    let pool = sqlx::sqlite::SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect("sqlite::memory:")
-        .await
-        .expect("in-memory SQLite pool must open");
-
-    init_schema(&pool)
-        .await
-        .expect("init_schema must succeed on in-memory SQLite");
-
-    // ── 2. Mint a token row directly into `port_resume_tokens` ───────────────
-    // Using sqlx directly mirrors how the engine's `TransitionBatch` commit
-    // inserts rows.  `port_resume_tokens` has a FK on `execution_id →
-    // port_executions(id)` (with CASCADE delete), so we must insert a
-    // parent execution row first.
-    let bearer = "resume-bearer-t15-sqlite-round-trip";
+/// Insert the minimal parent execution row + a webhook token row directly into a
+/// SQLite pool, mirroring what the engine's `TransitionBatch` commit writes.
+async fn seed_sqlite_webhook_token(
+    pool: &sqlx::SqlitePool,
+    bearer: &str,
+    execution_id: &str,
+    callback_label: &str,
+    scope: &Scope,
+) {
     let token_hash_bytes = {
         use sha2::{Digest, Sha256};
-        let digest = Sha256::digest(bearer.as_bytes());
-        digest.to_vec()
+        Sha256::digest(bearer.as_bytes()).to_vec()
     };
-    let scope = test_scope();
-
-    // Parent execution row — minimal valid row satisfying NOT NULL constraints.
     sqlx::query(
         "INSERT INTO port_executions \
          (id, workspace_id, org_id, workflow_id, status, state, version, \
           created_at, updated_at) \
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
-    .bind("exe-t15-sqlite")
+    .bind(execution_id)
     .bind(&scope.workspace_id)
     .bind(&scope.org_id)
-    .bind("wf-t15")
+    .bind("wf-resume-producer")
     .bind("Running")
     .bind("{}")
     .bind(0_i64)
     .bind("2026-06-21T00:00:00Z")
     .bind("2026-06-21T00:00:00Z")
-    .execute(&pool)
+    .execute(pool)
     .await
     .expect("parent execution row insert must succeed");
 
@@ -1073,16 +1107,40 @@ async fn sqlite_backend_round_trip_durable_token_is_consumable() {
     .bind(&token_hash_bytes)
     .bind(&scope.workspace_id)
     .bind(&scope.org_id)
-    .bind("exe-t15-sqlite")
-    .bind("node_step_t15")
+    .bind(execution_id)
+    .bind("node_resume_producer")
     .bind("webhook")
-    .bind("cb-t15")
+    .bind(callback_label)
     .bind("2026-06-21T00:00:00Z")
-    .execute(&pool)
+    .execute(pool)
     .await
     .expect("direct token insert must succeed");
+}
 
-    // ── 3. Build AppState wired to the SAME pool via SqliteResumeTokenStore ──
+/// Count `Resume` rows in the SQLite `port_control_queue`.
+async fn sqlite_resume_count(pool: &sqlx::SqlitePool) -> i64 {
+    use sqlx::Row;
+    sqlx::query("SELECT COUNT(*) AS n FROM port_control_queue WHERE command = 'Resume'")
+        .fetch_one(pool)
+        .await
+        .expect("count query must succeed")
+        .try_get::<i64, _>("n")
+        .expect("count column must decode")
+}
+
+/// Build an `AppState` whose `POST /resume` is wired to a `SqliteResumeProducer`
+/// over `pool` (the atomic consume+enqueue seam), with a controllable clock.
+fn build_sqlite_resume_app(
+    pool: &sqlx::SqlitePool,
+    api_config: &ApiConfig,
+    clock: Arc<dyn nebula_action::Clock>,
+) -> axum::Router {
+    use nebula_storage::inmem::{
+        InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
+        InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
+    };
+    use nebula_storage::sqlite::SqliteResumeProducer;
+
     let exec_store = InMemoryExecutionStore::new();
     let control_queue = InMemoryControlQueue::new(&exec_store);
     let journal = InMemoryJournalReader::new(&exec_store);
@@ -1090,93 +1148,297 @@ async fn sqlite_backend_round_trip_durable_token_is_consumable() {
     let workflow_versions = InMemoryWorkflowVersionStore::new();
     let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
 
-    // The durable resume-token store is wired from the SAME pool the token was
-    // minted into — this is the invariant FIX 1 enforces in compose.rs.
-    let durable_token_store = Arc::new(SqliteResumeTokenStore::new(pool.clone()));
-
-    let clock = Arc::new(MockClock::at_now());
-    let components = components_with_clock(clock);
-
-    let api_config = ApiConfig::for_test();
     let state = AppState::new(
         Arc::new(workflow_store),
         Arc::new(workflow_versions),
         Arc::new(exec_store),
         Arc::new(node_results),
         Arc::new(journal),
-        Arc::new(control_queue.clone()),
+        Arc::new(control_queue),
         api_config.jwt_secret.clone(),
     )
     .with_org_resolver(Arc::new(common::TestOrgResolver))
     .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
     .with_insecure_tenant_rbac_bypass_for_tests()
-    .with_resume_token_store(durable_token_store)
-    .with_resume_handler_components(components);
+    .with_resume_producer(Arc::new(SqliteResumeProducer::new(pool.clone())))
+    .with_resume_handler_components(components_with_clock(clock));
 
-    let app = app::build_app(state, &api_config);
+    app::build_app(state, api_config)
+}
 
-    // ── 4. POST /resume — must return 202 and enqueue one Resume ─────────────
+/// Open an in-memory SQLite pool (one shared connection) with the port schema.
+async fn open_sqlite_pool() -> sqlx::SqlitePool {
+    use nebula_storage::sqlite::init_schema;
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory SQLite pool must open");
+    init_schema(&pool)
+        .await
+        .expect("init_schema must succeed on in-memory SQLite");
+    pool
+}
+
+/// **MERGE GATE (red to green).** `burn_iff_enqueued` — a failed enqueue must
+/// NOT burn the token.
+///
+/// A real `SqliteResumeProducer` consumes the token and enqueues the `Resume`
+/// in ONE transaction. We force the control-queue INSERT to fail INSIDE that
+/// transaction by dropping `port_control_queue` first, so the `DELETE` of the
+/// token is rolled back with it. The handler returns 503, and:
+/// - (a) the token row STILL exists (peek-able) — it survived the rolled-back tx;
+/// - (b) NO `Resume` was enqueued;
+/// - (c) after the table is restored, a retry succeeds (202) and enqueues
+///   EXACTLY ONE `Resume`.
+///
+/// This FAILS on the prior burn-then-enqueue handler (the token would be gone
+/// after the 503, the retry would 404, and a `timeout: None` webhook wait would
+/// park forever) and PASSES on the atomic seam.
+#[tokio::test]
+async fn burn_iff_enqueued_resume_survives_failed_enqueue() {
+    use nebula_storage::sqlite::{SqliteResumeProducer, init_schema};
+    use nebula_storage_port::store::ResumeProducer;
+
+    let pool = open_sqlite_pool().await;
+    let api_config = ApiConfig::for_test();
+    let scope = test_scope();
+    let bearer = "resume-bearer-burn-iff-enqueued";
+    seed_sqlite_webhook_token(&pool, bearer, "exe-burn-iff", "cb-burn-iff", &scope).await;
+
+    // Force the control-queue INSERT (inside the producer's tx) to fail by
+    // removing the target table. The token DELETE must roll back with it.
+    sqlx::query("DROP TABLE port_control_queue")
+        .execute(&pool)
+        .await
+        .expect("drop port_control_queue must succeed");
+
+    let clock = Arc::new(MockClock::at_now());
+    let app = build_sqlite_resume_app(&pool, &api_config, clock);
+
     let resp = app
         .oneshot(resume_post(bearer, PEER_A))
         .await
         .expect("oneshot must not fail");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a failed enqueue inside the tx must surface as 503 (token NOT burned)"
+    );
 
+    // (a) The token row survived the rolled-back transaction.
+    let probe = SqliteResumeProducer::new(pool.clone());
+    let survived = probe
+        .peek(&token_hash_of(bearer))
+        .await
+        .expect("peek must not error");
+    assert!(
+        survived.is_some(),
+        "the token MUST survive a rolled-back enqueue — burning it here is the P1 bug \
+         (a timeout-less webhook wait would park Paused forever)"
+    );
+
+    // Restore the control-queue table so the retry can enqueue.
+    init_schema(&pool)
+        .await
+        .expect("re-applying schema must restore port_control_queue");
+
+    // (b) Before the retry, there is no Resume.
+    assert_eq!(
+        sqlite_resume_count(&pool).await,
+        0,
+        "the failed attempt must not have enqueued any Resume"
+    );
+
+    // (c) A retry now succeeds and enqueues exactly one Resume.
+    let app_retry = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+    let resp_retry = app_retry
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .expect("retry oneshot must not fail");
+    assert_eq!(
+        resp_retry.status(),
+        StatusCode::ACCEPTED,
+        "after the transient fault clears, the retry must succeed (token was still live)"
+    );
+    assert_eq!(
+        sqlite_resume_count(&pool).await,
+        1,
+        "the successful retry must enqueue exactly one Resume"
+    );
+
+    // The token is now burned — a second peek is empty (single-use).
+    let survived_after = probe
+        .peek(&token_hash_of(bearer))
+        .await
+        .expect("peek must not error");
+    assert!(
+        survived_after.is_none(),
+        "after the successful consume the token must be burned"
+    );
+}
+
+/// Happy path on the atomic seam: 202 + exactly one Resume with scope/target
+/// from the row; the token is no longer peek-able afterward.
+#[tokio::test]
+async fn happy_path_atomic_round_trip() {
+    use nebula_storage::sqlite::SqliteResumeProducer;
+    use nebula_storage_port::store::ResumeProducer;
+
+    let pool = open_sqlite_pool().await;
+    let api_config = ApiConfig::for_test();
+    let scope = test_scope();
+    let bearer = "resume-bearer-happy-atomic";
+    seed_sqlite_webhook_token(&pool, bearer, "exe-happy-atomic", "cb-happy", &scope).await;
+
+    let app = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+    let resp = app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .expect("oneshot must not fail");
     assert_eq!(
         resp.status(),
         StatusCode::ACCEPTED,
-        "SQLite round-trip: token minted into durable pool must be consumable by the wired producer"
+        "happy path must be 202"
     );
 
-    let queued = control_queue.snapshot();
-    assert_eq!(
-        queued.len(),
-        1,
-        "SQLite round-trip: exactly one Resume ControlMsg must be enqueued"
-    );
-    let (msg, _status) = &queued[0];
-    assert_eq!(msg.execution_id, "exe-t15-sqlite");
-    assert_eq!(msg.scope, test_scope());
-    assert_eq!(
-        msg.resume_target,
-        Some(ResumeTarget::Webhook {
-            callback_id: "cb-t15".to_owned()
-        })
-    );
-
-    // ── 5. Second call with same bearer must return 404 (token consumed) ──────
-    // Re-assemble the app since `oneshot` consumes it.
-    let durable_token_store_2 = Arc::new(SqliteResumeTokenStore::new(pool));
-    let exec_store_2 = InMemoryExecutionStore::new();
-    let control_queue_2 = InMemoryControlQueue::new(&exec_store_2);
-    let journal_2 = InMemoryJournalReader::new(&exec_store_2);
-    let node_results_2 = InMemoryNodeResultStore::new();
-    let workflow_versions_2 = InMemoryWorkflowVersionStore::new();
-    let workflow_store_2 = InMemoryWorkflowStore::new_with_versions(&workflow_versions_2);
-    let clock_2 = Arc::new(MockClock::at_now());
-    let state_2 = AppState::new(
-        Arc::new(workflow_store_2),
-        Arc::new(workflow_versions_2),
-        Arc::new(exec_store_2),
-        Arc::new(node_results_2),
-        Arc::new(journal_2),
-        Arc::new(control_queue_2),
-        api_config.jwt_secret.clone(),
+    // Exactly one Resume, with the row's scope + callback as the target.
+    use sqlx::Row;
+    let rows = sqlx::query(
+        "SELECT execution_id, workspace_id, org_id, command, resume_target \
+         FROM port_control_queue",
     )
-    .with_org_resolver(Arc::new(common::TestOrgResolver))
-    .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
-    .with_insecure_tenant_rbac_bypass_for_tests()
-    .with_resume_token_store(durable_token_store_2)
-    .with_resume_handler_components(components_with_clock(clock_2));
+    .fetch_all(&pool)
+    .await
+    .expect("control-queue query must succeed");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one control message must be enqueued"
+    );
+    let row = &rows[0];
+    assert_eq!(
+        row.try_get::<String, _>("execution_id").unwrap(),
+        "exe-happy-atomic"
+    );
+    assert_eq!(row.try_get::<String, _>("command").unwrap(), "Resume");
+    assert_eq!(
+        row.try_get::<String, _>("workspace_id").unwrap(),
+        scope.workspace_id
+    );
+    assert_eq!(row.try_get::<String, _>("org_id").unwrap(), scope.org_id);
+    let target_json: String = row.try_get("resume_target").unwrap();
+    let target: ResumeTarget = serde_json::from_str(&target_json).unwrap();
+    assert_eq!(
+        target,
+        ResumeTarget::Webhook {
+            callback_id: "cb-happy".to_owned()
+        }
+    );
 
-    let app_2 = app::build_app(state_2, &api_config);
-    let resp_2 = app_2
+    // Token is burned — no longer peek-able.
+    let probe = SqliteResumeProducer::new(pool.clone());
+    assert!(
+        probe
+            .peek(&token_hash_of(bearer))
+            .await
+            .expect("peek must not error")
+            .is_none(),
+        "the consumed token must no longer be peek-able"
+    );
+}
+
+/// Single-use replay on the atomic seam: first 202, replay 404; exactly one Resume.
+#[tokio::test]
+async fn single_use_replay_still_404s() {
+    let pool = open_sqlite_pool().await;
+    let api_config = ApiConfig::for_test();
+    let scope = test_scope();
+    let bearer = "resume-bearer-replay-atomic";
+    seed_sqlite_webhook_token(&pool, bearer, "exe-replay-atomic", "cb-replay", &scope).await;
+
+    let app1 = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+    let resp1 = app1
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .expect("first oneshot must not fail");
+    assert_eq!(resp1.status(), StatusCode::ACCEPTED, "first call is 202");
+
+    let app2 = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+    let resp2 = app2
         .oneshot(resume_post(bearer, PEER_A))
         .await
         .expect("second oneshot must not fail");
+    assert_eq!(
+        resp2.status(),
+        StatusCode::NOT_FOUND,
+        "replay of a consumed token must 404"
+    );
 
     assert_eq!(
-        resp_2.status(),
-        StatusCode::NOT_FOUND,
-        "SQLite round-trip: second call with same bearer must return 404 (token already consumed)"
+        sqlite_resume_count(&pool).await,
+        1,
+        "a replay must NOT produce a second Resume"
+    );
+}
+
+/// Concurrent replay: two simultaneous POSTs with the same bearer → exactly one
+/// 202 and one non-2xx; the `DELETE … RETURNING` row lock makes exactly one win,
+/// so exactly one Resume is enqueued.
+#[tokio::test]
+async fn concurrent_replay_enqueues_once() {
+    let pool = open_sqlite_pool().await;
+    let api_config = ApiConfig::for_test();
+    let scope = test_scope();
+    let bearer = "resume-bearer-concurrent-atomic";
+    seed_sqlite_webhook_token(&pool, bearer, "exe-concurrent", "cb-concurrent", &scope).await;
+
+    let app_a = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+    let app_b = build_sqlite_resume_app(&pool, &api_config, Arc::new(MockClock::at_now()));
+
+    let (resp_a, resp_b) = tokio::join!(
+        app_a.oneshot(resume_post(bearer, PEER_A)),
+        app_b.oneshot(resume_post(bearer, PEER_B)),
+    );
+    let status_a = resp_a.expect("a oneshot must not fail").status();
+    let status_b = resp_b.expect("b oneshot must not fail").status();
+
+    let accepted = [status_a, status_b]
+        .iter()
+        .filter(|s| **s == StatusCode::ACCEPTED)
+        .count();
+    assert_eq!(
+        accepted, 1,
+        "exactly one of two concurrent replays may win the atomic delete \
+         (got {status_a} / {status_b})"
+    );
+    assert_eq!(
+        sqlite_resume_count(&pool).await,
+        1,
+        "concurrent replays must enqueue exactly one Resume"
+    );
+}
+
+/// Storage error on the read-only `peek` → 503 + `Retry-After`, token left live.
+/// Proves the 503-on-peek path on the real producer trait at the HTTP boundary
+/// (mirrors test 12: `AlwaysFailResumeProducer.peek` returns `Err`).
+#[tokio::test]
+async fn peek_storage_error_is_503_token_live() {
+    let harness =
+        build_failing_store_harness(components_with_clock(Arc::new(MockClock::at_now()))).await;
+
+    let resp = harness
+        .app
+        .oneshot(resume_post("bearer-peek-error", PEER_A))
+        .await
+        .expect("oneshot must not fail");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a peek storage error must surface as 503"
+    );
+    assert!(
+        resp.headers().contains_key("retry-after"),
+        "503 on peek error must include Retry-After"
     );
 }

--- a/crates/api/tests/resume_e2e.rs
+++ b/crates/api/tests/resume_e2e.rs
@@ -820,10 +820,27 @@ async fn no_token_in_url_path_route_exists() {
 
     let resp = harness.app.oneshot(get_with_path_param).await.unwrap();
 
+    // Assert the token is NOT in the URL path by proving no successful
+    // response is returned.  The specific error code is intentionally
+    // not pinned to 404: in axum 0.8 the `internal_auth_middleware`
+    // layer wrapping the `/internal/v1/...` sub-router runs even for
+    // unmatched paths (the layer fires before axum's global 404 fallback),
+    // producing 503 "internal auth not configured" for any path that
+    // reaches that middleware without a match.  What matters for the
+    // oracle-free security property is that the response is NEVER
+    // 200 OK or 202 Accepted — there is no `/resume/{token}` route
+    // that could echo the token back to the caller or signal existence.
     assert_ne!(
         resp.status(),
         StatusCode::OK,
-        "GET /resume/{{token}} must not return 200 — no path-parameter route must exist"
+        "GET /resume/{{token}} must not return 200 — no path-parameter route exists that \
+         would echo or signal the token's existence"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "GET /resume/{{token}} must not return 202 — no path-parameter route exists that \
+         would accept the token from the URL path"
     );
 }
 
@@ -980,5 +997,187 @@ async fn bearer_extraction_uniformity_all_variants_return_404() {
     assert!(
         harness.control_queue.snapshot().is_empty(),
         "no ControlMsg must be enqueued from bearer-extraction failures"
+    );
+}
+
+// ── FIX-1 regression: SQLite backend round-trip ───────────────────────────────
+
+/// Test 15 — SQLite backend round-trip: token minted into `SqliteResumeTokenStore`
+/// is consumable by a producer wired to the SAME pool.
+///
+/// This test proves the P1 correctness fix (FIX 1): on durable backends the
+/// `resume_token_store` wired into `AppState` must share the same pool as the
+/// execution store that mints tokens.  A standalone in-memory store would silently
+/// serve empty lookups while the engine persists to the pool.
+///
+/// The test bypasses `TransitionBatch` by inserting the token row directly via
+/// `sqlx::query` — this is intentional: we want to test the store + producer
+/// integration without needing a full execution store + engine path.
+#[tokio::test]
+async fn sqlite_backend_round_trip_durable_token_is_consumable() {
+    use nebula_storage::inmem::{
+        InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
+        InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
+    };
+    use nebula_storage::sqlite::{SqliteResumeTokenStore, init_schema};
+
+    // ── 1. Build a shared in-memory SQLite pool + apply schema ────────────────
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory SQLite pool must open");
+
+    init_schema(&pool)
+        .await
+        .expect("init_schema must succeed on in-memory SQLite");
+
+    // ── 2. Mint a token row directly into `port_resume_tokens` ───────────────
+    // Using sqlx directly mirrors how the engine's `TransitionBatch` commit
+    // inserts rows.  `port_resume_tokens` has a FK on `execution_id →
+    // port_executions(id)` (with CASCADE delete), so we must insert a
+    // parent execution row first.
+    let bearer = "resume-bearer-t15-sqlite-round-trip";
+    let token_hash_bytes = {
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(bearer.as_bytes());
+        digest.to_vec()
+    };
+    let scope = test_scope();
+
+    // Parent execution row — minimal valid row satisfying NOT NULL constraints.
+    sqlx::query(
+        "INSERT INTO port_executions \
+         (id, workspace_id, org_id, workflow_id, status, state, version, \
+          created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("exe-t15-sqlite")
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .bind("wf-t15")
+    .bind("Running")
+    .bind("{}")
+    .bind(0_i64)
+    .bind("2026-06-21T00:00:00Z")
+    .bind("2026-06-21T00:00:00Z")
+    .execute(&pool)
+    .await
+    .expect("parent execution row insert must succeed");
+
+    sqlx::query(
+        "INSERT INTO port_resume_tokens \
+         (token_hash, workspace_id, org_id, execution_id, node_key, \
+          wait_kind, callback_label, created_at, expires_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+    )
+    .bind(&token_hash_bytes)
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .bind("exe-t15-sqlite")
+    .bind("node_step_t15")
+    .bind("webhook")
+    .bind("cb-t15")
+    .bind("2026-06-21T00:00:00Z")
+    .execute(&pool)
+    .await
+    .expect("direct token insert must succeed");
+
+    // ── 3. Build AppState wired to the SAME pool via SqliteResumeTokenStore ──
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let journal = InMemoryJournalReader::new(&exec_store);
+    let node_results = InMemoryNodeResultStore::new();
+    let workflow_versions = InMemoryWorkflowVersionStore::new();
+    let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
+
+    // The durable resume-token store is wired from the SAME pool the token was
+    // minted into — this is the invariant FIX 1 enforces in compose.rs.
+    let durable_token_store = Arc::new(SqliteResumeTokenStore::new(pool.clone()));
+
+    let clock = Arc::new(MockClock::at_now());
+    let components = components_with_clock(clock);
+
+    let api_config = ApiConfig::for_test();
+    let state = AppState::new(
+        Arc::new(workflow_store),
+        Arc::new(workflow_versions),
+        Arc::new(exec_store),
+        Arc::new(node_results),
+        Arc::new(journal),
+        Arc::new(control_queue.clone()),
+        api_config.jwt_secret.clone(),
+    )
+    .with_org_resolver(Arc::new(common::TestOrgResolver))
+    .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests()
+    .with_resume_token_store(durable_token_store)
+    .with_resume_handler_components(components);
+
+    let app = app::build_app(state, &api_config);
+
+    // ── 4. POST /resume — must return 202 and enqueue one Resume ─────────────
+    let resp = app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .expect("oneshot must not fail");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "SQLite round-trip: token minted into durable pool must be consumable by the wired producer"
+    );
+
+    let queued = control_queue.snapshot();
+    assert_eq!(
+        queued.len(),
+        1,
+        "SQLite round-trip: exactly one Resume ControlMsg must be enqueued"
+    );
+    let (msg, _status) = &queued[0];
+    assert_eq!(msg.execution_id, "exe-t15-sqlite");
+    assert_eq!(msg.scope, test_scope());
+    assert_eq!(
+        msg.resume_target,
+        Some(ResumeTarget::Webhook {
+            callback_id: "cb-t15".to_owned()
+        })
+    );
+
+    // ── 5. Second call with same bearer must return 404 (token consumed) ──────
+    // Re-assemble the app since `oneshot` consumes it.
+    let durable_token_store_2 = Arc::new(SqliteResumeTokenStore::new(pool));
+    let exec_store_2 = InMemoryExecutionStore::new();
+    let control_queue_2 = InMemoryControlQueue::new(&exec_store_2);
+    let journal_2 = InMemoryJournalReader::new(&exec_store_2);
+    let node_results_2 = InMemoryNodeResultStore::new();
+    let workflow_versions_2 = InMemoryWorkflowVersionStore::new();
+    let workflow_store_2 = InMemoryWorkflowStore::new_with_versions(&workflow_versions_2);
+    let clock_2 = Arc::new(MockClock::at_now());
+    let state_2 = AppState::new(
+        Arc::new(workflow_store_2),
+        Arc::new(workflow_versions_2),
+        Arc::new(exec_store_2),
+        Arc::new(node_results_2),
+        Arc::new(journal_2),
+        Arc::new(control_queue_2),
+        api_config.jwt_secret.clone(),
+    )
+    .with_org_resolver(Arc::new(common::TestOrgResolver))
+    .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests()
+    .with_resume_token_store(durable_token_store_2)
+    .with_resume_handler_components(components_with_clock(clock_2));
+
+    let app_2 = app::build_app(state_2, &api_config);
+    let resp_2 = app_2
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .expect("second oneshot must not fail");
+
+    assert_eq!(
+        resp_2.status(),
+        StatusCode::NOT_FOUND,
+        "SQLite round-trip: second call with same bearer must return 404 (token already consumed)"
     );
 }

--- a/crates/api/tests/resume_e2e.rs
+++ b/crates/api/tests/resume_e2e.rs
@@ -1,0 +1,984 @@
+//! End-to-end tests for `POST /resume` (ADR-0099 W-S3d).
+//!
+//! ## Coverage
+//!
+//! 1.  Happy path — 202 Accepted, one `ControlMsg{Resume, Webhook target}` enqueued.
+//! 2.  Single-use replay — same bearer twice: first 202, second 404; ONE enqueue.
+//! 3.  Forged/absent bearer — 404, ZERO enqueues.
+//! 4.  Expired token (clock-injected past expiry) — consumed, 404, no enqueue.
+//! 5.  Malformed `expires_at` — consumed, 404, no enqueue (fail-closed).
+//! 6.  Kind-confusion — `Approval`-kind row → 404, ZERO enqueues.
+//! 7.  Scope-from-row — enqueued scope == `row.scope`, unaffected by request headers.
+//! 8.  Per-IP rate-limit fires BEFORE DB: saturate → 429 + `Retry-After`; store not hit.
+//! 9.  Global rate-limit fires BEFORE DB: saturate → 429 + `Retry-After`; store not hit.
+//! 10. Per-tenant rate-limit fires AFTER consume: 429 (token burned, documented).
+//! 11. No token-in-URL path — `GET /resume/{token}` returns non-200.
+//! 12. Storage error → 503 + `Retry-After`, ZERO enqueues, token unconsumed.
+//! 13. Body inert — extra JSON body ignored; oversized body → 413, no store hit.
+//! 14. Bearer-extraction uniformity — missing header / `Basic` scheme / empty token → same 404.
+//!
+//! ## Harness
+//!
+//! Each test builds an `AppState` with:
+//! - `InMemoryResumeTokenStore` seeded via `seed_for_test`.
+//! - `InMemoryControlQueue` inspected via `snapshot()`.
+//! - `ResumeHandlerComponents` with a `MockClock` (controllable expiry time).
+//!
+//! The router is the real `nebula_api::app::build_app` router, which mounts
+//! `POST /resume` before tenancy middleware.  Per-IP rate-limit control is
+//! achieved by injecting `ConnectInfo<SocketAddr>` into the request extension
+//! (axum's `ConnectInfo` extractor reads from `request.extensions()`) and/or
+//! via `X-Forwarded-For` headers.
+
+mod common;
+
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{
+    body::Body,
+    extract::ConnectInfo,
+    http::{Request, StatusCode},
+};
+use nebula_action::MockClock;
+use nebula_api::{
+    ApiConfig, AppState, app,
+    transport::webhook::{ResumeHandlerComponents, ratelimit::WebhookRateLimiter},
+};
+use nebula_storage::{
+    InMemoryResumeTokenStore,
+    inmem::{InMemoryControlQueue, InMemoryExecutionStore},
+};
+use nebula_storage_port::{
+    Scope, StorageError,
+    dto::{
+        ControlCommand, ResumeTarget,
+        resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash},
+    },
+    store::ResumeTokenStore,
+};
+use tower::ServiceExt;
+
+// ── Test constants ────────────────────────────────────────────────────────────
+
+/// Fixed tenant scope used for all token rows unless a test overrides it.
+fn test_scope() -> Scope {
+    Scope::new("ws_test_000000000001", "org_test_000000000001")
+}
+
+/// RFC 5737 documentation-range peer address injected as `ConnectInfo`.
+const PEER_A: &str = "203.0.113.10:5000";
+/// Second documentation-range address for tests that need two distinct IPs.
+const PEER_B: &str = "203.0.113.20:5001";
+
+// ── Token / row builders ──────────────────────────────────────────────────────
+
+/// Compute the SHA-256 of `plaintext` and wrap it as a `TokenHash`.
+///
+/// Mirrors `nebula_api::transport::webhook::token::token_hash` exactly —
+/// used here to build seeded rows whose hash the handler will reconstruct.
+fn token_hash_of(plaintext: &str) -> TokenHash {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(plaintext.as_bytes());
+    TokenHash::try_from_bytes(digest.to_vec()).expect("SHA-256 always produces exactly 32 bytes")
+}
+
+/// Minimal `Webhook`-kind `ResumeTokenRow` for `plaintext`, without expiry.
+fn webhook_row(
+    plaintext: &str,
+    execution_id: &str,
+    callback_label: &str,
+    scope: Scope,
+) -> ResumeTokenRow {
+    ResumeTokenRow::new(
+        token_hash_of(plaintext),
+        scope,
+        execution_id.to_owned(),
+        "node_step_a".to_owned(),
+        ResumeTokenWaitKind::Webhook,
+        callback_label.to_owned(),
+        "2026-06-21T00:00:00Z".to_owned(),
+        None,
+    )
+}
+
+/// Webhook-kind row with an explicit RFC-3339 expiry timestamp.
+fn webhook_row_with_expiry(
+    plaintext: &str,
+    execution_id: &str,
+    callback_label: &str,
+    scope: Scope,
+    expires_at: &str,
+) -> ResumeTokenRow {
+    ResumeTokenRow::new(
+        token_hash_of(plaintext),
+        scope,
+        execution_id.to_owned(),
+        "node_step_a".to_owned(),
+        ResumeTokenWaitKind::Webhook,
+        callback_label.to_owned(),
+        "2026-06-21T00:00:00Z".to_owned(),
+        Some(expires_at.to_owned()),
+    )
+}
+
+/// `Approval`-kind row — used for the kind-confusion test (test 6).
+fn approval_row(plaintext: &str, execution_id: &str, scope: Scope) -> ResumeTokenRow {
+    ResumeTokenRow::new(
+        token_hash_of(plaintext),
+        scope,
+        execution_id.to_owned(),
+        "node_step_b".to_owned(),
+        ResumeTokenWaitKind::Approval,
+        "approver@example.com".to_owned(),
+        "2026-06-21T00:00:00Z".to_owned(),
+        None,
+    )
+}
+
+// ── Component builders ────────────────────────────────────────────────────────
+
+/// Default components with a generous rate-limit (no test hits RL by accident)
+/// and a caller-supplied clock.
+fn components_with_clock(clock: Arc<dyn nebula_action::Clock>) -> ResumeHandlerComponents {
+    ResumeHandlerComponents {
+        ip_rate_limiter: WebhookRateLimiter::new(10_000),
+        global_rate_limiter: WebhookRateLimiter::new(10_000),
+        tenant_rate_limiter: WebhookRateLimiter::new(10_000),
+        clock,
+    }
+}
+
+/// Components with a 1-RPM per-IP cap; others generous.  Used for test 8.
+fn components_tight_ip_rate_limit(clock: Arc<dyn nebula_action::Clock>) -> ResumeHandlerComponents {
+    ResumeHandlerComponents {
+        ip_rate_limiter: WebhookRateLimiter::new(1),
+        global_rate_limiter: WebhookRateLimiter::new(10_000),
+        tenant_rate_limiter: WebhookRateLimiter::new(10_000),
+        clock,
+    }
+}
+
+/// Components with a 1-RPM global cap; others generous.  Used for test 9.
+fn components_tight_global_rate_limit(
+    clock: Arc<dyn nebula_action::Clock>,
+) -> ResumeHandlerComponents {
+    ResumeHandlerComponents {
+        ip_rate_limiter: WebhookRateLimiter::new(10_000),
+        global_rate_limiter: WebhookRateLimiter::new(1),
+        tenant_rate_limiter: WebhookRateLimiter::new(10_000),
+        clock,
+    }
+}
+
+/// Components with a 1-RPM per-tenant cap; others generous.  Used for test 10.
+fn components_tight_tenant_rate_limit(
+    clock: Arc<dyn nebula_action::Clock>,
+) -> ResumeHandlerComponents {
+    ResumeHandlerComponents {
+        ip_rate_limiter: WebhookRateLimiter::new(10_000),
+        global_rate_limiter: WebhookRateLimiter::new(10_000),
+        tenant_rate_limiter: WebhookRateLimiter::new(1),
+        clock,
+    }
+}
+
+// ── Harness ───────────────────────────────────────────────────────────────────
+
+/// Shared handles returned by the test harness builders.
+struct ResumeHarness {
+    /// The fully assembled axum app (routes + middleware) under test.
+    app: axum::Router,
+    /// Raw token store — seeded before test requests; shared with `AppState`.
+    token_store: InMemoryResumeTokenStore,
+    /// Raw control-queue handle — inspected after requests via `snapshot()`.
+    control_queue: InMemoryControlQueue,
+}
+
+/// Build the standard resume test harness with the given rate-limit components.
+///
+/// Wires an `InMemoryResumeTokenStore` and `InMemoryControlQueue` whose `Arc`s
+/// are shared with `AppState` so `seed_for_test` writes are visible through
+/// the handler, and `snapshot()` reflects every enqueued `ControlMsg`.
+async fn build_resume_harness(components: ResumeHandlerComponents) -> ResumeHarness {
+    use nebula_storage::inmem::{
+        InMemoryJournalReader, InMemoryNodeResultStore, InMemoryWorkflowStore,
+        InMemoryWorkflowVersionStore,
+    };
+
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let journal = InMemoryJournalReader::new(&exec_store);
+    let node_results = InMemoryNodeResultStore::new();
+    let workflow_versions = InMemoryWorkflowVersionStore::new();
+    let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
+    let token_store = InMemoryResumeTokenStore::standalone();
+
+    let api_config = ApiConfig::for_test();
+    let state = AppState::new(
+        Arc::new(workflow_store),
+        Arc::new(workflow_versions),
+        Arc::new(exec_store),
+        Arc::new(node_results),
+        Arc::new(journal),
+        Arc::new(control_queue.clone()),
+        api_config.jwt_secret.clone(),
+    )
+    .with_org_resolver(Arc::new(common::TestOrgResolver))
+    .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests()
+    .with_resume_token_store(Arc::new(token_store.clone()))
+    .with_resume_handler_components(components);
+
+    let app = app::build_app(state, &api_config);
+
+    ResumeHarness {
+        app,
+        token_store,
+        control_queue,
+    }
+}
+
+/// A `ResumeTokenStore` port whose `consume` always returns a storage error.
+///
+/// Used to assert abuse-case 15: storage transient fault → 503, token unconsumed,
+/// no `ControlMsg` enqueued.
+#[derive(Debug)]
+struct AlwaysFailTokenStore;
+
+#[async_trait::async_trait]
+impl ResumeTokenStore for AlwaysFailTokenStore {
+    async fn consume(&self, _hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
+        Err(StorageError::Connection(
+            "simulated transient storage failure".to_owned(),
+        ))
+    }
+
+    async fn revoke_on_terminal(
+        &self,
+        _scope: &Scope,
+        _execution_id: &str,
+    ) -> Result<u64, StorageError> {
+        Ok(0)
+    }
+}
+
+/// Build a harness whose token store always returns a storage error on `consume`.
+async fn build_failing_store_harness(components: ResumeHandlerComponents) -> ResumeHarness {
+    use nebula_storage::inmem::{
+        InMemoryJournalReader, InMemoryNodeResultStore, InMemoryWorkflowStore,
+        InMemoryWorkflowVersionStore,
+    };
+
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let journal = InMemoryJournalReader::new(&exec_store);
+    let node_results = InMemoryNodeResultStore::new();
+    let workflow_versions = InMemoryWorkflowVersionStore::new();
+    let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
+    // A standalone store is returned in `token_store` for the field but is
+    // never wired into AppState — `AlwaysFailTokenStore` is wired instead.
+    let token_store_placeholder = InMemoryResumeTokenStore::standalone();
+
+    let api_config = ApiConfig::for_test();
+    let state = AppState::new(
+        Arc::new(workflow_store),
+        Arc::new(workflow_versions),
+        Arc::new(exec_store),
+        Arc::new(node_results),
+        Arc::new(journal),
+        Arc::new(control_queue.clone()),
+        api_config.jwt_secret.clone(),
+    )
+    .with_org_resolver(Arc::new(common::TestOrgResolver))
+    .with_workspace_resolver(Arc::new(common::TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests()
+    .with_resume_token_store(Arc::new(AlwaysFailTokenStore))
+    .with_resume_handler_components(components);
+
+    let app = app::build_app(state, &api_config);
+
+    ResumeHarness {
+        app,
+        token_store: token_store_placeholder,
+        control_queue,
+    }
+}
+
+// ── Request builders ──────────────────────────────────────────────────────────
+
+/// `POST /resume` with a Bearer token and an injected `ConnectInfo` extension.
+///
+/// Injecting `ConnectInfo<SocketAddr>` into extensions is the axum-documented
+/// approach for testing handlers that use the `ConnectInfo` extractor without
+/// `into_make_service_with_connect_info`.
+fn resume_post(bearer: &str, peer: &str) -> Request<Body> {
+    let peer_addr: SocketAddr = peer
+        .parse()
+        .expect("test peer must be a valid socket address");
+    Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .header("Authorization", format!("Bearer {bearer}"))
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::empty())
+        .expect("resume POST must construct without error")
+}
+
+/// `POST /resume` with a Bearer token, an injected peer, and an explicit body.
+fn resume_post_with_body(bearer: &str, peer: &str, body: impl Into<Body>) -> Request<Body> {
+    let peer_addr: SocketAddr = peer
+        .parse()
+        .expect("test peer must be a valid socket address");
+    Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .header("Authorization", format!("Bearer {bearer}"))
+        .header("Content-Type", "application/json")
+        .extension(ConnectInfo(peer_addr))
+        .body(body.into())
+        .expect("resume POST with body must construct without error")
+}
+
+/// `POST /resume` with no `Authorization` header.
+fn resume_post_no_auth(peer: &str) -> Request<Body> {
+    let peer_addr: SocketAddr = peer
+        .parse()
+        .expect("test peer must be a valid socket address");
+    Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::empty())
+        .expect("no-auth resume POST must construct without error")
+}
+
+/// `POST /resume` with a `Basic` scheme (wrong scheme).
+fn resume_post_basic_scheme(peer: &str) -> Request<Body> {
+    let peer_addr: SocketAddr = peer
+        .parse()
+        .expect("test peer must be a valid socket address");
+    Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .header("Authorization", "Basic dXNlcjpwYXNz")
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::empty())
+        .expect("basic-scheme resume POST must construct without error")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Test 1 — Happy path: 202 Accepted + one targeted `Resume` `ControlMsg` enqueued.
+///
+/// Asserts: status 202, exactly one Pending Resume msg with correct execution_id,
+/// scope, and `ResumeTarget::Webhook{callback_id}`.
+#[tokio::test]
+async fn happy_path_returns_202_and_enqueues_resume() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let bearer = "resume-bearer-t1-happy";
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer, "exe-t1", "my-callback", test_scope()));
+
+    let resp = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::ACCEPTED,
+        "happy path must return 202"
+    );
+
+    let queued = harness.control_queue.snapshot();
+    assert_eq!(
+        queued.len(),
+        1,
+        "exactly one control message must be enqueued"
+    );
+    let (msg, status) = &queued[0];
+    assert_eq!(msg.command, ControlCommand::Resume);
+    assert_eq!(msg.execution_id, "exe-t1");
+    assert_eq!(
+        msg.scope,
+        test_scope(),
+        "enqueued scope must come from the token row"
+    );
+    assert_eq!(
+        msg.resume_target,
+        Some(ResumeTarget::Webhook {
+            callback_id: "my-callback".to_owned()
+        }),
+        "resume target must be Webhook with the row's callback_label"
+    );
+    assert_eq!(
+        status, "Pending",
+        "enqueued message must be in Pending status"
+    );
+}
+
+/// Test 2 — Single-use replay: first request → 202; second with same bearer → 404.
+///
+/// Only ONE `ControlMsg` must ever be enqueued across both calls.
+#[tokio::test]
+async fn single_use_replay_second_call_returns_404_one_enqueue() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let bearer = "resume-bearer-t2-replay";
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer, "exe-t2", "cb-replay", test_scope()));
+
+    let resp_first = harness
+        .app
+        .clone()
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_first.status(),
+        StatusCode::ACCEPTED,
+        "first call must return 202"
+    );
+
+    let resp_second = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_second.status(),
+        StatusCode::NOT_FOUND,
+        "second call with same bearer must return 404 (token consumed)"
+    );
+
+    assert_eq!(
+        harness.control_queue.snapshot().len(),
+        1,
+        "replay must not produce a second enqueue"
+    );
+}
+
+/// Test 3 — Forged/absent bearer: 404, ZERO enqueues.
+///
+/// A token hash that was never seeded returns uniform 404, byte-identical to the
+/// consumed-token 404 in test 2 (no existence oracle).
+#[tokio::test]
+async fn forged_bearer_returns_404_no_enqueue() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    // Seed a real row but present a completely different plaintext.
+    harness.token_store.seed_for_test(webhook_row(
+        "real-token-t3",
+        "exe-t3",
+        "cb-t3",
+        test_scope(),
+    ));
+
+    let resp = harness
+        .app
+        .oneshot(resume_post("forged-token-never-seeded", PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "forged bearer must return 404"
+    );
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "no ControlMsg must be enqueued for a forged bearer"
+    );
+}
+
+/// Test 4 — Expired token (clock past expiry): consumed, 404, no enqueue.
+///
+/// Token expiry is checked AFTER consume (step 8 in the pipeline).  The
+/// token is burned but no `ControlMsg` is emitted, and the caller sees 404.
+#[tokio::test]
+async fn expired_token_consumed_returns_404_no_enqueue() {
+    // Clock at epoch 1001; token expired at epoch 1000.
+    let clock = Arc::new(MockClock::at_unix_secs(1_001));
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let bearer = "resume-bearer-t4-expired";
+    // RFC-3339 for Unix epoch 1000 = 1970-01-01T00:16:40Z
+    let row = webhook_row_with_expiry(
+        bearer,
+        "exe-t4",
+        "cb-t4",
+        test_scope(),
+        "1970-01-01T00:16:40Z",
+    );
+    harness.token_store.seed_for_test(row);
+
+    let resp = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "expired token must return 404"
+    );
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "expired token must not produce a ControlMsg enqueue"
+    );
+}
+
+/// Test 5 — Malformed `expires_at`: fail-closed → consumed, 404, no enqueue.
+///
+/// A row with an unparseable `expires_at` string is treated as expired
+/// (fail-closed): the handler returns 404 and does not enqueue a Resume.
+#[tokio::test]
+async fn malformed_expires_at_fails_closed_404_no_enqueue() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let bearer = "resume-bearer-t5-malformed-expiry";
+    let row = webhook_row_with_expiry(
+        bearer,
+        "exe-t5",
+        "cb-t5",
+        test_scope(),
+        "NOT-A-VALID-RFC3339-DATE",
+    );
+    harness.token_store.seed_for_test(row);
+
+    let resp = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "malformed expires_at must fail-closed to 404"
+    );
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "malformed expires_at must not produce a ControlMsg enqueue"
+    );
+}
+
+/// Test 6 — Kind-confusion: `Approval`-kind row at `POST /resume` → 404, no enqueue.
+///
+/// The Webhook endpoint must not resolve an Approval wait.  The `_` arm on the
+/// kind-match in the handler is the structural fail-closed gate.
+#[tokio::test]
+async fn approval_kind_row_at_webhook_endpoint_returns_404_no_enqueue() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let bearer = "resume-bearer-t6-approval-kind";
+    harness
+        .token_store
+        .seed_for_test(approval_row(bearer, "exe-t6", test_scope()));
+
+    let resp = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "Approval-kind token at /resume must return 404 (fail-closed kind-match)"
+    );
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "Approval-kind token must never enqueue a Resume at the Webhook endpoint"
+    );
+}
+
+/// Test 7 — Scope-from-row: enqueued scope is `row.scope`, not from the request.
+///
+/// The handler has no `TenantContext` extractor.  The structural proof is the
+/// ABSENCE of any tenant scope in the extractor list.  This test asserts the
+/// behavioral effect: the enqueued `ControlMsg.scope` equals the row's scope,
+/// regardless of what path or headers the request carries.
+#[tokio::test]
+async fn enqueued_scope_comes_from_row_not_from_request() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    // Use a scope completely unrelated to `TEST_ORG`/`TEST_WS`.
+    let row_scope = Scope::new("ws_row_scoped_only_111", "org_row_scoped_only_222");
+    let bearer = "resume-bearer-t7-scope-from-row";
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer, "exe-t7", "cb-t7", row_scope.clone()));
+
+    let resp = harness
+        .app
+        .oneshot(resume_post(bearer, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED, "must succeed");
+
+    let queued = harness.control_queue.snapshot();
+    assert_eq!(queued.len(), 1);
+    assert_eq!(
+        queued[0].0.scope, row_scope,
+        "enqueued scope must be row.scope, not derived from request URL or headers"
+    );
+}
+
+/// Test 8 — Per-IP rate-limit fires BEFORE the DB store is touched.
+///
+/// Saturate the per-IP bucket (capacity 1) from PEER_A, then assert the next
+/// request from PEER_A returns 429 with `Retry-After`, and no second enqueue
+/// happened (proving the store was never reached for that request).
+#[tokio::test]
+async fn per_ip_rate_limit_429_before_db_hit() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_tight_ip_rate_limit(clock)).await;
+
+    let bearer_a = "resume-bearer-t8-ip-rl-first";
+    let bearer_b = "resume-bearer-t8-ip-rl-second";
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_a, "exe-t8-a", "cb-t8a", test_scope()));
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_b, "exe-t8-b", "cb-t8b", test_scope()));
+
+    // First request from PEER_A consumes the per-IP slot (capacity = 1).
+    let resp_first = harness
+        .app
+        .clone()
+        .oneshot(resume_post(bearer_a, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_first.status(),
+        StatusCode::ACCEPTED,
+        "first request must pass per-IP RL"
+    );
+
+    // Second request from the SAME IP must be rate-limited.
+    let resp_second = harness
+        .app
+        .oneshot(resume_post(bearer_b, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "second request from same IP must be 429"
+    );
+    assert!(
+        resp_second.headers().contains_key("retry-after"),
+        "per-IP 429 must include Retry-After header"
+    );
+
+    // Only the first request reached the store; the second was blocked pre-DB.
+    assert_eq!(
+        harness.control_queue.snapshot().len(),
+        1,
+        "only first request must have enqueued a Resume (second was IP-RL blocked)"
+    );
+}
+
+/// Test 9 — Global rate-limit fires BEFORE the DB store is touched.
+///
+/// Saturate the global bucket (capacity 1) with one request from PEER_A, then
+/// assert a request from a DIFFERENT IP (PEER_B) is still blocked globally.
+#[tokio::test]
+async fn global_rate_limit_429_before_db_hit() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_tight_global_rate_limit(clock)).await;
+
+    let bearer_a = "resume-bearer-t9-global-rl-first";
+    let bearer_b = "resume-bearer-t9-global-rl-second";
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_a, "exe-t9-a", "cb-t9a", test_scope()));
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_b, "exe-t9-b", "cb-t9b", test_scope()));
+
+    // First request (any peer) consumes the global slot.
+    let resp_first = harness
+        .app
+        .clone()
+        .oneshot(resume_post(bearer_a, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_first.status(),
+        StatusCode::ACCEPTED,
+        "first request must pass global RL"
+    );
+
+    // Second request from a DIFFERENT peer is still globally rate-limited.
+    let resp_second = harness
+        .app
+        .oneshot(resume_post(bearer_b, PEER_B))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "second request must be blocked by global RL even from a different IP"
+    );
+    assert!(
+        resp_second.headers().contains_key("retry-after"),
+        "global 429 must include Retry-After header"
+    );
+
+    assert_eq!(
+        harness.control_queue.snapshot().len(),
+        1,
+        "only first request must have enqueued a Resume"
+    );
+}
+
+/// Test 10 — Per-tenant rate-limit fires AFTER consume (token already burned).
+///
+/// This is documented behavior: once `store.consume()` succeeds and the row
+/// is deleted, the token cannot be "un-burned" even if per-tenant RL fires.
+/// The test asserts the 429 + `Retry-After` and that only ONE Resume was
+/// enqueued (from the first request that passed the tenant RL).
+#[tokio::test]
+async fn per_tenant_rate_limit_429_post_consume_token_burned() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_tight_tenant_rate_limit(clock)).await;
+
+    let bearer_a = "resume-bearer-t10-tenant-rl-first";
+    let bearer_b = "resume-bearer-t10-tenant-rl-second";
+    // Both rows share the same scope → same tenant rate-limit key.
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_a, "exe-t10-a", "cb-t10a", test_scope()));
+    harness
+        .token_store
+        .seed_for_test(webhook_row(bearer_b, "exe-t10-b", "cb-t10b", test_scope()));
+
+    // First request passes per-tenant RL and saturates its slot (capacity = 1).
+    let resp_first = harness
+        .app
+        .clone()
+        .oneshot(resume_post(bearer_a, PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_first.status(),
+        StatusCode::ACCEPTED,
+        "first request must pass tenant RL"
+    );
+
+    // Second request from a different peer but same tenant is rate-limited post-consume.
+    let resp_second = harness
+        .app
+        .oneshot(resume_post(bearer_b, PEER_B))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_second.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "second same-tenant request must be 429 (post-consume)"
+    );
+    assert!(
+        resp_second.headers().contains_key("retry-after"),
+        "tenant 429 must include Retry-After header"
+    );
+
+    // The first request's Resume was enqueued; the second was blocked after consume.
+    assert_eq!(harness.control_queue.snapshot().len(), 1);
+}
+
+/// Test 11 — No token-in-URL route: `GET /resume/{token}` must not return 200.
+///
+/// A path-parameter route `/resume/{token}` would be an existence oracle (the
+/// token appears in server logs, CDN caches, referrer headers).  We assert no
+/// such route exists in the router.
+#[tokio::test]
+async fn no_token_in_url_path_route_exists() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    let peer_addr: SocketAddr = PEER_A.parse().unwrap();
+    let get_with_path_param = Request::builder()
+        .method("GET")
+        .uri("/resume/some-secret-token-in-the-url")
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = harness.app.oneshot(get_with_path_param).await.unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "GET /resume/{{token}} must not return 200 — no path-parameter route must exist"
+    );
+}
+
+/// Test 12 — Storage error on `consume` → 503 + `Retry-After`, ZERO enqueues.
+///
+/// When the token store returns `Err` on `consume`, the token was NOT consumed
+/// (the store never deleted it), so the caller can retry.  The handler must
+/// return 503 with `Retry-After` and must not enqueue anything.
+#[tokio::test]
+async fn storage_error_returns_503_retry_after_no_enqueue() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_failing_store_harness(components_with_clock(clock)).await;
+
+    let resp = harness
+        .app
+        .oneshot(resume_post("any-bearer-does-not-matter", PEER_A))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "store error must return 503"
+    );
+    assert!(
+        resp.headers().contains_key("retry-after"),
+        "503 on storage error must include Retry-After header"
+    );
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "no ControlMsg must be enqueued when the store returns an error"
+    );
+}
+
+/// Test 13 — Body is inert: extra JSON ignored; oversized body → 413 before store hit.
+///
+/// Two sub-cases:
+/// - 13a: a valid bearer with an attacker-injected body claiming a different
+///        `execution_id` and `scope` — the enqueued msg must reflect ONLY the row.
+/// - 13b: a 5 KiB body (exceeding the 4 KiB cap) — returns 413 before any store hit.
+#[tokio::test]
+async fn body_inert_extra_json_ignored_oversized_body_413() {
+    // ── 13a: valid bearer + attacker-injected body ────────────────────────────
+    let clock_a = Arc::new(MockClock::at_now());
+    let harness_a = build_resume_harness(components_with_clock(clock_a)).await;
+
+    let bearer = "resume-bearer-t13-body-inert";
+    harness_a
+        .token_store
+        .seed_for_test(webhook_row(bearer, "exe-t13", "cb-t13", test_scope()));
+
+    let attacker_body = r#"{"execution_id":"attacker-injected-id","scope":"attacker-scope"}"#;
+    let resp_a = harness_a
+        .app
+        .oneshot(resume_post_with_body(bearer, PEER_A, attacker_body))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp_a.status(),
+        StatusCode::ACCEPTED,
+        "valid bearer with extra body must still return 202"
+    );
+
+    let queued = harness_a.control_queue.snapshot();
+    assert_eq!(queued.len(), 1);
+    let (enqueued_msg, _) = &queued[0];
+    assert_eq!(
+        enqueued_msg.execution_id, "exe-t13",
+        "execution_id must come from the token row, not the request body"
+    );
+    assert_eq!(
+        enqueued_msg.scope,
+        test_scope(),
+        "scope must come from the token row, not the request body"
+    );
+
+    // ── 13b: oversized body → 413 before any store hit ───────────────────────
+    let clock_b = Arc::new(MockClock::at_now());
+    let harness_b = build_resume_harness(components_with_clock(clock_b)).await;
+
+    let peer_addr: SocketAddr = PEER_A.parse().unwrap();
+    let oversized_body = "x".repeat(5 * 1024); // 5 KiB > 4 KiB cap
+    let oversized_request = Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .header("Authorization", "Bearer would-be-a-real-token-t13b")
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::from(oversized_body))
+        .unwrap();
+
+    let resp_b = harness_b.app.oneshot(oversized_request).await.unwrap();
+    assert_eq!(
+        resp_b.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "oversized body must return 413"
+    );
+    assert!(
+        harness_b.control_queue.snapshot().is_empty(),
+        "oversized body must not trigger any store hit or ControlMsg enqueue"
+    );
+}
+
+/// Test 14 — Bearer-extraction uniformity: missing header / `Basic` scheme / empty
+/// token all return the same uniform 404 (never 401 — no auth-revealing status).
+#[tokio::test]
+async fn bearer_extraction_uniformity_all_variants_return_404() {
+    let clock = Arc::new(MockClock::at_now());
+    let harness = build_resume_harness(components_with_clock(clock)).await;
+
+    // 14a — no Authorization header at all.
+    let resp_no_header = harness
+        .app
+        .clone()
+        .oneshot(resume_post_no_auth(PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_no_header.status(),
+        StatusCode::NOT_FOUND,
+        "missing Authorization header must return 404, not 401"
+    );
+
+    // 14b — wrong scheme (`Basic`).
+    let resp_basic = harness
+        .app
+        .clone()
+        .oneshot(resume_post_basic_scheme(PEER_A))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_basic.status(),
+        StatusCode::NOT_FOUND,
+        "Basic-scheme Authorization must return 404, not 401"
+    );
+
+    // 14c — `Bearer ` prefix with an empty token value.
+    let peer_addr: SocketAddr = PEER_A.parse().unwrap();
+    let empty_bearer_request = Request::builder()
+        .method("POST")
+        .uri("/resume")
+        .header("Authorization", "Bearer ")
+        .extension(ConnectInfo(peer_addr))
+        .body(Body::empty())
+        .unwrap();
+    let resp_empty = harness.app.oneshot(empty_bearer_request).await.unwrap();
+    assert_eq!(
+        resp_empty.status(),
+        StatusCode::NOT_FOUND,
+        "empty Bearer token must return 404"
+    );
+
+    // No enqueues from any of the three bearer-extraction failure paths.
+    assert!(
+        harness.control_queue.snapshot().is_empty(),
+        "no ControlMsg must be enqueued from bearer-extraction failures"
+    );
+}

--- a/crates/storage-port/src/store/mod.rs
+++ b/crates/storage-port/src/store/mod.rs
@@ -15,6 +15,7 @@ mod job_dispatch;
 mod journal;
 mod node_result;
 mod refresh_claim;
+mod resume_producer;
 mod resume_token;
 mod trigger_dedup;
 mod webhook;
@@ -35,6 +36,7 @@ pub use refresh_claim::{
     ClaimAttempt, ClaimToken, HeartbeatError, ReclaimedClaim, RefreshClaim, RefreshClaimError,
     RefreshClaimStore, ReplicaId, SentinelState,
 };
+pub use resume_producer::ResumeProducer;
 pub use resume_token::ResumeTokenStore;
 pub use trigger_dedup::TriggerDedupInbox;
 pub use webhook::WebhookActivationStore;

--- a/crates/storage-port/src/store/resume_producer.rs
+++ b/crates/storage-port/src/store/resume_producer.rs
@@ -1,0 +1,83 @@
+//! Resume-producer port — atomic single-use consume + Resume-enqueue.
+//!
+//! [`ResumeTokenStore::consume`](crate::store::ResumeTokenStore::consume) burns
+//! a resume token (atomic `DELETE … RETURNING`) but cannot, in the same
+//! transaction, enqueue the `Resume` it authorises. A `POST /resume` handler
+//! that consumes-then-enqueues across two statements has a durability gap: if
+//! the enqueue fails after the token is burned, the token is gone and no
+//! `Resume` exists — the caller retries, the now-absent token yields a `404`,
+//! and a `timeout: None` webhook wait parks `Paused` forever.
+//!
+//! [`ResumeProducer`] closes that gap. `consume_and_enqueue_resume` deletes the
+//! token row and inserts the `Resume` control message in ONE transaction: the
+//! `DELETE … RETURNING` (rows-affected == 1) is the single-use replay gate, and
+//! the enqueue rides the same commit, so either both land or neither does. A
+//! transient backend fault rolls the transaction back, leaving the token live
+//! for the caller's retry.
+//!
+//! [`ResumeProducer::peek`] is the read-only lookup the handler uses BEFORE the
+//! burn — to reject wrong-kind / expired tokens (and surface storage faults as
+//! `503`) without consuming the token.
+//!
+//! See ADR-0099 W-S3d.
+use crate::dto::ControlMsg;
+use crate::dto::resume_token::{ResumeTokenRow, TokenHash};
+use crate::error::StorageError;
+
+/// Atomic consume + Resume-enqueue for the `POST /resume` producer.
+///
+/// Object-safe — consumed as `Arc<dyn ResumeProducer>`. Backed by the same
+/// pool / shared state as [`crate::store::ExecutionStore`] and
+/// [`crate::store::ControlQueue`] so the token DELETE and the control-queue
+/// INSERT commit in one transaction.
+#[async_trait::async_trait]
+pub trait ResumeProducer: Send + Sync + std::fmt::Debug {
+    /// Read-only lookup by hash — does NOT delete the row.
+    ///
+    /// Returns the row if a token with `token_hash` is present, else `None`.
+    /// The caller inspects `wait_kind` / `expires_at` and surfaces a storage
+    /// `Err` as `503` (token NOT burned) before deciding to consume.
+    ///
+    /// **Security note — no `scope` parameter by design:** scope is read FROM
+    /// the returned row (the same confused-deputy boundary as
+    /// [`crate::store::ResumeTokenStore::consume`]). Possession of the 256-bit
+    /// secret is the only authority; the caller cannot forge a foreign scope
+    /// because the hash itself is the only lookup key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] on a backend failure. `None` is NOT an error —
+    /// it means the token does not exist or was already consumed.
+    async fn peek(&self, token_hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError>;
+
+    /// Atomic single-use consume + Resume-enqueue in ONE transaction.
+    ///
+    /// Deletes the token row for `token_hash`; IFF exactly one row is deleted,
+    /// inserts `resume_msg` into the control queue and commits. The
+    /// `DELETE … RETURNING` (rows-affected == 1) IS the single-use replay gate:
+    /// a second call with the same hash deletes zero rows and returns
+    /// `Ok(false)` without enqueuing.
+    ///
+    /// Returns:
+    /// - `Ok(true)` — row deleted AND `Resume` enqueued (caller → `202`).
+    /// - `Ok(false)` — zero rows deleted; raced, replayed, or absent
+    ///   (caller → uniform `404`).
+    ///
+    /// On any backend fault the transaction is rolled back: the token row is
+    /// left intact (live for retry) and no `Resume` is enqueued. This is the
+    /// durability invariant the two-statement consume-then-enqueue lacked.
+    ///
+    /// `resume_msg` is built by the caller and passed in pre-formed; its
+    /// `scope` MUST be the row's scope (never request-derived) and its
+    /// `command` MUST be [`crate::dto::ControlCommand::Resume`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] on a backend failure (the transaction is rolled
+    /// back; the token survives).
+    async fn consume_and_enqueue_resume(
+        &self,
+        token_hash: &TokenHash,
+        resume_msg: &ControlMsg,
+    ) -> Result<bool, StorageError>;
+}

--- a/crates/storage/src/inmem/execution.rs
+++ b/crates/storage/src/inmem/execution.rs
@@ -117,6 +117,15 @@ impl InMemoryExecutionStore {
     pub fn resume_token_store(&self) -> super::resume_token::InMemoryResumeTokenStore {
         super::resume_token::InMemoryResumeTokenStore::new(Arc::clone(&self.inner))
     }
+
+    /// Build a [`super::resume_producer::InMemoryResumeProducer`] backed by
+    /// this store's shared state so the token DELETE and the control-queue
+    /// INSERT in `consume_and_enqueue_resume` happen under the same mutex
+    /// (W-S3d single-lock atomicity invariant).
+    #[must_use]
+    pub fn resume_producer(&self) -> super::resume_producer::InMemoryResumeProducer {
+        super::resume_producer::InMemoryResumeProducer::new(Arc::clone(&self.inner))
+    }
 }
 
 /// Clamp the lease TTL to a sane range (mirrors the legacy repo: ≥1s,

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -15,6 +15,7 @@ mod identity;
 mod job_dispatch;
 mod journal;
 mod node_result;
+mod resume_producer;
 mod resume_token;
 mod workflow;
 
@@ -29,5 +30,6 @@ pub use identity::{
 pub use job_dispatch::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox};
 pub use journal::InMemoryJournalReader;
 pub use node_result::{InMemoryCheckpointStore, InMemoryNodeResultStore};
+pub use resume_producer::InMemoryResumeProducer;
 pub use resume_token::InMemoryResumeTokenStore;
 pub use workflow::{InMemoryWorkflowStore, InMemoryWorkflowVersionStore};

--- a/crates/storage/src/inmem/resume_producer.rs
+++ b/crates/storage/src/inmem/resume_producer.rs
@@ -1,0 +1,97 @@
+//! In-memory [`ResumeProducer`] implementation (ADR-0099 W-S3d, Option B1).
+//!
+//! Shares the single [`super::execution::SharedState`] mutex that holds BOTH
+//! the resume-token map and the control queue, so `consume_and_enqueue_resume`
+//! removes the token and inserts the `Resume` row under ONE lock — the
+//! in-memory analogue of the SQL backends' single transaction. There is no
+//! window where a token is burned but the `Resume` is missing.
+
+use nebula_storage_port::StorageError;
+use nebula_storage_port::dto::resume_token::{ResumeTokenRow, TokenHash};
+use nebula_storage_port::dto::{ControlCommand, ControlMsg};
+use nebula_storage_port::store::ResumeProducer;
+use subtle::ConstantTimeEq;
+
+use super::execution::{QueuedMsg, SharedState};
+
+/// In-memory resume producer.
+///
+/// Wraps the same `SharedState` as [`super::InMemoryExecutionStore`] and
+/// [`super::InMemoryControlQueue`], so the token DELETE and control-queue
+/// INSERT happen under one lock (single-lock atomicity invariant).
+///
+/// Wrap with `Arc` at the composition root.
+#[derive(Debug, Clone)]
+pub struct InMemoryResumeProducer {
+    inner: SharedState,
+}
+
+impl InMemoryResumeProducer {
+    /// Construct a producer backed by the given shared state.
+    ///
+    /// Pass the same `SharedState` used by the `InMemoryExecutionStore` so the
+    /// token map (read/removed here) and the control queue (written here) are
+    /// the ones the rest of the process observes.
+    #[must_use]
+    pub(super) fn new(inner: SharedState) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl ResumeProducer for InMemoryResumeProducer {
+    async fn peek(&self, token_hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
+        let guard = self.inner.lock();
+        let target = token_hash.as_bytes();
+        // Best-effort constant-time key scan (defence-in-depth, parity with
+        // `InMemoryResumeTokenStore::consume`); the map lookup is the
+        // correctness primitive.
+        let matching = guard
+            .resume_tokens
+            .iter()
+            .find(|(key, _)| bool::from(key.as_slice().ct_eq(target)))
+            .map(|(_, row)| row.clone());
+        Ok(matching)
+    }
+
+    async fn consume_and_enqueue_resume(
+        &self,
+        token_hash: &TokenHash,
+        resume_msg: &ControlMsg,
+    ) -> Result<bool, StorageError> {
+        let mut guard = self.inner.lock();
+        let target = token_hash.as_bytes();
+        let matching_key: Option<Vec<u8>> = guard
+            .resume_tokens
+            .keys()
+            .find(|key| bool::from(key.as_slice().ct_eq(target)))
+            .cloned();
+
+        let Some(key) = matching_key else {
+            // Zero rows removed — raced / replayed / absent. No enqueue.
+            return Ok(false);
+        };
+
+        // Single-use gate: remove the token, then enqueue under the SAME lock.
+        guard.resume_tokens.remove(&key);
+        // Byte-identical to `InMemoryControlQueue::enqueue` so a `Resume`
+        // produced here is indistinguishable from one minted via a commit.
+        guard.queue.insert(
+            resume_msg.id,
+            QueuedMsg {
+                msg: resume_msg.clone(),
+                status: "Pending".to_string(),
+                processed_by: None,
+                processed_at: None,
+                reclaim_count: 0,
+                error_message: None,
+            },
+        );
+        debug_assert_eq!(
+            resume_msg.command,
+            ControlCommand::Resume,
+            "ResumeProducer must only enqueue Resume commands"
+        );
+        Ok(true)
+    }
+}

--- a/crates/storage/src/inmem/resume_producer.rs
+++ b/crates/storage/src/inmem/resume_producer.rs
@@ -59,6 +59,15 @@ impl ResumeProducer for InMemoryResumeProducer {
         token_hash: &TokenHash,
         resume_msg: &ControlMsg,
     ) -> Result<bool, StorageError> {
+        // Fail-closed at the boundary: this producer enqueues ONLY `Resume`.
+        // Checked BEFORE taking the lock or mutating, and release-enforced
+        // (unlike a `debug_assert!`), so a misused command can never burn a token.
+        if resume_msg.command != ControlCommand::Resume {
+            return Err(StorageError::Internal(
+                "ResumeProducer requires a Resume command".to_owned(),
+            ));
+        }
+
         let mut guard = self.inner.lock();
         let target = token_hash.as_bytes();
         let matching_key: Option<Vec<u8>> = guard
@@ -86,11 +95,6 @@ impl ResumeProducer for InMemoryResumeProducer {
                 reclaim_count: 0,
                 error_message: None,
             },
-        );
-        debug_assert_eq!(
-            resume_msg.command,
-            ControlCommand::Resume,
-            "ResumeProducer must only enqueue Resume commands"
         );
         Ok(true)
     }

--- a/crates/storage/src/inmem/resume_token.rs
+++ b/crates/storage/src/inmem/resume_token.rs
@@ -58,6 +58,21 @@ impl InMemoryResumeTokenStore {
             inner: Arc::new(Mutex::new(State::default())),
         }
     }
+
+    /// Insert a row directly into the token map.
+    ///
+    /// Test-only seeding helper: bypasses the `TransitionBatch` path so
+    /// integration tests can seed token rows without wiring a full
+    /// `InMemoryExecutionStore` + `commit` cycle.  The row is inserted
+    /// under its `token_hash` key, exactly as production `commit` does.
+    ///
+    /// Mirrors the spirit of [`super::control_queue::InMemoryControlQueue::snapshot`]
+    /// (always `pub` on a dev-only adapter) — not gated by `cfg(test)` so
+    /// it is reachable from integration tests in sibling crates.
+    pub fn seed_for_test(&self, row: ResumeTokenRow) {
+        let key = row.token_hash.as_bytes().to_vec();
+        self.inner.lock().resume_tokens.insert(key, row);
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -104,6 +104,6 @@ pub use format::StorageFormat;
 pub use inmem::{
     InMemoryCheckpointStore, InMemoryControlQueue, InMemoryExecutionStore,
     InMemoryIdempotencyGuard, InMemoryIdempotencyStore, InMemoryJournalReader,
-    InMemoryNodeResultStore, InMemoryResumeTokenStore, InMemoryWebhookActivationStore,
-    InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
+    InMemoryNodeResultStore, InMemoryResumeProducer, InMemoryResumeTokenStore,
+    InMemoryWebhookActivationStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
 };

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -16,6 +16,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod resume_producer;
 mod resume_token;
 mod workflow;
 
@@ -27,6 +28,7 @@ pub use identity::{
     PgTriggerStore, PgUserStore, PgWorkspaceStore,
 };
 pub use job_dispatch::{PgJobDispatchQueue, PgTriggerDedupInbox};
+pub use resume_producer::PgResumeProducer;
 pub use resume_token::PgResumeTokenStore;
 pub use workflow::{PgWorkflowStore, PgWorkflowVersionStore};
 

--- a/crates/storage/src/postgres/resume_producer.rs
+++ b/crates/storage/src/postgres/resume_producer.rs
@@ -1,0 +1,160 @@
+//! PostgreSQL [`ResumeProducer`] implementation (ADR-0099 W-S3d, Option B1).
+//!
+//! `peek` is a read-only `SELECT … WHERE token_hash = $1` — no delete.
+//!
+//! `consume_and_enqueue_resume` runs the token DELETE and the control-queue
+//! INSERT in ONE transaction. `DELETE … RETURNING token_hash` is the
+//! single-use replay gate (the row lock the DELETE takes serialises
+//! concurrent consumers, so READ COMMITTED suffices — only one transaction
+//! deletes the row); zero rows deleted → `Ok(false)`, rollback. On exactly one
+//! deleted row the `Resume` control message is inserted with bindings
+//! byte-identical to the execution-store outbox append, and the tx commits. A
+//! transient fault rolls back, leaving the token live for retry.
+
+use chrono::{DateTime, Utc};
+use nebula_storage_port::Scope;
+use nebula_storage_port::StorageError;
+use nebula_storage_port::dto::resume_token::{
+    ResumeTokenRow, ResumeTokenWaitKind, TokenHash, TokenHashLengthError,
+};
+use nebula_storage_port::dto::{ControlCommand, ControlMsg};
+use nebula_storage_port::store::ResumeProducer;
+use sqlx::{PgPool, Row};
+
+fn conn_err(e: impl std::fmt::Display) -> StorageError {
+    StorageError::Connection(e.to_string())
+}
+
+fn deserialize_wait_kind(raw: &str) -> Result<ResumeTokenWaitKind, StorageError> {
+    serde_json::from_str(&format!("\"{raw}\""))
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+/// Reconstruct a [`ResumeTokenRow`] from a token-table row.
+///
+/// Postgres stores `created_at`/`expires_at` as `TIMESTAMPTZ`; they are read
+/// as [`DateTime<Utc>`] and rendered back to RFC-3339 to match the DTO's
+/// string shape (mirrors `postgres::resume_token`).
+fn row_from_token_columns(row: &sqlx::postgres::PgRow) -> Result<ResumeTokenRow, StorageError> {
+    let raw_hash: Vec<u8> = row.try_get("token_hash").map_err(conn_err)?;
+    let hash = TokenHash::try_from_bytes(raw_hash).map_err(|e: TokenHashLengthError| {
+        StorageError::Internal(format!("persisted token_hash bad length: {e}"))
+    })?;
+    let wait_kind_str: String = row.try_get("wait_kind").map_err(conn_err)?;
+    let wait_kind = deserialize_wait_kind(&wait_kind_str)?;
+    let created_at: DateTime<Utc> = row.try_get("created_at").map_err(conn_err)?;
+    let expires_at: Option<DateTime<Utc>> = row.try_get("expires_at").map_err(conn_err)?;
+    let scope = Scope {
+        workspace_id: row.try_get("workspace_id").map_err(conn_err)?,
+        org_id: row.try_get("org_id").map_err(conn_err)?,
+    };
+    Ok(ResumeTokenRow::new(
+        hash,
+        scope,
+        row.try_get("execution_id").map_err(conn_err)?,
+        row.try_get("node_key").map_err(conn_err)?,
+        wait_kind,
+        row.try_get("callback_label").map_err(conn_err)?,
+        created_at.to_rfc3339(),
+        expires_at.map(|dt| dt.to_rfc3339()),
+    ))
+}
+
+/// PostgreSQL-backed resume producer.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`] (the same
+/// pool the execution store and control queue use, so the DELETE and INSERT
+/// share one transaction).
+#[derive(Clone, Debug)]
+pub struct PgResumeProducer {
+    pool: PgPool,
+}
+
+impl PgResumeProducer {
+    /// Wrap an existing pool. The caller installs the port schema.
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl ResumeProducer for PgResumeProducer {
+    async fn peek(&self, token_hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
+        let row = sqlx::query(
+            "SELECT token_hash, workspace_id, org_id, execution_id, \
+                    node_key, wait_kind, callback_label, created_at, expires_at \
+             FROM port_resume_tokens \
+             WHERE token_hash = $1",
+        )
+        .bind(token_hash.as_bytes())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(conn_err)?;
+
+        match row {
+            None => Ok(None),
+            Some(row) => Ok(Some(row_from_token_columns(&row)?)),
+        }
+    }
+
+    async fn consume_and_enqueue_resume(
+        &self,
+        token_hash: &TokenHash,
+        resume_msg: &ControlMsg,
+    ) -> Result<bool, StorageError> {
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+
+        // `DELETE … RETURNING` (rows-affected == 1) IS the single-use replay
+        // gate: a raced/replayed/absent hash deletes zero rows. The DELETE's
+        // row lock serialises concurrent consumers — only one tx wins.
+        let deleted = sqlx::query(
+            "DELETE FROM port_resume_tokens \
+             WHERE token_hash = $1 \
+             RETURNING token_hash",
+        )
+        .bind(token_hash.as_bytes())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        if deleted.is_none() {
+            tx.rollback().await.map_err(conn_err)?;
+            return Ok(false);
+        }
+
+        // Exactly one row deleted — enqueue the Resume in the SAME transaction.
+        // Bindings byte-identical to the execution-store outbox append.
+        let resume_target_json: Option<String> = resume_msg
+            .resume_target
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        sqlx::query(
+            "INSERT INTO port_control_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              w3c_traceparent, reclaim_count, resume_target) \
+             VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8)",
+        )
+        .bind(resume_msg.id.as_slice())
+        .bind(&resume_msg.execution_id)
+        .bind(&resume_msg.scope.workspace_id)
+        .bind(&resume_msg.scope.org_id)
+        .bind(resume_msg.command.as_str())
+        .bind(resume_msg.w3c_traceparent.as_deref())
+        .bind(i32::try_from(resume_msg.reclaim_count).unwrap_or(i32::MAX))
+        .bind(resume_target_json)
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        tx.commit().await.map_err(conn_err)?;
+        debug_assert_eq!(
+            resume_msg.command,
+            ControlCommand::Resume,
+            "ResumeProducer must only enqueue Resume commands"
+        );
+        Ok(true)
+    }
+}

--- a/crates/storage/src/postgres/resume_producer.rs
+++ b/crates/storage/src/postgres/resume_producer.rs
@@ -103,6 +103,15 @@ impl ResumeProducer for PgResumeProducer {
         token_hash: &TokenHash,
         resume_msg: &ControlMsg,
     ) -> Result<bool, StorageError> {
+        // Fail-closed at the boundary: this producer enqueues ONLY `Resume`.
+        // Checked BEFORE any mutation and release-enforced (unlike a
+        // `debug_assert!`), so a misused command can never burn a token.
+        if resume_msg.command != ControlCommand::Resume {
+            return Err(StorageError::Internal(
+                "ResumeProducer requires a Resume command".to_owned(),
+            ));
+        }
+
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         // `DELETE … RETURNING` (rows-affected == 1) IS the single-use replay
@@ -150,11 +159,6 @@ impl ResumeProducer for PgResumeProducer {
         .map_err(conn_err)?;
 
         tx.commit().await.map_err(conn_err)?;
-        debug_assert_eq!(
-            resume_msg.command,
-            ControlCommand::Resume,
-            "ResumeProducer must only enqueue Resume commands"
-        );
         Ok(true)
     }
 }

--- a/crates/storage/src/sqlite/mod.rs
+++ b/crates/storage/src/sqlite/mod.rs
@@ -17,6 +17,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod resume_producer;
 mod resume_token;
 mod workflow;
 
@@ -28,6 +29,7 @@ pub use identity::{
     SqliteResourceStore, SqliteTriggerStore, SqliteUserStore, SqliteWorkspaceStore,
 };
 pub use job_dispatch::{SqliteJobDispatchQueue, SqliteTriggerDedupInbox};
+pub use resume_producer::SqliteResumeProducer;
 pub use resume_token::SqliteResumeTokenStore;
 pub use workflow::{SqliteWorkflowStore, SqliteWorkflowVersionStore};
 

--- a/crates/storage/src/sqlite/resume_producer.rs
+++ b/crates/storage/src/sqlite/resume_producer.rs
@@ -1,0 +1,160 @@
+//! SQLite [`ResumeProducer`] implementation (ADR-0099 W-S3d, Option B1).
+//!
+//! `peek` is a read-only `SELECT … WHERE token_hash = ?` — no delete.
+//!
+//! `consume_and_enqueue_resume` runs the token DELETE and the control-queue
+//! INSERT in ONE transaction: `BEGIN IMMEDIATE` takes the write lock up front
+//! (same single-writer contract as [`super::execution::SqliteExecutionStore`]),
+//! `DELETE … RETURNING token_hash` is the single-use replay gate (zero rows
+//! deleted → `Ok(false)`, rollback), and on exactly one deleted row the
+//! `Resume` control message is inserted with bindings byte-identical to the
+//! execution-store outbox append. A transient fault rolls the tx back, leaving
+//! the token live for the caller's retry — the durability gap the prior
+//! consume-then-enqueue handler had.
+
+use nebula_storage_port::Scope;
+use nebula_storage_port::StorageError;
+use nebula_storage_port::dto::resume_token::{
+    ResumeTokenRow, ResumeTokenWaitKind, TokenHash, TokenHashLengthError,
+};
+use nebula_storage_port::dto::{ControlCommand, ControlMsg};
+use nebula_storage_port::store::ResumeProducer;
+use sqlx::{Row, SqlitePool};
+
+fn conn_err(e: impl std::fmt::Display) -> StorageError {
+    StorageError::Connection(e.to_string())
+}
+
+fn deserialize_wait_kind(raw: &str) -> Result<ResumeTokenWaitKind, StorageError> {
+    serde_json::from_str(&format!("\"{raw}\""))
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+/// Reconstruct a [`ResumeTokenRow`] from a token-table row.
+///
+/// Shared by `peek` and the consume path so the column mapping lives once.
+fn row_from_token_columns(row: &sqlx::sqlite::SqliteRow) -> Result<ResumeTokenRow, StorageError> {
+    let raw_hash: Vec<u8> = row.try_get("token_hash").map_err(conn_err)?;
+    let hash = TokenHash::try_from_bytes(raw_hash).map_err(|e: TokenHashLengthError| {
+        StorageError::Internal(format!("persisted token_hash bad length: {e}"))
+    })?;
+    let wait_kind_str: String = row.try_get("wait_kind").map_err(conn_err)?;
+    let wait_kind = deserialize_wait_kind(&wait_kind_str)?;
+    let scope = Scope {
+        workspace_id: row.try_get("workspace_id").map_err(conn_err)?,
+        org_id: row.try_get("org_id").map_err(conn_err)?,
+    };
+    Ok(ResumeTokenRow::new(
+        hash,
+        scope,
+        row.try_get("execution_id").map_err(conn_err)?,
+        row.try_get("node_key").map_err(conn_err)?,
+        wait_kind,
+        row.try_get("callback_label").map_err(conn_err)?,
+        row.try_get("created_at").map_err(conn_err)?,
+        row.try_get("expires_at").map_err(conn_err)?,
+    ))
+}
+
+/// SQLite-backed resume producer.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`] (the same
+/// pool the execution store and control queue use, so the DELETE and INSERT
+/// share one connection/transaction).
+#[derive(Clone, Debug)]
+pub struct SqliteResumeProducer {
+    pool: SqlitePool,
+}
+
+impl SqliteResumeProducer {
+    /// Wrap an existing pool. The caller installs the port schema.
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl ResumeProducer for SqliteResumeProducer {
+    async fn peek(&self, token_hash: &TokenHash) -> Result<Option<ResumeTokenRow>, StorageError> {
+        let row = sqlx::query(
+            "SELECT token_hash, workspace_id, org_id, execution_id, \
+                    node_key, wait_kind, callback_label, created_at, expires_at \
+             FROM port_resume_tokens \
+             WHERE token_hash = ?",
+        )
+        .bind(token_hash.as_bytes())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(conn_err)?;
+
+        match row {
+            None => Ok(None),
+            Some(row) => Ok(Some(row_from_token_columns(&row)?)),
+        }
+    }
+
+    async fn consume_and_enqueue_resume(
+        &self,
+        token_hash: &TokenHash,
+        resume_msg: &ControlMsg,
+    ) -> Result<bool, StorageError> {
+        // BEGIN IMMEDIATE takes the write lock up front so the DELETE + INSERT
+        // pair is atomic against the single writer (spec §5 SQLite contract;
+        // mirrors `SqliteExecutionStore::commit`).
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *tx).await.ok(); // sqlx already opened a tx; the hint is best-effort.
+
+        // `DELETE … RETURNING` (rows-affected == 1) IS the single-use replay
+        // gate: a raced/replayed/absent hash deletes zero rows.
+        let deleted = sqlx::query(
+            "DELETE FROM port_resume_tokens \
+             WHERE token_hash = ? \
+             RETURNING token_hash",
+        )
+        .bind(token_hash.as_bytes())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        if deleted.is_none() {
+            // Zero rows deleted — nothing to enqueue. Roll back the empty tx.
+            tx.rollback().await.map_err(conn_err)?;
+            return Ok(false);
+        }
+
+        // Exactly one row deleted — enqueue the Resume in the SAME transaction.
+        // Bindings byte-identical to the execution-store outbox append.
+        let resume_target_json: Option<String> = resume_msg
+            .resume_target
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        sqlx::query(
+            "INSERT INTO port_control_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              w3c_traceparent, reclaim_count, resume_target) \
+             VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?)",
+        )
+        .bind(resume_msg.id.as_slice())
+        .bind(&resume_msg.execution_id)
+        .bind(&resume_msg.scope.workspace_id)
+        .bind(&resume_msg.scope.org_id)
+        .bind(resume_msg.command.as_str())
+        .bind(resume_msg.w3c_traceparent.as_deref())
+        .bind(i64::from(resume_msg.reclaim_count))
+        .bind(resume_target_json)
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        tx.commit().await.map_err(conn_err)?;
+        debug_assert_eq!(
+            resume_msg.command,
+            ControlCommand::Resume,
+            "ResumeProducer must only enqueue Resume commands"
+        );
+        Ok(true)
+    }
+}

--- a/crates/storage/src/sqlite/resume_producer.rs
+++ b/crates/storage/src/sqlite/resume_producer.rs
@@ -99,6 +99,15 @@ impl ResumeProducer for SqliteResumeProducer {
         token_hash: &TokenHash,
         resume_msg: &ControlMsg,
     ) -> Result<bool, StorageError> {
+        // Fail-closed at the boundary: this producer enqueues ONLY `Resume`.
+        // Checked BEFORE any mutation and release-enforced (unlike a
+        // `debug_assert!`), so a misused command can never burn a token.
+        if resume_msg.command != ControlCommand::Resume {
+            return Err(StorageError::Internal(
+                "ResumeProducer requires a Resume command".to_owned(),
+            ));
+        }
+
         // BEGIN IMMEDIATE takes the write lock up front so the DELETE + INSERT
         // pair is atomic against the single writer (spec §5 SQLite contract;
         // mirrors `SqliteExecutionStore::commit`).
@@ -150,11 +159,6 @@ impl ResumeProducer for SqliteResumeProducer {
         .map_err(conn_err)?;
 
         tx.commit().await.map_err(conn_err)?;
-        debug_assert_eq!(
-            resume_msg.command,
-            ControlCommand::Resume,
-            "ResumeProducer must only enqueue Resume commands"
-        );
         Ok(true)
     }
 }

--- a/crates/storage/tests/resume_producer_inmem.rs
+++ b/crates/storage/tests/resume_producer_inmem.rs
@@ -1,0 +1,267 @@
+//! Behavioral tests for `InMemoryResumeProducer` (W-S3d, Option B1).
+//!
+//! Covers the atomic consume+enqueue seam at the storage level:
+//!  1. `peek` returns the row WITHOUT burning it (a later consume still wins).
+//!  2. `peek` returns `None` for an absent hash.
+//!  3. `consume_and_enqueue_resume` burns the token AND enqueues the Resume
+//!     under one lock (the control queue observes exactly one Pending row).
+//!  4. A second `consume_and_enqueue_resume` on the same hash returns
+//!     `Ok(false)` and enqueues nothing (single-use replay gate).
+//!  5. The producer, token store, and control queue all share one `SharedState`
+//!     (a token minted via `commit` is consumable and lands in the same queue).
+//!
+//! Tokens are minted through `ExecutionStore::commit` with a `TransitionBatch`
+//! (the production path); the producer is obtained via `resume_producer()` so
+//! the shared-mutex invariant is exercised, not bypassed.
+
+use std::time::Duration;
+
+use nebula_storage::inmem::InMemoryControlQueue;
+use nebula_storage::{InMemoryExecutionStore, InMemoryResumeProducer};
+use nebula_storage_port::dto::resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash};
+use nebula_storage_port::dto::{ControlCommand, ControlMsg, ResumeTarget};
+use nebula_storage_port::store::{ExecutionStore, ResumeProducer};
+use nebula_storage_port::{Scope, TransitionBatch, TransitionOutcome};
+
+fn test_scope() -> Scope {
+    Scope::new("test-org", "test-ws")
+}
+
+fn fill_hash(byte: u8) -> TokenHash {
+    TokenHash::try_from_bytes(vec![byte; 32])
+        .expect("32 identical bytes must be a valid 32-byte hash")
+}
+
+fn webhook_token_row(hash: TokenHash, execution_id: &str, callback_label: &str) -> ResumeTokenRow {
+    ResumeTokenRow::new(
+        hash,
+        test_scope(),
+        execution_id.to_owned(),
+        "node-a".to_owned(),
+        ResumeTokenWaitKind::Webhook,
+        callback_label.to_owned(),
+        "2026-06-21T00:00:00Z".to_owned(),
+        None,
+    )
+}
+
+/// A `Resume` `ControlMsg` for `execution_id`, targeting `callback_label`.
+fn resume_msg(execution_id: &str, callback_label: &str) -> ControlMsg {
+    ControlMsg {
+        id: *uuid::Uuid::new_v4().as_bytes(),
+        execution_id: execution_id.to_owned(),
+        command: ControlCommand::Resume,
+        scope: test_scope(),
+        w3c_traceparent: None,
+        reclaim_count: 0,
+        resume_target: Some(ResumeTarget::Webhook {
+            callback_id: callback_label.to_owned(),
+        }),
+    }
+}
+
+/// Mint `token_row` into `exec_store` via the production `commit` path.
+async fn seed_token(
+    exec_store: &InMemoryExecutionStore,
+    scope: &Scope,
+    execution_id: &str,
+    token_row: ResumeTokenRow,
+) {
+    exec_store
+        .create(
+            scope,
+            execution_id,
+            "wf-1",
+            serde_json::json!({"s": "created"}),
+        )
+        .await
+        .expect("execution row must not already exist");
+
+    let fencing_token = exec_store
+        .acquire_lease(scope, execution_id, "test-runner", Duration::from_secs(30))
+        .await
+        .expect("acquire_lease must not error")
+        .expect("fresh row must yield a fencing token");
+
+    let batch = TransitionBatch::builder()
+        .scope(scope.clone())
+        .execution_id(execution_id)
+        .expected_version(0)
+        .fencing(fencing_token)
+        .new_state(serde_json::json!({"s": "waiting"}))
+        .resume_tokens(vec![token_row])
+        .build()
+        .expect("well-formed batch must build");
+
+    let outcome = exec_store
+        .commit(batch)
+        .await
+        .expect("commit must not error");
+    assert!(
+        matches!(outcome, TransitionOutcome::Applied { .. }),
+        "batch must apply; got {outcome:?}"
+    );
+    exec_store
+        .release_lease(scope, execution_id, fencing_token)
+        .await
+        .expect("release_lease must succeed");
+}
+
+/// Test 1 — `peek` returns the row but does NOT burn it.
+#[tokio::test]
+async fn peek_returns_row_without_burning() {
+    let exec_store = InMemoryExecutionStore::new();
+    let producer = exec_store.resume_producer();
+    let token_store = exec_store.resume_token_store();
+    let scope = test_scope();
+    let hash = fill_hash(0xA1);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-peek",
+        webhook_token_row(hash.clone(), "exe-peek", "cb-peek"),
+    )
+    .await;
+
+    let peeked = producer.peek(&hash).await.expect("peek must not error");
+    let row = peeked.expect("peek must return the seeded row");
+    assert_eq!(row.execution_id, "exe-peek");
+    assert_eq!(row.callback_label, "cb-peek");
+
+    // The token survived the peek — a direct consume still finds it.
+    use nebula_storage_port::store::ResumeTokenStore;
+    let still_there = token_store
+        .consume(&hash)
+        .await
+        .expect("consume must not error");
+    assert!(
+        still_there.is_some(),
+        "peek must NOT burn the token — a consume after peek must still win"
+    );
+}
+
+/// Test 2 — `peek` returns `None` for a hash that was never inserted.
+#[tokio::test]
+async fn peek_returns_none_for_absent_hash() {
+    let exec_store = InMemoryExecutionStore::new();
+    let producer = exec_store.resume_producer();
+    let absent = producer
+        .peek(&fill_hash(0xB2))
+        .await
+        .expect("peek must not error");
+    assert!(absent.is_none(), "peek of an absent hash must return None");
+}
+
+/// Test 3 — `consume_and_enqueue_resume` burns the token AND enqueues the
+/// Resume under one lock: the shared control queue sees exactly one Pending row.
+#[tokio::test]
+async fn consume_and_enqueue_is_atomic_under_one_lock() {
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let producer = exec_store.resume_producer();
+    let scope = test_scope();
+    let hash = fill_hash(0xC3);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-atomic",
+        webhook_token_row(hash.clone(), "exe-atomic", "cb-atomic"),
+    )
+    .await;
+
+    let msg = resume_msg("exe-atomic", "cb-atomic");
+    let won = producer
+        .consume_and_enqueue_resume(&hash, &msg)
+        .await
+        .expect("consume_and_enqueue must not error");
+    assert!(won, "the only consumer must win the atomic delete");
+
+    let queued = control_queue.snapshot();
+    assert_eq!(queued.len(), 1, "exactly one Resume must be enqueued");
+    let (enqueued, status) = &queued[0];
+    assert_eq!(enqueued.command, ControlCommand::Resume);
+    assert_eq!(enqueued.execution_id, "exe-atomic");
+    assert_eq!(
+        enqueued.resume_target,
+        Some(ResumeTarget::Webhook {
+            callback_id: "cb-atomic".to_owned()
+        })
+    );
+    assert_eq!(status, "Pending");
+
+    // The token is burned — peek now returns None.
+    assert!(
+        producer
+            .peek(&hash)
+            .await
+            .expect("peek must not error")
+            .is_none(),
+        "the token must be burned after a winning consume"
+    );
+}
+
+/// Test 4 — A second `consume_and_enqueue_resume` on the same hash returns
+/// `Ok(false)` and enqueues nothing (single-use replay gate).
+#[tokio::test]
+async fn second_consume_returns_false_and_enqueues_nothing() {
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let producer = exec_store.resume_producer();
+    let scope = test_scope();
+    let hash = fill_hash(0xD4);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-replay",
+        webhook_token_row(hash.clone(), "exe-replay", "cb-replay"),
+    )
+    .await;
+
+    let first = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-replay", "cb-replay"))
+        .await
+        .expect("first consume must not error");
+    assert!(first, "first consume wins");
+
+    let second = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-replay", "cb-replay"))
+        .await
+        .expect("second consume must not error");
+    assert!(
+        !second,
+        "second consume of the same hash must return Ok(false)"
+    );
+
+    assert_eq!(
+        control_queue.snapshot().len(),
+        1,
+        "the replay must NOT enqueue a second Resume"
+    );
+}
+
+/// Test 5 — `standalone()`-style independence: a producer over a fresh exec
+/// store sees no tokens minted on a different store.
+#[tokio::test]
+async fn producer_over_separate_state_sees_no_foreign_tokens() {
+    let store_a = InMemoryExecutionStore::new();
+    let store_b = InMemoryExecutionStore::new();
+    let producer_b: InMemoryResumeProducer = store_b.resume_producer();
+    let scope = test_scope();
+    seed_token(
+        &store_a,
+        &scope,
+        "exe-iso",
+        webhook_token_row(fill_hash(0xE5), "exe-iso", "cb-iso"),
+    )
+    .await;
+
+    // Producer B is backed by store B's state, which never received the token.
+    assert!(
+        producer_b
+            .peek(&fill_hash(0xE5))
+            .await
+            .expect("peek must not error")
+            .is_none(),
+        "a producer must not see tokens minted on a different execution store"
+    );
+}

--- a/crates/storage/tests/resume_producer_inmem.rs
+++ b/crates/storage/tests/resume_producer_inmem.rs
@@ -265,3 +265,49 @@ async fn producer_over_separate_state_sees_no_foreign_tokens() {
         "a producer must not see tokens minted on a different execution store"
     );
 }
+
+/// Test 6 — a non-`Resume` command is rejected at the boundary BEFORE any
+/// mutation: the call errors, the token is NOT burned, and nothing is enqueued.
+///
+/// This is the release-enforced structural guard (replacing the prior debug-only
+/// `debug_assert!` that ran *after* the mutation): the resume producer must only
+/// ever enqueue `Resume`, and a misuse must never burn a token.
+#[tokio::test]
+async fn non_resume_command_rejected_without_burning_token() {
+    let exec_store = InMemoryExecutionStore::new();
+    let control_queue = InMemoryControlQueue::new(&exec_store);
+    let producer = exec_store.resume_producer();
+    let scope = test_scope();
+    let hash = fill_hash(0xF6);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-guard",
+        webhook_token_row(hash.clone(), "exe-guard", "cb-guard"),
+    )
+    .await;
+
+    // A `ControlMsg` carrying a non-`Resume` command.
+    let mut wrong = resume_msg("exe-guard", "cb-guard");
+    wrong.command = ControlCommand::Cancel;
+
+    let result = producer.consume_and_enqueue_resume(&hash, &wrong).await;
+    assert!(
+        result.is_err(),
+        "a non-Resume command must be rejected, not enqueued; got {result:?}"
+    );
+
+    // Boundary check fires BEFORE mutation: the token must survive.
+    assert!(
+        producer
+            .peek(&hash)
+            .await
+            .expect("peek must not error")
+            .is_some(),
+        "the token must NOT be burned when the command is rejected"
+    );
+    assert!(
+        control_queue.snapshot().is_empty(),
+        "nothing may be enqueued when the command is rejected"
+    );
+}

--- a/crates/storage/tests/resume_producer_sqlite.rs
+++ b/crates/storage/tests/resume_producer_sqlite.rs
@@ -1,0 +1,300 @@
+//! SQLite per-backend tests for `SqliteResumeProducer` (W-S3d, Option B1).
+//!
+//! These exercise the production SQL path via a real in-memory SQLite pool and
+//! prove the atomic consume+enqueue seam at the storage level:
+//!  1. `peek` returns a committed token WITHOUT burning it.
+//!  2. `consume_and_enqueue_resume` burns the token AND inserts the Resume into
+//!     `port_control_queue` in one transaction.
+//!  3. A replay returns `Ok(false)` and inserts no second Resume.
+//!  4. **Atomicity gate**: when the control INSERT fails inside the tx, the token
+//!     DELETE is rolled back — the token survives and no Resume is written.
+//!
+//! Gated on the `sqlite` feature — skips automatically without it.
+
+#![cfg(feature = "sqlite")]
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use nebula_storage::sqlite::{SqliteExecutionStore, SqliteResumeProducer, init_schema};
+use nebula_storage_port::dto::resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash};
+use nebula_storage_port::dto::{ControlCommand, ControlMsg, ResumeTarget};
+use nebula_storage_port::store::{ExecutionStore, ResumeProducer};
+use nebula_storage_port::{Scope, TransitionBatch, TransitionOutcome};
+use sqlx::Row;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+/// Create an isolated, schema-initialised in-memory SQLite pool (shared cache so
+/// the pool's connections see the same tables).
+async fn fresh_pool() -> sqlx::SqlitePool {
+    let db_name = format!("nebula-rp-test-{}", uuid::Uuid::new_v4());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let opts = SqliteConnectOptions::from_str(&url)
+        .expect("parse sqlite memory url")
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect_with(opts)
+        .await
+        .expect("connect sqlite memory");
+    init_schema(&pool)
+        .await
+        .expect("install port schema including port_resume_tokens");
+    pool
+}
+
+fn test_scope() -> Scope {
+    Scope::new("ws-sqlite-rp", "org-sqlite-rp")
+}
+
+fn fill_hash(byte: u8) -> TokenHash {
+    TokenHash::try_from_bytes(vec![byte; 32])
+        .expect("32 identical bytes must be a valid 32-byte hash")
+}
+
+fn token_row_for(hash: TokenHash, execution_id: &str, callback_label: &str) -> ResumeTokenRow {
+    ResumeTokenRow::new(
+        hash,
+        test_scope(),
+        execution_id.to_owned(),
+        "node-a".to_owned(),
+        ResumeTokenWaitKind::Webhook,
+        callback_label.to_owned(),
+        "2026-06-21T00:00:00Z".to_owned(),
+        None,
+    )
+}
+
+fn resume_msg(execution_id: &str, callback_label: &str) -> ControlMsg {
+    ControlMsg {
+        id: *uuid::Uuid::new_v4().as_bytes(),
+        execution_id: execution_id.to_owned(),
+        command: ControlCommand::Resume,
+        scope: test_scope(),
+        w3c_traceparent: None,
+        reclaim_count: 0,
+        resume_target: Some(ResumeTarget::Webhook {
+            callback_id: callback_label.to_owned(),
+        }),
+    }
+}
+
+/// Mint `token_row` into the SQLite execution store via the production `commit`.
+async fn seed_token(
+    exec_store: &SqliteExecutionStore,
+    scope: &Scope,
+    execution_id: &str,
+    token_row: ResumeTokenRow,
+) {
+    exec_store
+        .create(
+            scope,
+            execution_id,
+            "wf-sqlite-1",
+            serde_json::json!({"s": "created"}),
+        )
+        .await
+        .expect("create must succeed on a fresh row");
+    let fencing = exec_store
+        .acquire_lease(scope, execution_id, "test-runner", Duration::from_secs(30))
+        .await
+        .expect("acquire_lease must not error")
+        .expect("fresh row must yield a fencing token");
+    let batch = TransitionBatch::builder()
+        .scope(scope.clone())
+        .execution_id(execution_id)
+        .expected_version(0)
+        .fencing(fencing)
+        .new_state(serde_json::json!({"s": "waiting"}))
+        .resume_tokens(vec![token_row])
+        .build()
+        .expect("well-formed batch must build");
+    let outcome = exec_store
+        .commit(batch)
+        .await
+        .expect("commit must not error");
+    assert!(
+        matches!(outcome, TransitionOutcome::Applied { .. }),
+        "batch must apply; got {outcome:?}"
+    );
+    exec_store
+        .release_lease(scope, execution_id, fencing)
+        .await
+        .expect("release_lease must succeed");
+}
+
+async fn resume_count(pool: &sqlx::SqlitePool) -> i64 {
+    sqlx::query("SELECT COUNT(*) AS n FROM port_control_queue WHERE command = 'Resume'")
+        .fetch_one(pool)
+        .await
+        .expect("count query must succeed")
+        .try_get::<i64, _>("n")
+        .expect("count column must decode")
+}
+
+/// Test 1 — `peek` returns the committed token without burning it.
+#[tokio::test]
+async fn sqlite_peek_returns_row_without_burning() {
+    let pool = fresh_pool().await;
+    let exec_store = SqliteExecutionStore::new(pool.clone());
+    let producer = SqliteResumeProducer::new(pool.clone());
+    let scope = test_scope();
+    let hash = fill_hash(0xA1);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-peek",
+        token_row_for(hash.clone(), "exe-peek", "cb-peek"),
+    )
+    .await;
+
+    let peeked = producer.peek(&hash).await.expect("peek must not error");
+    assert_eq!(
+        peeked.expect("peek must return the row").callback_label,
+        "cb-peek"
+    );
+    // Survived the peek — a winning consume still follows.
+    let won = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-peek", "cb-peek"))
+        .await
+        .expect("consume must not error");
+    assert!(
+        won,
+        "peek must not burn the token — the consume after peek wins"
+    );
+}
+
+/// Test 2 — `consume_and_enqueue_resume` burns the token AND writes the Resume.
+#[tokio::test]
+async fn sqlite_consume_and_enqueue_writes_one_resume() {
+    let pool = fresh_pool().await;
+    let exec_store = SqliteExecutionStore::new(pool.clone());
+    let producer = SqliteResumeProducer::new(pool.clone());
+    let scope = test_scope();
+    let hash = fill_hash(0xB2);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-atomic",
+        token_row_for(hash.clone(), "exe-atomic", "cb-atomic"),
+    )
+    .await;
+
+    let won = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-atomic", "cb-atomic"))
+        .await
+        .expect("consume must not error");
+    assert!(won, "the only consumer wins");
+    assert_eq!(
+        resume_count(&pool).await,
+        1,
+        "exactly one Resume must be written"
+    );
+    assert!(
+        producer
+            .peek(&hash)
+            .await
+            .expect("peek must not error")
+            .is_none(),
+        "token must be burned after a winning consume"
+    );
+}
+
+/// Test 3 — A replay returns `Ok(false)` and writes no second Resume.
+#[tokio::test]
+async fn sqlite_replay_returns_false_and_writes_nothing() {
+    let pool = fresh_pool().await;
+    let exec_store = SqliteExecutionStore::new(pool.clone());
+    let producer = SqliteResumeProducer::new(pool.clone());
+    let scope = test_scope();
+    let hash = fill_hash(0xC3);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-replay",
+        token_row_for(hash.clone(), "exe-replay", "cb-replay"),
+    )
+    .await;
+
+    assert!(
+        producer
+            .consume_and_enqueue_resume(&hash, &resume_msg("exe-replay", "cb-replay"))
+            .await
+            .expect("first consume must not error")
+    );
+    assert!(
+        !producer
+            .consume_and_enqueue_resume(&hash, &resume_msg("exe-replay", "cb-replay"))
+            .await
+            .expect("replay must not error"),
+        "replay of a burned token must return Ok(false)"
+    );
+    assert_eq!(
+        resume_count(&pool).await,
+        1,
+        "replay must not write a second Resume"
+    );
+}
+
+/// Test 4 — **Atomicity gate (real-tx rollback).** When the control INSERT fails
+/// inside the producer's transaction, the token DELETE rolls back with it: the
+/// token survives and no Resume is written.
+///
+/// We force the INSERT to fail by dropping `port_control_queue` before the call.
+/// Falsifiability: a non-atomic `commit`-the-delete-then-insert producer would
+/// burn the token and return `Err` with the token gone → `peek` returns `None`
+/// → the `is_some()` assertion fails → this is exactly the P1 bug.
+#[tokio::test]
+async fn sqlite_failed_enqueue_rolls_back_the_burn() {
+    let pool = fresh_pool().await;
+    let exec_store = SqliteExecutionStore::new(pool.clone());
+    let producer = SqliteResumeProducer::new(pool.clone());
+    let scope = test_scope();
+    let hash = fill_hash(0xD4);
+    seed_token(
+        &exec_store,
+        &scope,
+        "exe-rollback",
+        token_row_for(hash.clone(), "exe-rollback", "cb-rollback"),
+    )
+    .await;
+
+    // Make the in-tx control INSERT fail.
+    sqlx::query("DROP TABLE port_control_queue")
+        .execute(&pool)
+        .await
+        .expect("drop must succeed");
+
+    let result = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-rollback", "cb-rollback"))
+        .await;
+    assert!(
+        result.is_err(),
+        "a failed control INSERT must surface as Err (tx rolled back)"
+    );
+
+    // The token survived the rolled-back transaction.
+    assert!(
+        producer
+            .peek(&hash)
+            .await
+            .expect("peek must not error")
+            .is_some(),
+        "the token MUST survive a rolled-back enqueue — burning it here is the P1 bug"
+    );
+
+    // Restore the table and prove the retry now succeeds + writes exactly one Resume.
+    init_schema(&pool)
+        .await
+        .expect("re-init must restore the table");
+    let won = producer
+        .consume_and_enqueue_resume(&hash, &resume_msg("exe-rollback", "cb-rollback"))
+        .await
+        .expect("retry after fault clears must not error");
+    assert!(won, "the retry must win (token was still live)");
+    assert_eq!(
+        resume_count(&pool).await,
+        1,
+        "the retry writes exactly one Resume"
+    );
+}


### PR DESCRIPTION
## What

The final wait-state slice (ADR-0099 W-S3d): the **inbound transport** that makes the resume machinery reachable. `POST /resume` accepts a bearer resume token, consumes it against the W-S3c store (single-use), and enqueues a **targeted** `ControlCommand::Resume`. This is the only attacker-reachable wait-state surface — **security-auditor RELEASE-GATE**.

## Security design (born already-safe)

- **Bearer in `Authorization: Bearer` header, never the URL** — no secret-in-logs.
- **Mounted pre-tenancy** — the handler has **no** `TenantContext` extractor, so scope-from-row is enforced by *absence*: `scope`/`execution_id`/`target` all come from the resolved `ResumeTokenRow`, never the request.
- **Anti-guessing rate-limit = per-IP + global tiers, BEFORE any store hit** (per-token limiting is worthless against rotation; the global tier is the IP-trust-independent backstop). Per-tenant tier runs post-consume.
- **Single-use `consume`** (`DELETE…RETURNING`) → **kind-match fail-closed** (Webhook only; `#[non_exhaustive]` `_`→404) → **expiry** via injectable `Clock` (fail-closed on parse failure) → enqueue via `ScopedControlQueue` bound to `row.scope`.
- **Uniform 404** for absent/expired/consumed/forged/malformed-bearer (no existence oracle).
- **Storage error → 503 + Retry-After**, token unconsumed (a transient DB blip must not silently drop a legitimate resume).
- **Body inert** (never deserialized into the enqueue); HMAC-gated body mode hard-blocked. Bearer dropped immediately after hashing; never logged.

## Tests

14 integration tests (`crates/api/tests/resume_e2e.rs`): happy path, single-use replay, forged/absent, expired, malformed-expiry, kind-confusion, scope-from-row, per-IP/global/per-tenant rate-limit ordering, no-token-in-URL, storage-err→503, body-inert, bearer-extraction uniformity. clippy `--all-features -D` clean; 554 nebula-api tests pass; zero library-path `expect`/`unwrap`/`panic!`.

## Abuse-case coverage

15-case enumeration (chief-architect plan): token guessing/rotation/DoS, replay, cross-tenant, confused-deputy, kind-confusion, rate-limit bypass, timing/existence oracle (rate-limited residual), enqueue-without-consume, body-trust, expired-resume, secret-in-logs, storage-error-downgrade. The timing-oracle residual and the per-replica rate-limit cap are flagged for the RELEASE-GATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `POST /resume` webhook callback with Bearer token handling and a request body size limit.
  * Enforced fail-closed validation, single-use replay protection, and staged rate limiting (per-IP, global, per-tenant).
  * Returns `202` on success, `404` for invalid/expired tokens, `429` when rate-limited, and `503` for transient storage issues (with `Retry-After` where applicable).
* **Infrastructure**
  * Wired resume storage/producer components across Memory/SQLite/Postgres so resume operations use the same durable backend state.
* **Tests**
  * Added expanded end-to-end and producer contract tests, including SQLite atomicity/durability cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->