### PR TITLE
fix(plugin-core): preserve sub-second precision in core.datetime parse

### DIFF
--- a/crates/plugin-core/src/actions/datetime.rs
+++ b/crates/plugin-core/src/actions/datetime.rs
@@ -123,8 +123,9 @@ pub enum DateTimeOp {
     /// Normalise an offset-aware RFC3339 timestamp to canonical UTC form.
     ///
     /// In v1 the optional `format` field is reserved and unused. The canonical
-    /// output uses whole-second precision with a `Z` suffix
-    /// (e.g. `"2026-06-19T00:00:00Z"`).
+    /// output carries a `Z` suffix and whole-second instants render without a
+    /// fractional part (e.g. `"2026-06-19T00:00:00Z"`); any sub-second component
+    /// in the input is preserved (e.g. `"...00.250Z"`), not truncated.
     Parse {
         /// Offset-aware RFC3339 string to normalise.
         input: String,
@@ -212,9 +213,12 @@ fn parse_rfc3339(field: &str, s: &str) -> Result<DateTime<FixedOffset>, ActionEr
     })
 }
 
-/// Canonical UTC RFC3339 with whole-second precision and `Z` suffix.
+/// Canonical UTC RFC3339 with a `Z` suffix. Uses `AutoSi`: whole-second
+/// instants render without a fractional part (byte-identical to second
+/// precision), while any sub-second component present in the input is preserved
+/// rather than truncated away.
 fn to_utc_rfc3339(dt: DateTime<FixedOffset>) -> String {
-    dt.to_utc().to_rfc3339_opts(SecondsFormat::Secs, true)
+    dt.to_utc().to_rfc3339_opts(SecondsFormat::AutoSi, true)
 }
 
 /// Build a `chrono::Duration` from `amount` (≥ 0) × `unit`, guarding overflow.
@@ -544,6 +548,22 @@ mod tests {
     async fn parse_round_trip_utc() {
         let out = extract_output(run(parse_input("2026-06-19T00:00:00Z")).await.unwrap());
         assert_eq!(out, json!("2026-06-19T00:00:00Z"));
+    }
+
+    /// Parse preserves a sub-second component while normalising the offset to UTC.
+    ///
+    /// 2026-06-19T11:30:00.250+05:30 = 2026-06-19T06:00:00.250Z.
+    ///
+    /// RED witness: with `SecondsFormat::Secs` the `.250` was truncated and this
+    /// returned `2026-06-19T06:00:00Z`.
+    #[tokio::test]
+    async fn parse_preserves_sub_second() {
+        let out = extract_output(
+            run(parse_input("2026-06-19T11:30:00.250+05:30"))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(out, json!("2026-06-19T06:00:00.250Z"));
     }
 
     // ── Add ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why
Follow-up to #873 (the millisecond-base `DurationUnit` rework). After that change, `core.datetime` was **half** millisecond-precise: `add`/`subtract` preserve sub-second results and `diff` measures in milliseconds, but `parse` still normalised via `SecondsFormat::Secs` — so a sub-second input like `2026-06-19T11:30:00.250+05:30` was silently truncated to `2026-06-19T06:00:00Z`.

That is the same silent-truncation footgun the Codex bot flagged on #873 (which fixed add/subtract). This closes the last gap so `core.datetime` is uniformly millisecond-precise.

## Change
- `to_utc_rfc3339` helper (parse's only call site): `SecondsFormat::Secs` → `SecondsFormat::AutoSi`. Whole-second instants render byte-identically (no `.0` suffix); sub-second components are preserved.
- Parse variant doc + helper doc updated to state the new precision contract.

`format` is already user-controlled (strftime), so it needs no change.

## Tests & gates
- New `parse_preserves_sub_second` (`...11:30:00.250+05:30` → `...06:00:00.250Z`) — verified red→green: with `Secs` it returned `...06:00:00Z` (truncated), captured before the fix.
- Existing whole-second parse tests (`parse_offset_to_utc_canonical`, `parse_round_trip_utc`) unchanged — confirm `AutoSi` adds no fractional part to whole seconds.
- `cargo fmt`, `clippy --all-targets --all-features -D warnings`, **361 nextest**, `cargo test --doc`, `RUSTDOCFLAGS=-D warnings cargo doc` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)