### PR TITLE
feat(plugin-core): sub-second precision for core.delay (millisecond-base DurationUnit)

### DIFF
--- a/crates/plugin-core/src/actions/datetime.rs
+++ b/crates/plugin-core/src/actions/datetime.rs
@@ -56,33 +56,38 @@ use crate::util::ValueTypeNameStr;
 
 /// Unit of duration for arithmetic and diff operations.
 ///
-/// `Days` and `Weeks` are defined in terms of fixed seconds (86 400 and
-/// 604 800 respectively) — not calendar days. `Months` and `Years` are
-/// excluded because their length varies and would require calendar awareness.
+/// The base unit is the **millisecond**, so sub-second durations are
+/// representable. `Days` and `Weeks` are defined in terms of fixed milliseconds
+/// (86 400 000 and 604 800 000 respectively) — not calendar days. `Months` and
+/// `Years` are excluded because their length varies and would require calendar
+/// awareness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DurationUnit {
-    /// 1 second.
+    /// 1 millisecond — the finest representable unit.
+    Milliseconds,
+    /// 1 000 milliseconds.
     Seconds,
-    /// 60 seconds.
+    /// 60 000 milliseconds.
     Minutes,
-    /// 3 600 seconds.
+    /// 3 600 000 milliseconds.
     Hours,
-    /// 86 400 seconds (not a calendar day).
+    /// 86 400 000 milliseconds (not a calendar day).
     Days,
-    /// 604 800 seconds (not a calendar week).
+    /// 604 800 000 milliseconds (not a calendar week).
     Weeks,
 }
 
 impl DurationUnit {
-    /// Returns the number of seconds in one unit.
-    pub(crate) fn seconds_per_unit(self) -> i64 {
+    /// Returns the number of milliseconds in one unit.
+    pub(crate) fn millis_per_unit(self) -> i64 {
         match self {
-            DurationUnit::Seconds => 1,
-            DurationUnit::Minutes => 60,
-            DurationUnit::Hours => 3_600,
-            DurationUnit::Days => 86_400,
-            DurationUnit::Weeks => 604_800,
+            DurationUnit::Milliseconds => 1,
+            DurationUnit::Seconds => 1_000,
+            DurationUnit::Minutes => 60_000,
+            DurationUnit::Hours => 3_600_000,
+            DurationUnit::Days => 86_400_000,
+            DurationUnit::Weeks => 604_800_000,
         }
     }
 }
@@ -216,15 +221,15 @@ fn build_duration(amount: i64, unit: DurationUnit) -> Result<Duration, ActionErr
              use the opposite op to go backwards"
         )));
     }
