### PR TITLE
fix(schema): derive macros handle raw idents + acronym casing; reject duplicate option values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ dependencies = [
 name = "nebula-schema-macros"
 version = "0.1.0"
 dependencies = [
+ "heck",
  "proc-macro-crate",
  "proc-macro2",
  "quote",

--- a/crates/schema/macros/Cargo.toml
+++ b/crates/schema/macros/Cargo.toml
@@ -18,6 +18,10 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "3"
+# Case conversion for `#[derive(EnumSelect)]` option values — `heck` splits
+# acronym runs correctly (`HTTPProxy` → `http_proxy`) where a hand-rolled pass
+# does not. Small, maintained, the de-facto standard (used by serde/clap).
+heck = "0.5"
 
 [lints]
 workspace = true

--- a/crates/schema/macros/src/derive_enum.rs
+++ b/crates/schema/macros/src/derive_enum.rs
@@ -7,19 +7,23 @@
 //!
 //! # Value encoding
 //!
-//! Each variant's stored value is `snake_case(variant_name)` — this is
-//! **hardcoded** and does not read `serde` attributes. If an enum also
-//! derives `Serialize` / `Deserialize` and intends the catalog options
-//! to round-trip back into the enum, the enum author must pin
-//! `#[serde(rename_all = "snake_case")]` (or `#[serde(rename = "...")]`
-//! per variant) to match. Reading serde attrs here is tracked for a
-//! follow-up — at this point in the lifecycle the only consumers of
-//! `EnumSelect` are not also `Serialize`-derivers, so hardcoding the
-//! safe default is the simplest honest implementation.
+//! Each variant's stored value is its name in `snake_case`, computed with
+//! [`heck`] so acronym runs split correctly (`HTTPProxy` → `http_proxy`, not
+//! `httpproxy`). Two variants that collapse to the same value are a spanned
+//! compile error rather than a silent collision.
+//!
+//! This does **not** yet read `serde` rename attributes. An enum that also
+//! derives `Serialize` / `Deserialize` and wants its catalog options to
+//! round-trip must keep an explicit `#[serde(rename_all = "snake_case")]` (or
+//! per-variant `#[serde(rename = "...")]`) aligned with this default. Honoring
+//! serde attributes is the keystone of the schema↔wire key-alignment follow-up.
 
+use std::collections::HashMap;
+
+use heck::ToSnakeCase;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{Data, DataEnum, DeriveInput, Fields};
+use syn::{Data, DataEnum, DeriveInput, Fields, ext::IdentExt};
 
 use crate::attrs::FieldAttrs;
 
@@ -40,6 +44,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
     };
 
     let mut option_exprs = Vec::with_capacity(variants.len());
+    let mut seen_values = HashMap::with_capacity(variants.len());
     for variant in variants {
         if !matches!(variant.fields, Fields::Unit) {
             return Err(syn::Error::new_spanned(
@@ -48,9 +53,22 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
             ));
         }
         let variant_name = &variant.ident;
-        let value = snake_case(&variant_name.to_string());
+        // Strip the raw-identifier prefix (`r#Type` → `Type`), then split on
+        // case/acronym boundaries via `heck` so `HTTPProxy` → `http_proxy`.
+        let value = variant_name.unraw().to_string().to_snake_case();
+        if let Some(previous) = seen_values.insert(value.clone(), variant_name.clone()) {
+            return Err(syn::Error::new_spanned(
+                variant_name,
+                format!(
+                    "#[derive(EnumSelect)]: variants `{previous}` and `{variant_name}` both map to \
+                     the option value `{value}` — rename one variant so its catalog value is unique",
+                ),
+            ));
+        }
         let field_attr = FieldAttrs::from_attrs(&variant.attrs)?;
-        let label = field_attr.label.unwrap_or_else(|| variant_name.to_string());
+        let label = field_attr
+            .label
+            .unwrap_or_else(|| variant_name.unraw().to_string());
         let description = field_attr.description;
         let mut expr = quote! {
             #crate_path::SelectOption::new(
@@ -74,23 +92,4 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
             }
         }
     })
