### PR TITLE
fix(plugin-core): compare large integers exactly in core actions

### DIFF
--- a/crates/plugin-core/src/actions/aggregate.rs
+++ b/crates/plugin-core/src/actions/aggregate.rs
@@ -68,6 +68,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 use tracing::instrument;
 
+use crate::condition::compare_ordered;
 use crate::util::ValueTypeNameStr;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -262,10 +263,12 @@ enum Accumulator {
         contributing_count: u64,
     },
     Min {
-        current_min: Option<(f64, Value)>,
+        // The original `Value` (not a cached f64): min/max are decided by exact
+        // comparison so large 64-bit integers don't collapse via f64.
+        current_min: Option<Value>,
     },
     Max {
-        current_max: Option<(f64, Value)>,
+        current_max: Option<Value>,
     },
     Collect {
         collected_values: Vec<Value>,
@@ -450,14 +453,16 @@ impl Accumulator {
             // MIN
             (Accumulator::Min { current_min }, Aggregation::Min { field, out }) => {
                 match element.get(field.as_str()) {
+                    // `as_f64_strict` is the numeric-type guard only; the actual
+                    // min is decided by exact comparison so large integers survive.
                     Some(field_value) => match as_f64_strict(field_value) {
-                        Some(candidate_f64) => {
-                            let is_new_minimum = current_min
-                                .as_ref()
-                                .is_none_or(|(prior_f64, _)| candidate_f64 < *prior_f64);
+                        Some(_) => {
+                            let is_new_minimum = match current_min.as_ref() {
+                                None => true,
+                                Some(prior) => compare_ordered(field_value, prior)?.is_lt(),
+                            };
                             if is_new_minimum {
-                                // Preserve the original Value so integer types survive.
-                                *current_min = Some((candidate_f64, field_value.clone()));
+                                *current_min = Some(field_value.clone());
                             }
                         },
                         None if field_value.is_null() => {
@@ -486,13 +491,16 @@ impl Accumulator {
             // MAX
             (Accumulator::Max { current_max }, Aggregation::Max { field, out }) => {
                 match element.get(field.as_str()) {
+                    // `as_f64_strict` is the numeric-type guard only; the actual
+                    // max is decided by exact comparison so large integers survive.
                     Some(field_value) => match as_f64_strict(field_value) {
-                        Some(candidate_f64) => {
-                            let is_new_maximum = current_max
-                                .as_ref()
-                                .is_none_or(|(prior_f64, _)| candidate_f64 > *prior_f64);
+                        Some(_) => {
+                            let is_new_maximum = match current_max.as_ref() {
+                                None => true,
+                                Some(prior) => compare_ordered(field_value, prior)?.is_gt(),
+                            };
                             if is_new_maximum {
-                                *current_max = Some((candidate_f64, field_value.clone()));
+                                *current_max = Some(field_value.clone());
                             }
                         },
                         None if field_value.is_null() => {
@@ -591,12 +599,8 @@ impl Accumulator {
                     ActionError::fatal("aggregate: avg overflow (non-finite result)")
                 })?))
             },
-            Accumulator::Min { current_min } => Ok(current_min
-                .map(|(_, original_value)| original_value)
-                .unwrap_or(Value::Null)),
-            Accumulator::Max { current_max } => Ok(current_max
-                .map(|(_, original_value)| original_value)
-                .unwrap_or(Value::Null)),
+            Accumulator::Min { current_min } => Ok(current_min.unwrap_or(Value::Null)),
+            Accumulator::Max { current_max } => Ok(current_max.unwrap_or(Value::Null)),
             Accumulator::Collect { collected_values } => Ok(Value::Array(collected_values)),
             Accumulator::Join {
                 joined_parts,
@@ -1092,6 +1096,46 @@ mod tests {
         let output = extract_output(run(input).await.unwrap());
         assert_eq!(output[0]["lo"].as_i64(), Some(1), "min must be integer 1");
         assert_eq!(output[0]["hi"].as_i64(), Some(3), "max must be integer 3");
+    }
+
+    // ── 8b: min/max over large 64-bit IDs use EXACT comparison ────────────────
+    //
+    // 2^53, 2^53+1, 2^53+2 are distinct i64 but collapse to (near-)equal f64.
+    // RED witness: the old f64 comparison treated them as Equal and kept the
+    // first-seen value, so min == max == 2^53+1 (the first element) — both
+    // asserts below fail.
+    #[tokio::test]
+    async fn min_max_large_integers_exact() {
+        let input = AggregateInput {
+            data: Some(json!([
+                {"v": 9_007_199_254_740_993_i64},
+                {"v": 9_007_199_254_740_994_i64},
+                {"v": 9_007_199_254_740_992_i64},
+            ])),
+            group_by: vec![],
+            aggregations: vec![
+                Aggregation::Min {
+                    field: "v".into(),
+                    out: "lo".into(),
+                },
+                Aggregation::Max {
+                    field: "v".into(),
+                    out: "hi".into(),
+                },
+            ],
+            on_error: OnError::Fail,
+        };
+        let output = extract_output(run(input).await.unwrap());
+        assert_eq!(
+            output[0]["lo"].as_i64(),
+            Some(9_007_199_254_740_992),
+            "min must be the exact smallest large integer"
+        );
+        assert_eq!(
+            output[0]["hi"].as_i64(),
+            Some(9_007_199_254_740_994),
+            "max must be the exact largest large integer"
+        );
     }
 
     // ── 9: group_by produces one row per key in first-seen order ─────────────

--- a/crates/plugin-core/src/actions/if_action.rs
+++ b/crates/plugin-core/src/actions/if_action.rs
@@ -31,9 +31,8 @@
 //!
 //! ### `gt` / `gte` / `lt` / `lte`
 //! - Missing field → **Fatal** (ordered comparison requires a value).
-//! - Both numbers → compare via `f64`. Precision note: f64 loses precision
-//!   on integers larger than 2⁵³; exact large-integer comparison is deferred
-//!   to a future v2 operator.
+//! - Both numbers → integers compared **exactly** (large 64-bit IDs do not lose
+//!   precision); only genuine floats compare via `f64`.
 //! - Both strings → lexicographic byte-order comparison.
 //! - Type mismatch (e.g. number vs string) → **Fatal** with a message naming
 //!   both types.

--- a/crates/plugin-core/src/actions/sort.rs
+++ b/crates/plugin-core/src/actions/sort.rs
@@ -444,6 +444,33 @@ mod tests {
         );
     }
 
+    // ── 5b: sort by large 64-bit integer IDs (beyond f64 precision) ───────────
+    //
+    // 2^53, 2^53+1, 2^53+2 are distinct i64 but all round to (at most two) f64
+    // values. RED witness: with the old f64 comparison they compared Equal and
+    // the stable sort left them in input order [+1, +2, +0] — this assert fails.
+    #[tokio::test]
+    async fn sort_large_integer_ids_exact() {
+        let input = SortInput {
+            data: Some(json!([
+                { "id": 9_007_199_254_740_993_i64 },
+                { "id": 9_007_199_254_740_994_i64 },
+                { "id": 9_007_199_254_740_992_i64 },
+            ])),
+            keys: vec![asc("id")],
+        };
+        let out = extract_output(run(input).await.unwrap());
+        assert_eq!(
+            out,
+            json!([
+                { "id": 9_007_199_254_740_992_i64 },
+                { "id": 9_007_199_254_740_993_i64 },
+                { "id": 9_007_199_254_740_994_i64 },
+            ]),
+            "large integer IDs must sort by exact value, not collapse via f64"
+        );
+    }
+
     // ── 6: sort single key descending (numeric) ───────────────────────────────
     #[tokio::test]
     async fn sort_single_key_descending() {

--- a/crates/plugin-core/src/condition.rs
+++ b/crates/plugin-core/src/condition.rs
@@ -384,39 +384,51 @@ pub(crate) fn evaluate_condition(
 
 /// Compare two JSON values for order.
 ///
-/// Both values must be the same JSON kind: both numbers (compared via f64) or
-/// both strings (lexicographic byte order). Any other combination — including
-/// a number vs. a string — is a Fatal error that names both types.
+/// Both values must be the same JSON kind: both numbers or both strings
+/// (lexicographic byte order). Any other combination — including a number vs. a
+/// string — is a Fatal error that names both types.
 ///
-/// serde_json `Number` values are always finite (they are parsed from valid
-/// JSON text, which cannot represent NaN or Infinity). However, `as_f64()`
-/// returns `None` for very large `u64` values that do not fit in an f64
-/// mantissa without loss, so we still guard the conversion with `ok_or_else`
-/// rather than assuming `as_f64()` can never fail. In the vanishingly rare
-/// case that `f64::partial_cmp` returns `None` (two NaN-like values) we map
-/// it to Fatal rather than panicking.
+/// Integer pairs are compared **exactly** (as `i64`, or as `u64` when both
+/// exceed `i64::MAX`): f64 loses precision past 2^53, which would collapse
+/// distinct large IDs to Equal. Only when an operand is a genuine float, or the
+/// pair straddles the i64/u64 boundary (mixed sign), does the comparison fall
+/// back to f64 — and there the magnitudes are far enough apart that f64 still
+/// orders them correctly.
+///
+/// serde_json `Number` values are always finite (parsed from valid JSON text,
+/// which cannot represent NaN or Infinity), so the f64 fallback still guards
+/// `as_f64()` and `partial_cmp` with `ok_or_else` and maps the impossible
+/// `None` to Fatal rather than panicking.
 pub(crate) fn compare_ordered(a: &Value, b: &Value) -> Result<std::cmp::Ordering, ActionError> {
     match (a, b) {
         (Value::Number(lhs), Value::Number(rhs)) => {
-            // f64 is the common numeric type in serde_json; precision loss on
-            // integers larger than 2^53 is a known limitation (documented in
-            // the core.if module doc; exact large-integer ops deferred to v2).
-            let lhs_f64 = lhs.as_f64().ok_or_else(|| {
-                ActionError::fatal(format!(
-                    "could not represent left-hand number `{lhs}` as f64"
-                ))
-            })?;
-            let rhs_f64 = rhs.as_f64().ok_or_else(|| {
-                ActionError::fatal(format!(
-                    "could not represent right-hand number `{rhs}` as f64"
-                ))
-            })?;
-            // serde_json numbers are always finite, but we handle None defensively.
-            lhs_f64.partial_cmp(&rhs_f64).ok_or_else(|| {
-                ActionError::fatal(format!(
-                    "cannot compare non-finite numbers `{lhs_f64}` and `{rhs_f64}`"
-                ))
-            })
+            // Compare integers exactly: f64 silently loses precision past 2^53,
+            // which collapses distinct large IDs (e.g. Snowflake / 64-bit DB
+            // keys) to Equal. Only fall back to f64 when an operand is a genuine
+            // float or the pair straddles the i64/u64 boundary (mixed sign), a
+            // case f64 still orders correctly.
+            if let (Some(lhs_i64), Some(rhs_i64)) = (lhs.as_i64(), rhs.as_i64()) {
+                Ok(lhs_i64.cmp(&rhs_i64))
+            } else if let (Some(lhs_u64), Some(rhs_u64)) = (lhs.as_u64(), rhs.as_u64()) {
+                Ok(lhs_u64.cmp(&rhs_u64))
+            } else {
+                let lhs_f64 = lhs.as_f64().ok_or_else(|| {
+                    ActionError::fatal(format!(
+                        "could not represent left-hand number `{lhs}` as f64"
+                    ))
+                })?;
+                let rhs_f64 = rhs.as_f64().ok_or_else(|| {
+                    ActionError::fatal(format!(
+                        "could not represent right-hand number `{rhs}` as f64"
+                    ))
+                })?;
+                // serde_json numbers are always finite, but we handle None defensively.
+                lhs_f64.partial_cmp(&rhs_f64).ok_or_else(|| {
+                    ActionError::fatal(format!(
+                        "cannot compare non-finite numbers `{lhs_f64}` and `{rhs_f64}`"
+                    ))
+                })
+            }
         },
         (Value::String(lhs), Value::String(rhs)) => Ok(lhs.as_str().cmp(rhs.as_str())),
         (lhs_val, rhs_val) => Err(ActionError::fatal(format!(
@@ -696,6 +708,43 @@ mod tests {
             value: Some(json!(5)),
         };
         assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    /// Large integers (> 2^53) compare EXACTLY — they must not collapse to
+    /// Equal via an f64 round-trip (Snowflake / 64-bit DB IDs).
+    ///
+    /// RED witness: with the old f64-only path both values became the same f64,
+    /// so `compare_ordered` returned `Equal` and this `gt` was false.
+    #[test]
+    fn gt_large_integers_beyond_f64_precision() {
+        // 2^53 and 2^53 + 1 are distinct i64 but round to the SAME f64.
+        let data = json!({ "id": 9_007_199_254_740_993_i64 });
+        let cond = Condition::Leaf {
+            field: "id".into(),
+            op: ConditionOp::Gt,
+            value: Some(json!(9_007_199_254_740_992_i64)),
+        };
+        assert!(
+            evaluate_condition(&data, &cond).unwrap(),
+            "2^53+1 must be strictly greater than 2^53"
+        );
+    }
+
+    #[test]
+    fn compare_ordered_large_integers_exact() {
+        use std::cmp::Ordering;
+        let bigger = json!(9_007_199_254_740_993_i64);
+        let smaller = json!(9_007_199_254_740_992_i64);
+        assert_eq!(
+            compare_ordered(&bigger, &smaller).unwrap(),
+            Ordering::Greater
+        );
+        assert_eq!(compare_ordered(&smaller, &bigger).unwrap(), Ordering::Less);
+        // Genuine floats still compare via f64.
+        assert_eq!(
+            compare_ordered(&json!(1.5), &json!(2.5)).unwrap(),
+            Ordering::Less
+        );
     }
 
     // RED witness: type mismatch must Fatal, not silently return false.


### PR DESCRIPTION
## What & why
A correctness audit of the `core.*` actions found a real bug class: **ordered comparison of 64-bit integers went through `f64`**, which loses precision past 2^53. Distinct large IDs (Snowflake IDs, 64-bit DB primary keys) collapsed to `Equal`, so:
- `core.sort` left them in input order (wrong sort),
- `core.if` / `core.switch` `gt`/`gte`/`lt`/`lte` returned wrong results,
- `core.aggregate` `min`/`max` picked the first-seen value instead of the true extreme.

Two independent code paths had the flaw: the shared `compare_ordered` (sort + if/switch) and aggregate's separate `as_f64_strict` min/max path.

## Fix
- **`condition.rs` `compare_ordered`**: compare integer pairs exactly — as `i64`, or as `u64` when both exceed `i64::MAX`. Fall back to `f64` only when an operand is a genuine float or the pair is mixed-sign across the i64/u64 boundary (where f64 still orders correctly). Fixes `core.sort`, `core.if`, `core.switch`.
- **`aggregate.rs` min/max**: decide the extreme via `compare_ordered` on the original `Value` (the accumulator now stores the `Value`, not a cached `f64`); `as_f64_strict` remains only as the numeric-type guard. Fixes large-integer min/max.
- Updated the now-stale "f64 precision / deferred to v2" docs in `condition.rs` and the `core.if` module doc.

`Eq`/`Ne` are unaffected — they already compare exact `Number` representations.

## Tests (red→green)
Four new tests, each verified to **fail on the old f64 path** (captured by temporarily reverting the integer fast-path) and pass after:
- `condition::compare_ordered_large_integers_exact` + `gt_large_integers_beyond_f64_precision` (2^53 vs 2^53+1),
- `sort::sort_large_integer_ids_exact` (sorts 2^53, +1, +2 correctly),
- `aggregate::min_max_large_integers_exact` (exact min/max over 2^53±).

Genuine-float comparison is asserted to still work.

## Gates
`cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, **365 nextest** (4 new), `cargo test --doc`, `RUSTDOCFLAGS=-D warnings cargo doc` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)