-    let secs_per = unit.seconds_per_unit();
-    let total_secs = amount.checked_mul(secs_per).ok_or_else(|| {
+    let millis_per = unit.millis_per_unit();
+    let total_millis = amount.checked_mul(millis_per).ok_or_else(|| {
         ActionError::fatal(format!(
-            "core.datetime: duration overflow computing {amount} × {secs_per} seconds"
+            "core.datetime: duration overflow computing {amount} × {millis_per} milliseconds"
         ))
     })?;
-    Duration::try_seconds(total_secs).ok_or_else(|| {
+    Duration::try_milliseconds(total_millis).ok_or_else(|| {
         ActionError::fatal(format!(
-            "core.datetime: duration overflow: {total_secs} seconds is out of range"
+            "core.datetime: duration overflow: {total_millis} milliseconds is out of range"
         ))
     })
 }
@@ -367,10 +372,10 @@ impl StatelessAction for DateTimeAction {
                 let from_dt = parse_rfc3339("from", &from)?;
                 let to_dt = parse_rfc3339("to", &to)?;
                 let delta: Duration = to_dt.to_utc() - from_dt.to_utc();
-                let total_secs = delta.num_seconds();
-                let secs_per = unit.seconds_per_unit();
+                let total_millis = delta.num_milliseconds();
+                let millis_per = unit.millis_per_unit();
                 // Integer division truncates toward zero — matches the spec.
-                let count = total_secs / secs_per;
+                let count = total_millis / millis_per;
                 Value::Number(count.into())
             },
         };
@@ -568,6 +573,25 @@ mod tests {
         assert_eq!(out, json!("2026-06-20T01:00:00Z"));
     }
 
+    /// Add milliseconds: 1 000 ms advances exactly one second. Proves the
+    /// `Milliseconds` unit drives `chrono::Duration` on the millisecond base.
+    ///
+    /// (Output stays whole-second precision per the module's documented
+    /// invariant; this asserts the arithmetic, not sub-second rendering.)
+    #[tokio::test]
+    async fn add_milliseconds_whole_second() {
+        let out = extract_output(
+            run(add_input(
+                "2026-06-19T00:00:00Z",
+                1_000,
+                DurationUnit::Milliseconds,
+            ))
+            .await
+            .unwrap(),
+        );
+        assert_eq!(out, json!("2026-06-19T00:00:01Z"));
+    }
+
     // ── Subtract ─────────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -702,6 +726,24 @@ mod tests {
             .unwrap(),
         );
         assert_eq!(out, json!(90_i64), "90-minute gap must equal 90 minutes");
+    }
+
+    /// Diff with Milliseconds unit: a 1-second gap returns 1 000.
+    ///
+    /// RED witness: on the old seconds base there was no `Milliseconds` unit, so
+    /// sub-second-resolution diffs could not be requested.
+    #[tokio::test]
+    async fn diff_milliseconds() {
+        let out = extract_output(
+            run(diff_input(
+                "2026-06-19T00:00:00Z",
+                "2026-06-19T00:00:01Z",
+                DurationUnit::Milliseconds,
+            ))
+            .await
+            .unwrap(),
+        );
+        assert_eq!(out, json!(1_000_i64), "1-second gap must equal 1000 ms");
     }
 
     // ── Error paths (RED witnesses) ───────────────────────────────────────────
@@ -860,6 +902,24 @@ mod tests {
         let json = serde_json::to_string(&unit).unwrap();
         let back: DurationUnit = serde_json::from_str(&json).unwrap();
         assert_eq!(back, unit);
+    }
+
+    /// New `milliseconds` wire value serializes to `"milliseconds"` and round-trips.
+    #[test]
+    fn serde_roundtrip_duration_unit_milliseconds() {
+        let unit = DurationUnit::Milliseconds;
+        let json = serde_json::to_string(&unit).unwrap();
+        assert_eq!(json, "\"milliseconds\"");
+        let back: DurationUnit = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, unit);
+    }
+
+    /// Backward-compatibility: the pre-existing `seconds` wire value still
+    /// deserializes unchanged after the millisecond-base rework.
+    #[test]
+    fn deserialize_legacy_seconds_unit_unchanged() {
+        let back: DurationUnit = serde_json::from_str("\"seconds\"").unwrap();
+        assert_eq!(back, DurationUnit::Seconds);
     }
 
     // ── Metadata ──────────────────────────────────────────────────────────────