-}
-
-/// Convert a `CamelCase` identifier to `snake_case`.
-fn snake_case(ident: &str) -> String {
-    let mut out = String::with_capacity(ident.len() + 4);
-    let mut prev_lower = false;
-    for (i, ch) in ident.chars().enumerate() {
-        if ch.is_ascii_uppercase() {
-            if i > 0 && prev_lower {
-                out.push('_');
-            }
-            out.push(ch.to_ascii_lowercase());
-            prev_lower = false;
-        } else {
-            out.push(ch);
-            prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
-        }
-    }
-    out
 }

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -3,9 +3,9 @@
 //! Generates `impl HasSchema for T { fn schema() -> ValidSchema { ... } }`
 //! where the schema is computed once and cached behind a `OnceLock`.
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::{Data, DataStruct, DeriveInput, Fields, Ident};
+use syn::{Data, DataStruct, DeriveInput, Fields, Ident, ext::IdentExt};
 
 use crate::{
     attrs::{DefaultLit, FieldAttrs, SchemaStructAttrs, ValidateAttrs},
@@ -110,6 +110,31 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
     })
 }
 
+/// Derive the schema key for a struct field: strip the raw-identifier prefix
+/// (`r#type` → `type`, matching serde's own raw-ident handling) and validate it
+/// against the `FieldKey` rules at expansion, so an invalid key surfaces as a
+/// spanned compile error instead of a runtime `.expect()` panic in the
+/// consuming crate.
+fn ident_to_field_key(ident: &Ident) -> syn::Result<String> {
+    let key = ident.unraw().to_string();
+    check_field_key(&key, ident.span())?;
+    Ok(key)
+}
+
+/// Validate a generated schema-key string against the shared `FieldKey` rules
+/// (`crate::validate_field_key`) and report a violation as a spanned error.
+fn check_field_key(key: &str, span: Span) -> syn::Result<()> {
+    crate::validate_field_key(key).map_err(|reason| {
+        syn::Error::new(
+            span,
+            format!(
+                "`{key}` is not a valid schema field key ({reason}); rename the field so its \
+                 key is a non-empty ASCII identifier of at most 64 characters"
+            ),
+        )
+    })
+}
+
 /// Build the token-stream expression that produces a `Field` for one struct field.
 fn build_field_expr(
     field_name: &Ident,
@@ -118,13 +143,13 @@ fn build_field_expr(
     validate: &ValidateAttrs,
     crate_path: &TokenStream2,
 ) -> syn::Result<TokenStream2> {
-    let key_str = field_name.to_string();
-    // Wrap as FieldKey via fallible constructor + expect (Rust idents are
-    // always valid FieldKey strings — `.expect()` is unreachable in practice
-    // and is the derive-codegen equivalent of `unreachable!`).
+    let key_str = ident_to_field_key(field_name)?;
+    // `key_str` was validated against the `FieldKey` rules at expansion (see
+    // `ident_to_field_key`), so the runtime constructor cannot fail — the
+    // `.expect()` is the codegen equivalent of `unreachable!`.
     let key = quote! {
         #crate_path::FieldKey::new(#key_str)
-            .expect("#[derive(Schema)] field name is a valid FieldKey")
+            .expect("#[derive(Schema)] field key validated at macro expansion")
     };
     let optional = kind.is_optional();
     let inner = kind.inner();
@@ -353,15 +378,18 @@ fn list_field_expr(
     item_kind: &FieldKind,
     crate_path: &TokenStream2,
 ) -> syn::Result<TokenStream2> {
-    let key_str = field_name.to_string();
+    let key_str = ident_to_field_key(field_name)?;
     let item_key_str = format!("{key_str}_item");
+    // The item key derives from an already-valid field key; re-check it because
+    // the `_item` suffix can push a near-limit key past the 64-char bound.
+    check_field_key(&item_key_str, field_name.span())?;
     let key = quote! {
         #crate_path::FieldKey::new(#key_str)
-            .expect("#[derive(Schema)] field name is a valid FieldKey")
+            .expect("#[derive(Schema)] field key validated at macro expansion")
     };
     let item_key = quote! {
         #crate_path::FieldKey::new(#item_key_str)
-            .expect("#[derive(Schema)] list item key is a valid FieldKey")
+            .expect("#[derive(Schema)] list item key validated at macro expansion")
     };
     let item_expr = match item_kind {
         FieldKind::String => quote! { #crate_path::Field::string(#item_key) },

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -44,7 +44,7 @@ pub fn field_key(input: TokenStream) -> TokenStream {
     let lit = parse_macro_input!(input as LitStr);
     let value = lit.value();
 
-    if let Err(msg) = validate(&value) {
+    if let Err(msg) = validate_field_key(&value) {
         return syn::Error::new(lit.span(), format!("invalid FieldKey literal: {msg}"))
             .to_compile_error()
             .into();
@@ -86,7 +86,12 @@ pub fn derive_enum_select(input: TokenStream) -> TokenStream {
         .into()
 }
 
-fn validate(value: &str) -> Result<(), &'static str> {
+/// Validate a candidate schema field key against the `FieldKey` rules
+/// (non-empty, ≤64 chars, leading ASCII letter or `_`, then ASCII alphanumerics
+/// or `_`). Shared by the `field_key!` macro and the `Schema` / `EnumSelect`
+/// derives so the rules live in exactly one place (mirror of
+/// `nebula_schema::FieldKey::new`).
+pub(crate) fn validate_field_key(value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
         return Err("key cannot be empty");
     }

--- a/crates/schema/tests/compile_fail/derive_enum_value_collision.rs
+++ b/crates/schema/tests/compile_fail/derive_enum_value_collision.rs
@@ -1,0 +1,12 @@
+use nebula_schema::EnumSelect;
+
+// `HttpGet` and `HTTPGet` both snake_case to `http_get` — the derive must reject
+// the collision with a spanned compile error rather than silently emitting two
+// options with the same value.
+#[derive(EnumSelect)]
+enum Collide {
+    HttpGet,
+    HTTPGet,
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_enum_value_collision.stderr
+++ b/crates/schema/tests/compile_fail/derive_enum_value_collision.stderr
@@ -1,0 +1,5 @@
+error: #[derive(EnumSelect)]: variants `HttpGet` and `HTTPGet` both map to the option value `http_get` — rename one variant so its catalog value is unique
+ --> tests/compile_fail/derive_enum_value_collision.rs:9:5
+  |
+9 |     HTTPGet,
+  |     ^^^^^^^

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -244,3 +244,40 @@ fn sanity_build_many_fields_via_derive() {
         .expect("derived fields build into a new Schema");
     assert_eq!(s.fields().len(), 1);
 }
+
+// ── raw identifiers (keywords as field names) ──────────────────────────────
+
+#[derive(Schema)]
+#[expect(dead_code, reason = "fields exercised via HasSchema::schema")]
+struct RawIdentFields {
+    // `r#type` / `r#async` use Rust keywords as field names. The derive must
+    // strip the raw-identifier prefix to the schema keys `type` / `async`
+    // (matching serde) instead of panicking at runtime on the `#` in `r#type`.
+    r#type: String,
+    r#async: bool,
+}
+
+#[test]
+fn derive_schema_strips_raw_identifier_prefix() {
+    let schema = RawIdentFields::schema();
+    let keys: Vec<&str> = schema.fields().iter().map(|f| f.key().as_str()).collect();
+    assert_eq!(keys, ["type", "async"]);
+}
+
+// ── acronym-aware snake_case for enum option values ────────────────────────
+
+#[derive(EnumSelect, Clone, Copy)]
+#[expect(dead_code, reason = "variants exercised via derive")]
+enum AcronymMethod {
+    HTTPProxy,
+    PostBody,
+}
+
+#[test]
+fn derive_enum_select_uses_heck_for_acronyms() {
+    let options = AcronymMethod::select_options();
+    // `heck` splits the leading acronym run: `HTTPProxy` → `http_proxy`
+    // (the previous hand-rolled pass produced `httpproxy`).
+    assert_eq!(options[0].value, json!("http_proxy"));
+    assert_eq!(options[1].value, json!("post_body"));
+}


### PR DESCRIPTION
## Summary

Two correctness fixes in the `nebula-schema` derive macros. `#[derive(Schema)]` panicked at runtime when a field used a raw identifier (`r#type`), and `#[derive(EnumSelect)]` silently mangled acronyms and allowed colliding option values. Both are now handled at macro-expansion time. This is Step 0 of a broader `nebula-schema` audit/fix-plan (design records live in the maintainers' private design vault).

## Linked issue

None — Step 0 of the `nebula-schema` audit; design records are in the maintainers' private design vault, not in this repo.

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests added

## Affected crates / areas

- `nebula-schema` (the `nebula-schema-macros` proc-macro crate)

## Changes

- `derive_schema.rs`: new `ident_to_field_key()` strips the raw-identifier prefix (`r#type` → `type`, matching serde) and validates the resulting key against the `FieldKey` rules at expansion. An invalid key is now a **spanned compile error** instead of a runtime `.expect()` panic in the consuming crate. The list-item key is re-checked because the `_item` suffix can push a near-limit key past 64 chars.
- `derive_enum.rs`: option values now use `heck::ToSnakeCase` (`HTTPProxy` → `http_proxy`) instead of a hand-rolled pass that lost acronym boundaries (`httpproxy`). Two variants that collapse to the same option value are rejected with a spanned compile error instead of emitting silent duplicates. The variant ident is also `unraw()`'d.
- `lib.rs`: the `field_key!` key validator is now `pub(crate) validate_field_key` and reused by both derives — one copy of the `FieldKey` rules, not a fourth.
- `macros/Cargo.toml` + `Cargo.lock`: add `heck = "0.5"` (already present transitively in the lockfile).

## Test plan

- `derive_schema_strips_raw_identifier_prefix` — a struct with `r#type` / `r#async` fields yields keys `type` / `async` (this test **panics** without the fix).
- `derive_enum_select_uses_heck_for_acronyms` — `HTTPProxy` → `http_proxy`, `PostBody` → `post_body` (this test produced `httpproxy` without the fix).
- `tests/compile_fail/derive_enum_value_collision.rs` (trybuild) — `HttpGet` + `HTTPGet` both map to `http_get` → spanned compile error pinned in `.stderr`.
- Existing `derive_enum_select_generates_options` is unchanged (single-word variants `get`/`post`/`delete` are identical under `heck`).

### Local verification

- [x] `cargo fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean (pre-push `clippy-full`)
- [x] `cargo nextest run --workspace` — passes (430/430)
- [ ] `cargo test --workspace --doc` — n/a (only internal proc-macro module docs touched; no public doctests added)
- [x] `cargo deny check` — advisories/bans/licenses/sources ok (pre-commit `cargo-deny`)

## Breaking changes

Behavior change, **not a break for the current tree**:

- `EnumSelect` option values for variants with acronym runs now split differently (`HTTPProxy` → `http_proxy`). No such variants exist in-tree (verified — only the single-word `HttpMethod` enum, whose values are unchanged), so nothing in this repo changes value.
- Two `EnumSelect` variants that collapse to the same value are now a compile error (previously a silent duplicate).

## Docs checklist

- [x] Layer direction preserved (change is internal to the `nebula-schema` derive macros; no new cross-crate deps beyond `heck`)
- [x] No L2 invariant changed (derive codegen only; runtime schema/validation contracts unchanged)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code — the change **removes** a runtime panic path; the remaining generated `.expect()` is now provably unreachable (key validated at expansion) with an honest comment
- [x] No silent error suppression
- [x] Execution / engine state transitions — n/a (no engine code touched)
- [x] Credentials / secrets — n/a (no secret paths touched)
- [x] No new `unsafe` (`#![forbid(unsafe_code)]` in the crate)

## Notes for reviewers

- This is Step 0 of the `nebula-schema` audit fix-plan; the next step is the C1 keystone (making `#[derive(Schema)]` honor `#[serde(rename/rename_all/skip/flatten)]` so the schema key matches the wire key — a credential-struct footgun today).
- The `FieldKey`-rules duplication flagged in the audit is reduced here: the macro now has a single validator shared with `field_key!`. The remaining `lib.rs` ↔ `key.rs` runtime duplication is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved enum variant name handling with better support for acronyms (e.g., `HTTPProxy` → `http_proxy`).

* **Bug Fixes**
  * Added compile-time validation of field keys in schema derive macros with descriptive error messages.
  * Detect and prevent enum variant collisions that map to the same catalog value, emitting compile errors instead of allowing silent duplicates.

* **Tests**
  * Added test coverage for enum value collision detection and acronym handling in derived enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->