### PR TITLE
fix(expression): date_add/date_subtract no longer panic on out-of-range amount

### DIFF
--- a/crates/expression/src/builtins/datetime.rs
+++ b/crates/expression/src/builtins/datetime.rs
@@ -155,6 +155,33 @@ pub fn parse_date(
     Ok(Value::Number(dt.timestamp().into()))
 }
 
+/// Build a `chrono::Duration` for a unit string and an (untrusted) `amount`,
+/// rejecting an unknown unit or an out-of-range magnitude with a typed error.
+///
+/// Uses the non-panicking `try_*` constructors: `Duration::weeks`/`days`/… panic
+/// on overflow, and `amount` comes from workflow/template input.
+fn duration_for_unit(fn_name: &str, unit: &str, amount: i64) -> ExpressionResult<chrono::Duration> {
+    let duration = match unit.to_lowercase().as_str() {
+        "seconds" | "second" | "s" => chrono::Duration::try_seconds(amount),
+        "minutes" | "minute" | "m" => chrono::Duration::try_minutes(amount),
+        "hours" | "hour" | "h" => chrono::Duration::try_hours(amount),
+        "days" | "day" | "d" => chrono::Duration::try_days(amount),
+        "weeks" | "week" | "w" => chrono::Duration::try_weeks(amount),
+        _ => {
+            return Err(ExpressionError::expression_invalid_argument(
+                fn_name,
+                format!("Invalid unit: {unit}"),
+            ));
+        },
+    };
+    duration.ok_or_else(|| {
+        ExpressionError::expression_invalid_argument(
+            fn_name,
+            format!("duration {amount} {unit} is out of range"),
+        )
+    })
+}
+
 /// Add duration to a date
 pub fn date_add(
     args: &[Value],
@@ -174,19 +201,13 @@ pub fn date_add(
         )
     })?;
 
-    let new_dt = match unit.to_lowercase().as_str() {
-        "seconds" | "second" | "s" => dt + chrono::Duration::seconds(amount),
-        "minutes" | "minute" | "m" => dt + chrono::Duration::minutes(amount),
-        "hours" | "hour" | "h" => dt + chrono::Duration::hours(amount),
-        "days" | "day" | "d" => dt + chrono::Duration::days(amount),
-        "weeks" | "week" | "w" => dt + chrono::Duration::weeks(amount),
-        _ => {
-            return Err(ExpressionError::expression_invalid_argument(
-                "date_add",
-                format!("Invalid unit: {unit}"),
-            ));
-        },
-    };
+    let duration = duration_for_unit("date_add", unit, amount)?;
+    let new_dt = dt.checked_add_signed(duration).ok_or_else(|| {
+        ExpressionError::expression_invalid_argument(
+            "date_add",
+            format!("adding {amount} {unit} overflows the representable date range"),
+        )
+    })?;
 
     Ok(Value::Number(new_dt.timestamp().into()))
 }
@@ -210,19 +231,13 @@ pub fn date_subtract(
         )
     })?;
 
-    let new_dt = match unit.to_lowercase().as_str() {
-        "seconds" | "second" | "s" => dt - chrono::Duration::seconds(amount),
-        "minutes" | "minute" | "m" => dt - chrono::Duration::minutes(amount),
-        "hours" | "hour" | "h" => dt - chrono::Duration::hours(amount),
-        "days" | "day" | "d" => dt - chrono::Duration::days(amount),
-        "weeks" | "week" | "w" => dt - chrono::Duration::weeks(amount),
-        _ => {
-            return Err(ExpressionError::expression_invalid_argument(
-                "date_subtract",
-                format!("Invalid unit: {unit}"),
-            ));
-        },
-    };
+    let duration = duration_for_unit("date_subtract", unit, amount)?;
+    let new_dt = dt.checked_sub_signed(duration).ok_or_else(|| {
+        ExpressionError::expression_invalid_argument(
+            "date_subtract",
+            format!("subtracting {amount} {unit} overflows the representable date range"),
+        )
+    })?;
 
     Ok(Value::Number(new_dt.timestamp().into()))
 }

--- a/crates/expression/tests/builtin_functions.rs
+++ b/crates/expression/tests/builtin_functions.rs
@@ -668,3 +668,42 @@ fn parse_date_with_tz_ignores_explicit_offset() {
         eval(r#"parse_date("2024-01-01T00:00:00+03:00")"#)
     );
 }
+
+// ──────────────────────────────────────────────
+// DateTime: date_add / date_subtract overflow (no panic)
+// ──────────────────────────────────────────────
+
+#[test]
+fn date_add_normal_still_works() {
+    // epoch 0 + 1 day = 86_400 seconds.
+    assert_eq!(eval(r#"date_add(0, 1, "days")"#), json!(86_400));
+}
+
+#[test]
+fn date_subtract_normal_still_works() {
+    assert_eq!(eval(r#"date_subtract(86400, 1, "days")"#), json!(0));
+}
+
+/// A huge `amount` must return a typed error, not panic.
+///
+/// RED witness: `chrono::Duration::weeks(i64::MAX)` panics, so the old
+/// `dt + Duration::weeks(amount)` aborted the whole evaluation instead of
+/// returning an error.
+#[test]
+fn date_add_overflow_amount_is_error_not_panic() {
+    let err = eval_err(r#"date_add(0, 9223372036854775807, "weeks")"#);
+    assert!(
+        err.contains("out of range") || err.contains("overflow"),
+        "date_add with i64::MAX weeks must be a typed error; got: {err}"
+    );
+}
+
+/// `date_subtract` has the same guard.
+#[test]
+fn date_subtract_overflow_amount_is_error_not_panic() {
+    let err = eval_err(r#"date_subtract(0, 9223372036854775807, "days")"#);
+    assert!(
+        err.contains("out of range") || err.contains("overflow"),
+        "date_subtract with i64::MAX days must be a typed error; got: {err}"
+    );
+}


### PR DESCRIPTION
## What & why
An audit of `nebula-expression` found a **panic on untrusted input**. `date_add`/`date_subtract` build the duration with `chrono::Duration::weeks(amount)` (and `days`/`hours`/…), which **panic** on overflow, then add it via `dt + dur`, which also panics on out-of-range. `amount` comes from workflow/template input, so:

```
date_add(0, 9223372036854775807, "weeks")   →  thread panicked: TimeDelta::weeks out of bounds
```

That aborts the whole evaluation — a crash on attacker-reachable input, and a violation of the library no-panic rule.

## Fix
- New shared `duration_for_unit` helper builds the duration with the **non-panicking** `try_seconds`/`try_minutes`/`try_hours`/`try_days`/`try_weeks` constructors (also unifies the unit table for both functions).
- Apply it with `checked_add_signed` / `checked_sub_signed`.
- An out-of-range `amount` or result now returns a typed `ExpressionError`, never panics.

## Tests (red→green)
- `date_add_overflow_amount_is_error_not_panic` / `date_subtract_…` — assert a typed error for `i64::MAX`; **verified to panic on the old path** (`TimeDelta::weeks out of bounds`) before the fix.
- `date_add_normal_still_works` / `date_subtract_normal_still_works` — regression guards (epoch ± 1 day).

## Gates
`cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, **371 nextest** (4 new), `cargo test --doc`, `RUSTDOCFLAGS=-D warnings cargo doc` — all green.

## Note
The same audit flagged lower-severity footguns in the math builtins (`pow`/`round` returning `null` on non-finite results, integer args collapsing to `f64`) where the `**` operator already gets it right. Those are follow-ups; this PR fixes the one crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)