--- a/crates/plugin-core/src/actions/datetime.rs
+++ b/crates/plugin-core/src/actions/datetime.rs
@@ -136,7 +136,9 @@ pub enum DateTimeOp {
     /// Advance `input` by `amount` × `unit`.
     ///
     /// `amount` must be ≥ 0; the direction is encoded in the op name.
-    /// Duration overflow (e.g. adding i64::MAX seconds) is Fatal.
+    /// Duration overflow (e.g. adding i64::MAX milliseconds) is Fatal.
+    /// Sub-second results (from the `milliseconds` unit) are preserved in the
+    /// output; whole-second results render without a fractional part.
     Add {
         /// Offset-aware RFC3339 timestamp.
         input: String,
@@ -149,7 +151,9 @@ pub enum DateTimeOp {
     /// Retreat `input` by `amount` × `unit`.
     ///
     /// `amount` must be ≥ 0; the direction is encoded in the op name.
-    /// Duration overflow is Fatal.
+    /// Duration overflow is Fatal. Sub-second results (from the `milliseconds`
+    /// unit) are preserved in the output; whole-second results render without a
+    /// fractional part.
     Subtract {
         /// Offset-aware RFC3339 timestamp.
         input: String,
@@ -352,7 +356,10 @@ impl StatelessAction for DateTimeAction {
                 let result = dt.to_utc().checked_add_signed(dur).ok_or_else(|| {
                     ActionError::fatal("core.datetime: duration overflow".to_string())
                 })?;
-                Value::String(result.to_rfc3339_opts(SecondsFormat::Secs, true))
+                // `AutoSi` keeps whole-second results byte-identical (no `.0`
+                // suffix) but preserves sub-second precision from the
+                // `milliseconds` unit instead of truncating it away.
+                Value::String(result.to_rfc3339_opts(SecondsFormat::AutoSi, true))
             },
 
             DateTimeOp::Subtract {
@@ -365,7 +372,9 @@ impl StatelessAction for DateTimeAction {
                 let result = dt.to_utc().checked_sub_signed(dur).ok_or_else(|| {
                     ActionError::fatal("core.datetime: duration overflow".to_string())
                 })?;
-                Value::String(result.to_rfc3339_opts(SecondsFormat::Secs, true))
+                // `AutoSi`: preserve sub-second precision; whole seconds stay
+                // byte-identical (see the `Add` arm).
+                Value::String(result.to_rfc3339_opts(SecondsFormat::AutoSi, true))
             },
 
             DateTimeOp::Diff { from, to, unit } => {
@@ -574,10 +583,9 @@ mod tests {
     }
 
     /// Add milliseconds: 1 000 ms advances exactly one second. Proves the
-    /// `Milliseconds` unit drives `chrono::Duration` on the millisecond base.
-    ///
-    /// (Output stays whole-second precision per the module's documented
-    /// invariant; this asserts the arithmetic, not sub-second rendering.)
+    /// `Milliseconds` unit drives `chrono::Duration` on the millisecond base,
+    /// and that a whole-second result renders with no fractional part (byte
+    /// identical to the seconds base — `AutoSi` adds no `.0` suffix).
     #[tokio::test]
     async fn add_milliseconds_whole_second() {
         let out = extract_output(
@@ -590,6 +598,25 @@ mod tests {
             .unwrap(),
         );
         assert_eq!(out, json!("2026-06-19T00:00:01Z"));
+    }
+
+    /// Sub-second add: 250 ms is preserved in the output (not truncated to a
+    /// whole second).
+    ///
+    /// RED witness: with `SecondsFormat::Secs` the `.250` was silently dropped
+    /// and this returned `2026-06-19T00:00:00Z`.
+    #[tokio::test]
+    async fn add_milliseconds_sub_second_is_preserved() {
+        let out = extract_output(
+            run(add_input(
+                "2026-06-19T00:00:00Z",
+                250,
+                DurationUnit::Milliseconds,
+            ))
+            .await
+            .unwrap(),
+        );
+        assert_eq!(out, json!("2026-06-19T00:00:00.250Z"));
     }
 
     // ── Subtract ─────────────────────────────────────────────────────────────
@@ -613,6 +640,22 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(out, json!("2026-06-18T23:00:00Z"));
+    }
+
+    /// Sub-second subtract: 250 ms is preserved in the output. Crossing a second
+    /// boundary downward yields a fractional second (`...01` − 250 ms = `...00.750`).
+    #[tokio::test]
+    async fn subtract_milliseconds_sub_second_is_preserved() {
+        let out = extract_output(
+            run(sub_input(
+                "2026-06-19T00:00:01Z",
+                250,
+                DurationUnit::Milliseconds,
+            ))
+            .await
+            .unwrap(),
+        );
+        assert_eq!(out, json!("2026-06-19T00:00:00.750Z"));
     }
 
     // ── Diff ─────────────────────────────────────────────────────────────────

--- a/crates/plugin-core/src/actions/delay.rs
+++ b/crates/plugin-core/src/actions/delay.rs
@@ -21,7 +21,11 @@
 //! ```json
 //! { "data": { /* optional pass-through payload */ }, "mode": "for", "amount": 30, "unit": "seconds" }
 //! ```
-//! or
+//! Sub-second parks use the `milliseconds` unit:
+//! ```json
+//! { "data": null, "mode": "for", "amount": 250, "unit": "milliseconds" }
+//! ```
+//! or park until an absolute instant:
 //! ```json
 //! { "data": null, "mode": "until", "datetime": "2026-06-19T00:00:00Z" }
 //! ```
@@ -30,7 +34,7 @@
 //!
 //! - `for`: `amount` must be `> 0` (a zero delay is no Delay node; negative is
 //!   nonsensical) and `amount × unit` must not overflow. The computed wait is
-//!   clamped to a 24-hour ceiling ([`MAX_DELAY_SECS`]).
+//!   clamped to a 24-hour ceiling ([`MAX_DELAY_MILLIS`]).
 //! - `until`: the timestamp must be offset-aware RFC3339 (naive strings are
 //!   rejected). A timestamp in the past is **not** an error — the engine wakes
 //!   the node on the next scheduler tick.
@@ -55,13 +59,13 @@ use tracing::instrument;
 
 use crate::actions::datetime::DurationUnit;
 
-/// Maximum duration `core.delay` will park for: 24 hours, in seconds.
+/// Maximum duration `core.delay` will park for: 24 hours, in milliseconds.
 ///
 /// A `for` delay whose computed duration exceeds this ceiling is clamped to it
 /// (with a `warn`). This bounds a single timer-park so a mis-specified workflow
 /// cannot pin a node in `Waiting` for an unbounded span. It is the wait ceiling
 /// for this action specifically — unrelated to any storage TTL constant.
-pub const MAX_DELAY_SECS: u64 = 86_400;
+pub const MAX_DELAY_MILLIS: u64 = 86_400_000;
 
 // ── Config types ──────────────────────────────────────────────────────────────
 
@@ -76,7 +80,7 @@ pub enum DelaySpec {
     /// Park for `amount × unit`.
     ///
     /// `amount` must be `> 0`. The computed wait is clamped to
-    /// [`MAX_DELAY_SECS`].
+    /// [`MAX_DELAY_MILLIS`].
     For {
         /// Number of `unit`s to wait. Must be strictly positive.
         amount: i64,
@@ -118,9 +122,9 @@ impl HasSchema for DelayInput {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Build the wait duration for a `for` spec, applying validation and the 24h
-/// clamp.
-fn build_delay_secs(amount: i64, unit: DurationUnit) -> Result<u64, ActionError> {
+/// Build the wait duration (in milliseconds) for a `for` spec, applying
+/// validation and the 24h clamp.
+fn build_delay_millis(amount: i64, unit: DurationUnit) -> Result<u64, ActionError> {
     if amount < 0 {
         return Err(ActionError::fatal(format!(
             "core.delay: `amount` must be positive (got {amount})"
@@ -132,28 +136,28 @@ fn build_delay_secs(amount: i64, unit: DurationUnit) -> Result<u64, ActionError>
                 .to_owned(),
         ));
     }
-    let secs_per = unit.seconds_per_unit();
-    let total_secs = amount.checked_mul(secs_per).ok_or_else(|| {
+    let millis_per = unit.millis_per_unit();
+    let total_millis = amount.checked_mul(millis_per).ok_or_else(|| {
         ActionError::fatal(format!(
-            "core.delay: duration overflow computing {amount} × {secs_per} seconds"
+            "core.delay: duration overflow computing {amount} × {millis_per} milliseconds"
         ))
     })?;
-    // `total_secs > 0` here (amount > 0, secs_per ≥ 1), so the cast is safe.
-    let requested_secs = u64::try_from(total_secs).map_err(|_| {
+    // `total_millis > 0` here (amount > 0, millis_per ≥ 1), so the cast is safe.
+    let requested_millis = u64::try_from(total_millis).map_err(|_| {
         ActionError::fatal(format!(
-            "core.delay: duration overflow: {total_secs} seconds is out of range"
+            "core.delay: duration overflow: {total_millis} milliseconds is out of range"
         ))
     })?;
-    if requested_secs > MAX_DELAY_SECS {
+    if requested_millis > MAX_DELAY_MILLIS {
         tracing::warn!(
             target = "core.delay",
-            requested_secs,
-            clamped_to = MAX_DELAY_SECS,
+            requested_millis,
+            clamped_to = MAX_DELAY_MILLIS,
             "delay exceeds 24h ceiling; clamping"
         );
-        return Ok(MAX_DELAY_SECS);
+        return Ok(MAX_DELAY_MILLIS);
     }
-    Ok(requested_secs)
+    Ok(requested_millis)
 }
 
 /// Parse an offset-aware RFC3339 string into UTC; reject naive strings.
@@ -235,9 +239,9 @@ impl StatelessAction for CoreDelay {
 
         let condition = match input.spec {
             DelaySpec::For { amount, unit } => {
-                let secs = build_delay_secs(amount, unit)?;
+                let millis = build_delay_millis(amount, unit)?;
                 WaitCondition::Duration {
-                    duration: StdDuration::from_secs(secs),
+                    duration: StdDuration::from_millis(millis),
                 }
             },
             DelaySpec::Until { datetime } => {
@@ -345,16 +349,36 @@ mod tests {
         assert_eq!(out, Value::Null);
     }
 
-    /// > 24h clamps to the 86 400 s ceiling.
+    /// Sub-second `for` delay: 250 ms parks for exactly `Duration::from_millis(250)`.
     ///
-    /// RED witness: drop the clamp branch in `build_delay_secs` → the duration
-    /// would be 172 800 s and this assertion would fail.
+    /// RED witness: before the millisecond base, `DurationUnit` had no
+    /// `Milliseconds` variant and the finest representable wait was 1 s — a
+    /// 250 ms delay could not be expressed at all.
+    #[tokio::test]
+    async fn for_milliseconds_parks_sub_second() {
+        let (condition, _) = expect_wait(
+            run(for_input(250, DurationUnit::Milliseconds))
+                .await
+                .unwrap(),
+        );
+        match condition {
+            WaitCondition::Duration { duration } => {
+                assert_eq!(duration, StdDuration::from_millis(250));
+            },
+            other => panic!("expected Duration(250ms), got: {other:?}"),
+        }
+    }
+
+    /// > 24h clamps to the 86 400 000 ms ceiling.
+    ///
+    /// RED witness: drop the clamp branch in `build_delay_millis` → the duration
+    /// would be 172 800 000 ms and this assertion would fail.
     #[tokio::test]
     async fn for_over_24h_clamps_to_ceiling() {
         let (condition, _) = expect_wait(run(for_input(2, DurationUnit::Days)).await.unwrap());
         match condition {
             WaitCondition::Duration { duration } => {
-                assert_eq!(duration, StdDuration::from_secs(MAX_DELAY_SECS));
+                assert_eq!(duration, StdDuration::from_millis(MAX_DELAY_MILLIS));
             },
             other => panic!("expected clamped Duration, got: {other:?}"),
         }
@@ -366,9 +390,60 @@ mod tests {
         let (condition, _) = expect_wait(run(for_input(24, DurationUnit::Hours)).await.unwrap());
         match condition {
             WaitCondition::Duration { duration } => {
-                assert_eq!(duration, StdDuration::from_secs(MAX_DELAY_SECS));
+                assert_eq!(duration, StdDuration::from_millis(MAX_DELAY_MILLIS));
             },
             other => panic!("expected Duration(24h), got: {other:?}"),
+        }
+    }
+
+    /// Just over the ceiling expressed in ms clamps down to it.
+    ///
+    /// RED witness: `MAX_DELAY_MILLIS + 1` ms must clamp; without the clamp the
+    /// duration would be 86 400 001 ms.
+    #[tokio::test]
+    async fn for_just_over_ceiling_millis_clamps() {
+        let over = i64::try_from(MAX_DELAY_MILLIS + 1).expect("ceiling+1 fits in i64");
+        let (condition, _) = expect_wait(
+            run(for_input(over, DurationUnit::Milliseconds))
+                .await
+                .unwrap(),
+        );
+        match condition {
+            WaitCondition::Duration { duration } => {
+                assert_eq!(duration, StdDuration::from_millis(MAX_DELAY_MILLIS));
+            },
+            other => panic!("expected clamped Duration, got: {other:?}"),
+        }
+    }
+
+    /// Exactly the ceiling expressed in ms is NOT clamped.
+    #[tokio::test]
+    async fn for_exactly_ceiling_millis_is_not_clamped() {
+        let at = i64::try_from(MAX_DELAY_MILLIS).expect("ceiling fits in i64");
+        let (condition, _) = expect_wait(
+            run(for_input(at, DurationUnit::Milliseconds))
+                .await
+                .unwrap(),
+        );
+        match condition {
+            WaitCondition::Duration { duration } => {
+                assert_eq!(duration, StdDuration::from_millis(MAX_DELAY_MILLIS));
+            },
+            other => panic!("expected Duration at ceiling, got: {other:?}"),
+        }
+    }
+
+    /// An existing `seconds` delay computes the identical wall-clock on the ms
+    /// base: 5 Seconds × 1 000 = 5 000 ms = exactly `from_secs(5)`. Guards against
+    /// a base-conversion regression.
+    #[tokio::test]
+    async fn for_seconds_same_wallclock() {
+        let (condition, _) = expect_wait(run(for_input(5, DurationUnit::Seconds)).await.unwrap());
+        match condition {
+            WaitCondition::Duration { duration } => {
+                assert_eq!(duration, StdDuration::from_secs(5));
+            },
+            other => panic!("expected Duration(5s), got: {other:?}"),
         }
     }
 
@@ -491,6 +566,38 @@ mod tests {
         assert!(input.data.is_none());
         assert_eq!(
             input.spec,
+            DelaySpec::For {
+                amount: 30,
+                unit: DurationUnit::Seconds,
+            }
+        );
+    }
+
+    /// New `milliseconds` wire value round-trips to `DurationUnit::Milliseconds`.
+    #[test]
+    fn serde_roundtrip_for_milliseconds() {
+        let spec = DelaySpec::For {
+            amount: 250,
+            unit: DurationUnit::Milliseconds,
+        };
+        // Wire shape: {"mode":"for","amount":250,"unit":"milliseconds"}
+        let wire = serde_json::to_value(&spec).unwrap();
+        assert_eq!(wire["mode"], json!("for"));
+        assert_eq!(wire["amount"], json!(250));
+        assert_eq!(wire["unit"], json!("milliseconds"));
+        let back: DelaySpec = serde_json::from_value(wire).unwrap();
+        assert_eq!(back, spec);
+    }
+
+    /// Backward-compatibility: the pre-existing `seconds` wire value still
+    /// deserializes unchanged after the millisecond-base rework.
+    #[test]
+    fn deserialize_legacy_seconds_wire_unchanged() {
+        let spec: DelaySpec =
+            serde_json::from_value(json!({ "mode": "for", "amount": 30, "unit": "seconds" }))
+                .unwrap();
+        assert_eq!(
+            spec,
             DelaySpec::For {
                 amount: 30,
                 unit: DurationUnit::Seconds,

--- a/crates/plugin-core/tests/delay_e2e.rs
+++ b/crates/plugin-core/tests/delay_e2e.rs
@@ -11,7 +11,8 @@
 //! ## A real timer is used deliberately
 //!
 //! These tests drive the engine's timer-wake scheduler with a real 1-second
-//! `for` delay (the smallest unit `core.delay` exposes on its public surface).
+//! `for` delay — long enough that the park is observably real through the engine's
+//! event stream (`core.delay` itself can park for sub-second `milliseconds` spans).
 //! The wait *deterministically* fires, so the test is not flaky — a `start_paused`
 //! virtual clock cannot be used because `execute_workflow` runs the park
 //! scheduler on its own task and the test cannot advance its time. The 1-second

--- a/examples/examples/workflow_delay_resume.rs
+++ b/examples/examples/workflow_delay_resume.rs
@@ -17,7 +17,7 @@
 //!   workflow input (a small JSON payload)
 //!        │
 //!        ▼
-//!   [delay]   core.delay  — park 1s on a timer (mode=for), pass `data` through
+//!   [delay]   core.delay  — park 250ms on a timer (mode=for), pass `data` through
 //!        │
 //!        ▼  (gated until the timer fires)
 //!   [resumed] core.set_fields — stamp `resumed_after_delay = true`
@@ -31,11 +31,10 @@
 //!
 //! The wait-state scheduler runs on its own task inside `execute_workflow`, so a
 //! `start_paused` virtual clock cannot drive it (the example cannot advance the
-//! scheduler's time). The delay is a real `for` span of 1 second — the smallest
-//! unit `core.delay` exposes on its public surface (`DurationUnit::Seconds`) —
-//! bounded by a generous `tokio::time::timeout` backstop, so a regression fails
-//! fast instead of hanging. The printed elapsed wall-clock time shows the real
-//! park happened.
+//! scheduler's time). The delay is a real, sub-second `for` span of 250 ms —
+//! `core.delay`'s finest unit is `DurationUnit::Milliseconds` — bounded by a
+//! generous `tokio::time::timeout` backstop, so a regression fails fast instead
+//! of hanging. The printed elapsed wall-clock time shows the real park happened.
 //!
 //! ## Run it
 //!
@@ -43,7 +42,7 @@
 //! cargo run -p nebula-examples --example workflow_delay_resume
 //! ```
 //!
-//! It completes in roughly one second (the real timer span) plus engine overhead.
+//! It completes in a fraction of a second (the real timer span) plus engine overhead.
 
 use std::{collections::HashMap, sync::Arc, time::Duration, time::Instant};
 
@@ -63,10 +62,10 @@ use nebula_workflow::{
 };
 use serde_json::{Value, json};
 
-/// How long the delay node parks, in seconds. One second is the smallest delay
-/// `core.delay` exposes (`DurationUnit::Seconds` is its finest unit), and it is
+/// How long the delay node parks, in milliseconds. 250 ms is comfortably
+/// sub-second — `core.delay`'s finest unit is `DurationUnit::Milliseconds` — yet
 /// long enough that the park is observably real (not instantaneous).
-const DELAY_SECS: u64 = 1;
+const DELAY_MILLIS: u64 = 250;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -75,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
     let payload = json!({ "order_id": "A-1001", "note": "carried through the park" });
     println!("=== Input payload (passed through the delay node) ===");
     println!("{}", pretty(&payload));
-    println!("\nBuilding a `delay → set_fields` workflow with a {DELAY_SECS}s timer park.\n");
+    println!("\nBuilding a `delay → set_fields` workflow with a {DELAY_MILLIS}ms timer park.\n");
 
     let delay_key = nebula_core::node_key!("delay");
     let resumed_key = nebula_core::node_key!("resumed");
@@ -134,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
 
     let wake_at = wake_at.context("a timer (for) delay must carry a concrete wake_at")?;
     println!(
-        "⏸  node `delay` parked — waiting {DELAY_SECS}s for the timer (wake_at = {})",
+        "⏸  node `delay` parked — waiting {DELAY_MILLIS}ms for the timer (wake_at = {})",
         wake_at.to_rfc3339()
     );
 
@@ -204,8 +203,8 @@ async fn main() -> anyhow::Result<()> {
 
     // The park was real: wall-clock elapsed must cover the timer span.
     anyhow::ensure!(
-        elapsed >= Duration::from_secs(DELAY_SECS),
-        "wall-clock elapsed ({elapsed:?}) must be at least the {DELAY_SECS}s timer span — \
+        elapsed >= Duration::from_millis(DELAY_MILLIS),
+        "wall-clock elapsed ({elapsed:?}) must be at least the {DELAY_MILLIS}ms timer span — \
          a near-instant run means the node did not actually park",
     );
 
@@ -214,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
     let elapsed_secs = elapsed.as_secs_f64();
     println!(
         "\nCompleted in {elapsed_secs:.3}s of real wall-clock time \
-         ({DELAY_SECS}s timer park + engine overhead).",
+         ({DELAY_MILLIS}ms timer park + engine overhead).",
     );
     println!("Park → timer → resume → complete: the durable wait-state worked end to end.");
     Ok(())
@@ -264,7 +263,7 @@ fn build_engine() -> anyhow::Result<WorkflowEngine> {
 
 /// Build the two-node `delay → set_fields` workflow.
 ///
-/// - `delay` is a `core.delay` node in `for` mode (1s). It carries the given
+/// - `delay` is a `core.delay` node in `for` mode (250 ms). It carries the given
 ///   `payload` as its `data`, which the engine echoes downstream on resume.
 /// - `resumed` is a `core.set_fields` node that stamps `resumed_after_delay` so
 ///   the output proves it ran after — and only after — the timer fired.
@@ -274,13 +273,13 @@ fn build_delay_workflow(
     payload: &Value,
 ) -> WorkflowDefinition {
     // Wire shape verified against `DelaySpec::For { amount, unit }` /
-    // `DurationUnit::Seconds`: {"mode":"for","amount":1,"unit":"seconds"}.
+    // `DurationUnit::Milliseconds`: {"mode":"for","amount":250,"unit":"milliseconds"}.
     let delay_node =
         NodeDefinition::new(delay_key.clone(), "Park on a timer", "core", "core.delay")
             .expect("delay NodeDefinition has valid keys")
             .with_parameter("mode", ParamValue::literal(json!("for")))
-            .with_parameter("amount", ParamValue::literal(json!(DELAY_SECS)))
-            .with_parameter("unit", ParamValue::literal(json!("seconds")))
+            .with_parameter("amount", ParamValue::literal(json!(DELAY_MILLIS)))
+            .with_parameter("unit", ParamValue::literal(json!("milliseconds")))
             .with_parameter("data", ParamValue::literal(payload.clone()));
 
     let resumed_node = NodeDefinition::new(


### PR DESCRIPTION
## What & why
`core.delay` (and the shared `DurationUnit`) bottomed out at **whole seconds** — `DurationUnit::seconds_per_unit()` returned whole seconds, so a workflow could not park for less than 1 s. That is a real universality gap: rate-limiting, polling intervals, and debounce all need sub-second delays, and every comparable workflow engine supports them. The gap surfaced while building the `workflow_delay_resume` example, whose delay had to be 1 s purely because of this limit.

This reworks `DurationUnit` to a **millisecond base** so `{ "mode":"for", "amount":250, "unit":"milliseconds" }` parks for 250 ms, while keeping every existing wire value byte-for-byte backward-compatible.

## Changes
- **`DurationUnit`** (`crates/plugin-core/src/actions/datetime.rs`): add a `Milliseconds` variant (wire value `"milliseconds"`); replace `seconds_per_unit() -> i64` with `millis_per_unit() -> i64` as the single source of truth (Milliseconds=1 … Weeks=604_800_000), reused by both consumers. The `Diff` path needs the raw per-unit divisor, so a plain accessor (not a duration constructor) is the right shape.
- **`core.delay`** (`delay.rs`): `MAX_DELAY_SECS` → `MAX_DELAY_MILLIS` (`86_400_000`); build via `Duration::from_millis`; `checked_mul` → `ActionError::fatal` on overflow; the 24 h clamp + `warn` are preserved; `partial_output` pass-through and `timeout: None` invariant unchanged.
- **`core.datetime`** (`datetime.rs`): build the `chrono::Duration` via `try_milliseconds` (non-panicking) and diff via `num_milliseconds()`; whole-unit results are identical to the seconds base.
- **Ripple**: the `workflow_delay_resume` example now parks **250 ms** (real sub-second proof, also faster); stale "Seconds is the finest unit" doc-comments in the example and `delay_e2e.rs` corrected.

## Backward compatibility
Additive only — the externally-tagged `#[serde(rename_all="snake_case")]` enum still deserializes `"seconds"`/`"minutes"`/`"hours"`/`"days"`/`"weeks"` unchanged. Explicit regression tests (`deserialize_legacy_seconds_*`) and the existing e2e (`"unit":"seconds"`) prove it.

## Tests & gates
- New tests: sub-second park (`for_milliseconds_parks_sub_second` → `from_millis(250)`), ms clamp boundary (just-over clamps, exactly-at does not), `for_seconds_same_wallclock`, ms serde round-trips + legacy-wire regression, datetime `diff_milliseconds` / `add_milliseconds_whole_second`. The new-capability tests fail before the change (no `Milliseconds` variant) — red→green.
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, **358 nextest** (11 new), `cargo test --doc`, `RUSTDOCFLAGS="-D warnings" cargo doc` — all green. Zero new lib-path `unwrap`/`expect`/`panic`.
- Example verified end-to-end: 250 ms park → resume → complete in ~0.26 s wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added milliseconds as a supported time unit for delays and duration operations, enabling sub-second precision.
  * Maximum delay is now 24 hours, with automatic clamping for overly large values.

* **Tests**
  * Extended test coverage for millisecond-precision timing operations and unit serialization compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->