### PR TITLE
fix(schema): enforce SchemaKind Top/Bottom split across assignability

### DIFF
--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -450,15 +450,14 @@ impl ActionMetadata {
 
         // TypeDAG output-schema assignability: the NEW output is the producer;
         // the OLD output is the consumer (downstream nodes were typed against it).
-        // If `is_assignable` returns Err the new output dropped or changed a field
-        // that old consumers required — that is a silent breaking change on a
-        // same-major upgrade. A major version bump is required.
+        // If `is_assignable_schema` returns Err the new output dropped or changed
+        // a field that old consumers required — that is a silent breaking change
+        // on a same-major upgrade. A major version bump is required. The
+        // kind-aware check also catches a new output collapsing to an empty
+        // record (`Output = ()`), which an untyped `Any` would have masked.
         if same_major
-            && nebula_schema::is_assignable(
-                self.output_schema.fields(),
-                previous.output_schema.fields(),
-            )
-            .is_err()
+            && nebula_schema::is_assignable_schema(&self.output_schema, &previous.output_schema)
+                .is_err()
         {
             return Err(MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump);
         }

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -1065,6 +1065,63 @@ mod tests {
     }
 
     #[test]
+    fn output_schema_collapsed_to_empty_record_same_major_is_rejected() {
+        // v1.0 produces a typed record; v1.1 collapses output to `()` (an empty
+        // record — `ValidSchema::empty()`), emitting nothing. Downstream
+        // consumers that required any field break. The kind-aware check catches
+        // this collapse; the old gradual slice check masked it as `Any`.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, ValidSchema, field_key};
+        let typed = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("status"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(typed);
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 1)
+            .with_output_schema(ValidSchema::empty());
+
+        let err = next
+            .validate_compatibility(&prev)
+            .expect_err("collapsing output to an empty record on same major must be rejected");
+        assert_eq!(
+            err,
+            MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump,
+            "expected OutputSchemaNarrowedWithoutMajorBump for the `()` collapse"
+        );
+    }
+
+    #[test]
+    fn output_schema_collapsed_to_any_same_major_is_allowed() {
+        // Contrast with the empty-record collapse: v1.1 makes output the gradual
+        // `Any` (`serde_json::Value` -> `ValidSchema::any()`). An `Any` producer
+        // may still emit the old fields, so the break cannot be proven and the
+        // check passes — locking the gradual escape and proving the sibling
+        // rejection above is not tautological.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, ValidSchema, field_key};
+        let typed = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("status"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(typed);
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 1)
+            .with_output_schema(ValidSchema::any());
+
+        assert!(
+            next.validate_compatibility(&prev).is_ok(),
+            "collapsing output to the gradual `Any` cannot be proven breaking — must be allowed"
+        );
+    }
+
+    #[test]
     fn output_schema_narrowed_with_major_bump_is_allowed() {
         // A major version bump signals a breaking contract change — narrowing
         // the output is permitted regardless of what fields disappear.

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -8,7 +8,7 @@
 //! [`ValidSchema::fields`](crate::ValidSchema::fields) return `&[Field]`, so
 //! callers with either type call `is_assignable(producer.fields(), consumer.fields())`.
 
-use crate::{Field, FieldKey, RequiredMode};
+use crate::{Field, FieldKey, RequiredMode, SchemaKind, ValidSchema};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -111,6 +111,11 @@ pub enum SchemaIncompat {
 ///   `Computed` field on either side is treated as `Any`, so today's
 ///   `serde_json::Value` (⇒ empty schema) workflows continue to pass. The
 ///   check only bites when both endpoints carry non-trivial typed schemas.
+///   This slice-level entry point is **gradual**: it cannot tell an empty
+///   *record* (`()`) from the gradual `Any`, so it treats every empty producer
+///   as `Any`. To enforce the Top/Bottom split — an empty record produces no
+///   fields and must *not* satisfy a required consumer — use
+///   [`is_assignable_schema`], which inspects [`SchemaKind`].
 /// - **`Notice` fields** are display-only and are ignored on the consumer side.
 /// - Only [`RequiredMode::Always`] consumer fields are hard requirements;
 ///   [`RequiredMode::When`] and the default optional mode are not enforced
@@ -141,7 +146,49 @@ pub enum SchemaIncompat {
 ///   present on both sides but the `multiple` flag differs.
 #[must_use = "check the Result — an Err means the producer is not assignable to the consumer"]
 pub fn is_assignable(producer: &[Field], consumer: &[Field]) -> Result<(), SchemaIncompat> {
-    fields_assignable(producer, consumer)
+    // Gradual mode: an empty producer slice is the `Any` escape (see the
+    // `strict = false` short-circuit in `fields_assignable`).
+    fields_assignable(producer, consumer, false)
+}
+
+/// Kind-aware structural assignability: are producer values assignable where
+/// consumer values are expected, honoring the [`SchemaKind`] Top/Bottom split?
+///
+/// Unlike [`is_assignable`], which sees only `&[Field]` and therefore treats
+/// *every* empty schema as the gradual `Any`, this entry point distinguishes
+/// the gradual `Any` ([`SchemaKind::Any`] — `serde_json::Value`) from an empty
+/// *record* ([`SchemaKind::Record`] with no fields — `()`):
+///
+/// - **Gradual `Any` escape** — if either side is [`SchemaKind::Any`], the
+///   producer may emit anything (satisfies any consumer) and the consumer
+///   accepts anything, so the check passes. This preserves untyped
+///   `serde_json::Value` interop.
+/// - **Strict record subtyping** — when **both** sides are concrete records,
+///   width-subtyping is enforced *without* the empty-producer `Any` escape: an
+///   empty record produces no fields, so it does **not** satisfy a consumer
+///   that hard-requires any (it returns [`SchemaIncompat::MissingRequiredField`]).
+///   An empty record *consumer* still accepts everything (it requires nothing).
+///
+/// This is the entry point the workflow per-edge validator and the action
+/// output-evolution check use, so the Top/Bottom split is actually enforced on
+/// real producer→consumer edges rather than only at the type/serde level.
+///
+/// # Errors
+///
+/// Returns the same [`SchemaIncompat`] taxonomy as [`is_assignable`] (the first
+/// incompatibility found, depth-first, consumer-field order) when both sides are
+/// concrete records and the strict check fails.
+#[must_use = "check the Result — an Err means the producer is not assignable to the consumer"]
+pub fn is_assignable_schema(
+    producer: &ValidSchema,
+    consumer: &ValidSchema,
+) -> Result<(), SchemaIncompat> {
+    // Gradual `Any` on either side is the escape hatch.
+    if producer.kind() == SchemaKind::Any || consumer.kind() == SchemaKind::Any {
+        return Ok(());
+    }
+    // Both are concrete records: strict width-subtyping, no empty-producer escape.
+    fields_assignable(producer.fields(), consumer.fields(), true)
 }
 
 // ── Private core ─────────────────────────────────────────────────────────────
@@ -154,10 +201,17 @@ pub fn is_assignable(producer: &[Field], consumer: &[Field]) -> Result<(), Schem
 fn fields_assignable(
     producer_fields: &[Field],
     consumer_fields: &[Field],
+    strict: bool,
 ) -> Result<(), SchemaIncompat> {
-    // Any escape: empty producer = untyped/opaque output (gradual-typing `Any`);
-    // empty consumer = accepts everything.
-    if producer_fields.is_empty() || consumer_fields.is_empty() {
+    // An empty consumer requires nothing — always satisfiable, both modes.
+    if consumer_fields.is_empty() {
+        return Ok(());
+    }
+    // Gradual mode: an empty producer is the untyped/opaque `Any` escape. In
+    // strict mode the producer is a concrete record that emits exactly these
+    // fields, so an empty producer must face the per-field required check below
+    // (and will fail any hard-required consumer field).
+    if !strict && producer_fields.is_empty() {
         return Ok(());
     }
 
@@ -182,7 +236,7 @@ fn fields_assignable(
                 continue;
             },
             Some(producer_field) => {
-                field_pair_assignable(consumer_key, producer_field, consumer_field)?;
+                field_pair_assignable(consumer_key, producer_field, consumer_field, strict)?;
             },
         }
     }
@@ -213,8 +267,11 @@ fn field_pair_assignable(
     key: &FieldKey,
     producer_field: &Field,
     consumer_field: &Field,
+    strict: bool,
 ) -> Result<(), SchemaIncompat> {
-    // Any escape: Dynamic or Computed on either side matches anything.
+    // Any escape: Dynamic or Computed on either side matches anything. This
+    // per-field gradual escape holds in both modes — a `Dynamic`/`Computed`
+    // field is explicitly `Any`-typed regardless of the enclosing record's kind.
     if matches!(producer_field, Field::Dynamic(_) | Field::Computed(_))
         || matches!(consumer_field, Field::Dynamic(_) | Field::Computed(_))
     {
@@ -243,7 +300,7 @@ fn field_pair_assignable(
             Ok(())
         },
         (Field::Object(producer_obj), Field::Object(consumer_obj)) => {
-            fields_assignable(&producer_obj.fields, &consumer_obj.fields).map_err(|inner| {
+            fields_assignable(&producer_obj.fields, &consumer_obj.fields, strict).map_err(|inner| {
                 SchemaIncompat::NestedIncompat {
                     key: key.clone(),
                     inner: Box::new(inner),
@@ -255,12 +312,12 @@ fn field_pair_assignable(
                 // Either side has no typed item schema — Any escape.
                 (None, _) | (_, None) => Ok(()),
                 (Some(producer_item), Some(consumer_item)) => {
-                    field_pair_assignable(key, producer_item, consumer_item).map_err(|inner| {
-                        SchemaIncompat::NestedIncompat {
+                    field_pair_assignable(key, producer_item, consumer_item, strict).map_err(
+                        |inner| SchemaIncompat::NestedIncompat {
                             key: key.clone(),
                             inner: Box::new(inner),
-                        }
-                    })
+                        },
+                    )
                 },
             }
         },
@@ -567,5 +624,79 @@ mod tests {
         let producer = [Field::select(fk("tags")).multiple().required().into()];
         let consumer = [Field::select(fk("tags")).multiple().required().into()];
         assert_eq!(is_assignable(&producer, &consumer), Ok(()));
+    }
+
+    // ── Kind-aware entry point (`is_assignable_schema`): Top/Bottom split ──────
+
+    /// Build a single-required-field record `ValidSchema`.
+    fn required_record(key: &str) -> ValidSchema {
+        crate::Schema::builder()
+            .add(Field::string(fk(key)).required())
+            .build()
+            .unwrap()
+    }
+
+    /// The defining fix: an empty **record** producer (`()`) does NOT satisfy a
+    /// consumer that hard-requires a field — unlike the gradual `Any`, an empty
+    /// record provably emits nothing.
+    #[test]
+    fn empty_record_producer_does_not_satisfy_required_consumer() {
+        let producer = ValidSchema::empty(); // Record, zero fields
+        let consumer = required_record("name");
+        assert_eq!(
+            is_assignable_schema(&producer, &consumer),
+            Err(SchemaIncompat::MissingRequiredField { key: fk("name") }),
+        );
+    }
+
+    /// Contrast: a gradual `Any` producer DOES satisfy the same required
+    /// consumer — the escape hatch the slice-level check could not distinguish.
+    #[test]
+    fn any_producer_satisfies_required_consumer() {
+        let producer = ValidSchema::any();
+        let consumer = required_record("name");
+        assert_eq!(is_assignable_schema(&producer, &consumer), Ok(()));
+    }
+
+    /// An `Any` consumer accepts any producer (it requires nothing).
+    #[test]
+    fn typed_producer_satisfies_any_consumer() {
+        let producer = required_record("name");
+        let consumer = ValidSchema::any();
+        assert_eq!(is_assignable_schema(&producer, &consumer), Ok(()));
+    }
+
+    /// An empty **record** consumer accepts any producer (requires nothing) —
+    /// the consumer-side escape is preserved in strict mode.
+    #[test]
+    fn empty_record_consumer_accepts_typed_producer() {
+        let producer = required_record("name");
+        let consumer = ValidSchema::empty();
+        assert_eq!(is_assignable_schema(&producer, &consumer), Ok(()));
+    }
+
+    /// Two compatible concrete records pass through the kind-aware entry point,
+    /// matching the slice-level result (no behavior drift on the typed path).
+    #[test]
+    fn compatible_records_via_schema_entry_is_ok() {
+        let producer = crate::Schema::builder()
+            .add(Field::string(fk("name")).required())
+            .add(Field::number(fk("extra")))
+            .build()
+            .unwrap();
+        let consumer = required_record("name");
+        assert_eq!(is_assignable_schema(&producer, &consumer), Ok(()));
+    }
+
+    /// Two incompatible concrete records still produce the same first
+    /// incompatibility through the kind-aware entry point.
+    #[test]
+    fn incompatible_records_via_schema_entry_returns_error() {
+        let producer = required_record("name");
+        let consumer = required_record("other");
+        assert_eq!(
+            is_assignable_schema(&producer, &consumer),
+            Err(SchemaIncompat::MissingRequiredField { key: fk("other") }),
+        );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -4,9 +4,10 @@
 //! per-edge validator (T3) to decide whether a producer node's `Output` schema
 //! is assignable where a consumer node's `Input` schema is expected.
 //!
-//! Both [`Schema::fields`](crate::Schema::fields) and
-//! [`ValidSchema::fields`](crate::ValidSchema::fields) return `&[Field]`, so
-//! callers with either type call `is_assignable(producer.fields(), consumer.fields())`.
+//! The public entry point is [`is_assignable_schema`], which takes two
+//! [`ValidSchema`] values so it can honor the [`SchemaKind`] Top/Bottom split:
+//! `is_assignable_schema(&producer.output, &consumer.input)`. (An internal,
+//! kind-blind slice form is used only by this module's tests.)
 
 use crate::{Field, FieldKey, RequiredMode, SchemaKind, ValidSchema};
 
@@ -14,9 +15,9 @@ use crate::{Field, FieldKey, RequiredMode, SchemaKind, ValidSchema};
 
 /// Why a producer schema is not assignable to a consumer schema.
 ///
-/// Returned by [`is_assignable`] when the structural width-subtyping check
-/// fails. Carries the first incompatibility found (depth-first, consumer-field
-/// order).
+/// Returned by [`is_assignable_schema`] when the structural width-subtyping
+/// check fails. Carries the first incompatibility found (depth-first,
+/// consumer-field order).
 ///
 /// This enum is `#[non_exhaustive]` — new incompatibility kinds (e.g. semantic
 /// type constraints) may be added in future minor versions without breaking
@@ -79,62 +80,78 @@ pub enum SchemaIncompat {
 
 // ── Public entry point ───────────────────────────────────────────────────────
 
-/// Structural width-subtyping: are producer fields assignable where consumer
-/// fields are expected? (`Output <: Input`, Liskov.)
+/// Kind-aware structural width-subtyping: are producer values assignable where
+/// consumer values are expected? (`Output <: Input`, Liskov.)
 ///
-/// Accepts raw field slices so both [`Schema::fields`](crate::Schema::fields)
-/// and [`ValidSchema::fields`](crate::ValidSchema::fields) can be passed
-/// directly without constructing a wrapper type:
+/// This is **the** public assignability check (ADR-0100 T1). The workflow
+/// per-edge validator (T3) and the action output-evolution check both call it,
+/// so the [`SchemaKind`] Top/Bottom split is enforced on real producer→consumer
+/// edges, not merely at the type/serde level.
 ///
 /// ```rust
-/// use nebula_schema::{Field, Schema, field_key, is_assignable};
+/// use nebula_schema::{Field, Schema, ValidSchema, field_key, is_assignable_schema};
 ///
 /// let producer = Schema::builder()
 ///     .add(Field::string(field_key!("name")).required())
 ///     .add(Field::number(field_key!("extra")))
 ///     .build()
 ///     .unwrap();
-///
 /// let consumer = Schema::builder()
 ///     .add(Field::string(field_key!("name")).required())
 ///     .build()
 ///     .unwrap();
+/// // Width subtyping: the producer has every required consumer field (+ extras).
+/// assert!(is_assignable_schema(&producer, &consumer).is_ok());
 ///
-/// assert!(is_assignable(producer.fields(), consumer.fields()).is_ok());
+/// // An empty *record* producer (`()`) provably emits nothing, so it does NOT
+/// // satisfy a consumer that hard-requires a field …
+/// assert!(is_assignable_schema(&ValidSchema::empty(), &consumer).is_err());
+/// // … whereas the gradual `Any` (`serde_json::Value`) still passes.
+/// assert!(is_assignable_schema(&ValidSchema::any(), &consumer).is_ok());
 /// ```
 ///
-/// Implements ADR-0100 §L1/L2:
+/// # Kinds (Top/Bottom split)
+///
+/// - **Gradual `Any` escape** — if either side is [`SchemaKind::Any`] (e.g.
+///   `serde_json::Value`), the producer may emit anything and the consumer
+///   accepts anything, so the check passes; untyped interop is preserved.
+/// - **Strict record subtyping** — when **both** sides are concrete records,
+///   width-subtyping is enforced *without* the empty-producer escape: an empty
+///   record produces no fields, so it does **not** satisfy a consumer that
+///   hard-requires any (it returns [`SchemaIncompat::MissingRequiredField`]). An
+///   empty record *consumer* still accepts everything (it requires nothing).
+///
+/// Strict mode removes only the empty-*record*-producer escape. The per-field
+/// gradual escapes below (`Dynamic`/`Computed` fields, and `List` fields with no
+/// typed item) still pass in **both** modes by construction. A primitive or
+/// `serde_json::Value` output is [`SchemaKind::Any`], so a bare-scalar producer
+/// can never be statically rejected against a record consumer — gradual typing
+/// at the leaf (wrap the value in a `#[derive(Schema)]` struct for strict typing).
+///
+/// # Record subtyping rules (ADR-0100 §L1/L2)
+///
 /// - **Width subtyping** — the consumer's required fields must be a subset of
-///   the producer's fields with type-compatible matches on the overlap. The
-///   producer may emit extra fields; they are ignored.
-/// - **`Any` escape (gradual typing)** — an empty slice or a `Dynamic` /
-///   `Computed` field on either side is treated as `Any`, so today's
-///   `serde_json::Value` (⇒ empty schema) workflows continue to pass. The
-///   check only bites when both endpoints carry non-trivial typed schemas.
-///   This slice-level entry point is **gradual**: it cannot tell an empty
-///   *record* (`()`) from the gradual `Any`, so it treats every empty producer
-///   as `Any`. To enforce the Top/Bottom split — an empty record produces no
-///   fields and must *not* satisfy a required consumer — use
-///   [`is_assignable_schema`], which inspects [`SchemaKind`].
-/// - **`Notice` fields** are display-only and are ignored on the consumer side.
+///   the producer's fields with type-compatible matches on the overlap. Extra
+///   producer fields are ignored.
+/// - **`Dynamic`/`Computed` fields** are treated as `Any` on either side.
+/// - **`Notice` fields** are display-only and ignored on the consumer side.
 /// - Only [`RequiredMode::Always`] consumer fields are hard requirements;
 ///   [`RequiredMode::When`] and the default optional mode are not enforced
 ///   statically (the runtime condition cannot be proved at validation time).
 /// - **`File` and `Select` cardinality** — the `multiple` flag (scalar vs.
-///   array) is checked for equality. A scalar producer paired with an array
-///   consumer (or vice versa) is a wire-shape mismatch and returns
+///   array) is checked for equality; a mismatch returns
 ///   [`SchemaIncompat::CardinalityMismatch`].
 /// - **`Mode` fields** — `Mode`-vs-`Mode` is treated as compatible regardless
 ///   of variant payloads (lenient, never false-rejects). Real union-variance
-///   compatibility (sum-type variance has opposite direction from record
-///   width-subtyping) is deferred to an ADR-0100 addendum.
+///   compatibility is deferred to an ADR-0100 addendum.
 /// - **`Number` integer vs. float** — both carry `type_name() == "number"` and
 ///   are treated as compatible. Numeric-widening subtyping is deferred to an
 ///   ADR-0100 addendum.
 ///
 /// # Errors
 ///
-/// Returns the first [`SchemaIncompat`] found (depth-first, consumer-field order):
+/// When both sides are concrete records and the strict check fails, returns the
+/// first [`SchemaIncompat`] found (depth-first, consumer-field order):
 /// - [`SchemaIncompat::MissingRequiredField`] — a hard-required consumer field
 ///   has no counterpart in the producer.
 /// - [`SchemaIncompat::FieldTypeMismatch`] — a field present on both sides
@@ -144,40 +161,6 @@ pub enum SchemaIncompat {
 ///   fields are incompatible; wraps the inner [`SchemaIncompat`].
 /// - [`SchemaIncompat::CardinalityMismatch`] — a `File` or `Select` field is
 ///   present on both sides but the `multiple` flag differs.
-#[must_use = "check the Result — an Err means the producer is not assignable to the consumer"]
-pub fn is_assignable(producer: &[Field], consumer: &[Field]) -> Result<(), SchemaIncompat> {
-    // Gradual mode: an empty producer slice is the `Any` escape (see the
-    // `strict = false` short-circuit in `fields_assignable`).
-    fields_assignable(producer, consumer, false)
-}
-
-/// Kind-aware structural assignability: are producer values assignable where
-/// consumer values are expected, honoring the [`SchemaKind`] Top/Bottom split?
-///
-/// Unlike [`is_assignable`], which sees only `&[Field]` and therefore treats
-/// *every* empty schema as the gradual `Any`, this entry point distinguishes
-/// the gradual `Any` ([`SchemaKind::Any`] — `serde_json::Value`) from an empty
-/// *record* ([`SchemaKind::Record`] with no fields — `()`):
-///
-/// - **Gradual `Any` escape** — if either side is [`SchemaKind::Any`], the
-///   producer may emit anything (satisfies any consumer) and the consumer
-///   accepts anything, so the check passes. This preserves untyped
-///   `serde_json::Value` interop.
-/// - **Strict record subtyping** — when **both** sides are concrete records,
-///   width-subtyping is enforced *without* the empty-producer `Any` escape: an
-///   empty record produces no fields, so it does **not** satisfy a consumer
-///   that hard-requires any (it returns [`SchemaIncompat::MissingRequiredField`]).
-///   An empty record *consumer* still accepts everything (it requires nothing).
-///
-/// This is the entry point the workflow per-edge validator and the action
-/// output-evolution check use, so the Top/Bottom split is actually enforced on
-/// real producer→consumer edges rather than only at the type/serde level.
-///
-/// # Errors
-///
-/// Returns the same [`SchemaIncompat`] taxonomy as [`is_assignable`] (the first
-/// incompatibility found, depth-first, consumer-field order) when both sides are
-/// concrete records and the strict check fails.
 #[must_use = "check the Result — an Err means the producer is not assignable to the consumer"]
 pub fn is_assignable_schema(
     producer: &ValidSchema,
@@ -347,6 +330,16 @@ mod tests {
 
     fn fk(s: &str) -> FieldKey {
         FieldKey::new(s).unwrap()
+    }
+
+    /// Gradual, kind-blind slice check: an empty producer slice is the `Any`
+    /// escape. This is **test-only** — production code calls
+    /// [`is_assignable_schema`], which honors the `SchemaKind` Top/Bottom split.
+    /// Retained here to exercise the shared per-field matching logic (type
+    /// mismatch, cardinality, nesting) and the gradual empty-producer escape
+    /// directly on `&[Field]` without building a `ValidSchema` per case.
+    fn is_assignable(producer: &[Field], consumer: &[Field]) -> Result<(), SchemaIncompat> {
+        fields_assignable(producer, consumer, false)
     }
 
     // ── Compatible: producer has all required consumer fields + extra ──────
@@ -697,6 +690,79 @@ mod tests {
         assert_eq!(
             is_assignable_schema(&producer, &consumer),
             Err(SchemaIncompat::MissingRequiredField { key: fk("other") }),
+        );
+    }
+
+    /// Both sides `Any` short-circuits to `Ok` via the leading `||` term. Guards
+    /// against the condition being mistyped as `&&` (which would fall through to
+    /// the strict record path — masked here only because both field slices are
+    /// empty, so this test pins the intended both-`Any` contract explicitly).
+    #[test]
+    fn both_any_schemas_are_compatible() {
+        assert_eq!(
+            is_assignable_schema(&ValidSchema::any(), &ValidSchema::any()),
+            Ok(()),
+        );
+    }
+
+    // ── Strict-mode recursion: `strict` must reach nested Object / List leaves ──
+    // These drive the private core directly (the public `is_assignable_schema`
+    // delegates record subtyping to `fields_assignable(.., strict = true)`), and
+    // contrast strict vs gradual at depth so a dropped `strict` argument in the
+    // Object/List recursion arms goes RED.
+
+    /// An empty nested-object producer does NOT satisfy a consumer whose nested
+    /// object hard-requires a field — under strict mode, one level deep. Gradual
+    /// mode escapes it, proving the assertion is `strict`-specific.
+    #[test]
+    fn strict_rejects_empty_nested_object_producer() {
+        let producer = [Field::object(fk("config")).into()]; // empty inner object
+        let consumer = [Field::object(fk("config"))
+            .add(Field::string(fk("host")).required())
+            .into()];
+
+        assert_eq!(
+            fields_assignable(&producer, &consumer, true),
+            Err(SchemaIncompat::NestedIncompat {
+                key: fk("config"),
+                inner: Box::new(SchemaIncompat::MissingRequiredField { key: fk("host") }),
+            }),
+            "strict mode must recurse into the empty producer object and fail the required field"
+        );
+        assert_eq!(
+            fields_assignable(&producer, &consumer, false),
+            Ok(()),
+            "gradual mode escapes the empty nested producer — confirms the strict flag is what bites"
+        );
+    }
+
+    /// A list whose item is an empty object does NOT satisfy a consumer list
+    /// whose item object hard-requires a field — strict propagates List → item →
+    /// Object. Gradual mode escapes it.
+    #[test]
+    fn strict_rejects_empty_nested_list_item_producer() {
+        let producer = [Field::list(fk("items"))
+            .item(Field::object(fk("item")))
+            .into()];
+        let consumer = [Field::list(fk("items"))
+            .item(Field::object(fk("item")).add(Field::string(fk("id")).required()))
+            .into()];
+
+        assert_eq!(
+            fields_assignable(&producer, &consumer, true),
+            Err(SchemaIncompat::NestedIncompat {
+                key: fk("items"),
+                inner: Box::new(SchemaIncompat::NestedIncompat {
+                    key: fk("items"),
+                    inner: Box::new(SchemaIncompat::MissingRequiredField { key: fk("id") }),
+                }),
+            }),
+            "strict mode must recurse List -> item -> Object and fail the required field"
+        );
+        assert_eq!(
+            fields_assignable(&producer, &consumer, false),
+            Ok(()),
+            "gradual mode escapes the empty list-item object — confirms strict propagation"
         );
     }
 }

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -125,6 +125,14 @@ empty_has_schema_for!(
 /// Suitable for test fixtures / legacy types that don't yet declare a real
 /// schema. In production code, prefer `#[derive(Schema)]` so the
 /// schema matches the actual struct shape.
+///
+/// The emitted schema is an empty **record** (`SchemaKind::Record`), not the
+/// gradual `Any`. Used as an action `Output`, it is the genuine "no fields"
+/// case: under [`is_assignable_schema`](crate::is_assignable_schema) it will
+/// **fail** the strict check against a consumer that hard-requires a field. If
+/// gradual typing (an `Any` that satisfies any consumer) is what you want, do
+/// not declare an empty record — use an untyped `serde_json::Value` input, or
+/// implement [`HasSchema`] returning [`ValidSchema::any`](crate::ValidSchema::any).
 #[macro_export]
 macro_rules! impl_empty_has_schema {
     ($($t:ty),* $(,)?) => {

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -46,14 +46,31 @@ pub trait HasSelectOptions {
     fn select_options() -> Vec<SelectOption>;
 }
 
-/// Shared empty schema — delegates to [`ValidSchema::empty`].
+/// Shared empty-record schema — delegates to [`ValidSchema::empty`].
+///
+/// This is a [`SchemaKind::Record`](crate::SchemaKind::Record) with zero fields:
+/// the type genuinely has no inputs. Distinct from [`any_schema`], which is the
+/// gradual-typing `Any` for types whose shape is unknown.
 fn empty_schema() -> ValidSchema {
     ValidSchema::empty()
+}
+
+/// Shared gradual-typing `Any` schema — delegates to [`ValidSchema::any`].
+///
+/// Used for types that carry data of an unknown record shape (`serde_json::Value`,
+/// [`FieldValues`], primitive stubs). Unlike [`empty_schema`] it is *not* an
+/// empty record — it is the lattice `Any`, so it stays distinct from `()` and
+/// does not falsely claim to produce or consume zero fields.
+fn any_schema() -> ValidSchema {
+    ValidSchema::any()
 }
 
 /// Baseline `HasSchema` impl for the unit type — actions / credentials /
 /// resources that have no user-configurable parameters can use `()` as their
 /// `Input` / `Config` without forcing authors to implement the trait.
+///
+/// `()` is an empty *record* (`SchemaKind::Record`): it genuinely has no inputs,
+/// as opposed to the untyped `Any` of `serde_json::Value`.
 impl HasSchema for () {
     fn schema() -> ValidSchema {
         empty_schema()
@@ -61,34 +78,37 @@ impl HasSchema for () {
 }
 
 /// Baseline `HasSchema` impl for dynamic JSON values — authors using untyped
-/// `serde_json::Value` as their `Input` advertise an empty schema. They remain
-/// responsible for documenting the expected shape out-of-band. Use a concrete
-/// typed struct with `#[derive(Schema)]` to get a real schema.
+/// `serde_json::Value` as their `Input` advertise the gradual-typing `Any`: the
+/// shape is unknown, not empty. They remain responsible for documenting the
+/// expected shape out-of-band. Use a concrete typed struct with
+/// `#[derive(Schema)]` to get a real schema.
 impl HasSchema for serde_json::Value {
     fn schema() -> ValidSchema {
-        empty_schema()
+        any_schema()
     }
 }
 
-/// Baseline `HasSchema` impl for [`FieldValues`] — legacy code paths that
-/// still treat the raw value bag as the input type advertise an empty schema.
+/// Baseline `HasSchema` impl for [`FieldValues`] — legacy code paths that still
+/// treat the raw value bag as the input type advertise the gradual-typing `Any`
+/// (unknown shape), not an empty record.
 impl HasSchema for FieldValues {
     fn schema() -> ValidSchema {
-        empty_schema()
+        any_schema()
     }
 }
 
 /// Baseline `HasSchema` impls for common primitives — useful when a trait
 /// (e.g. [`ResourceConfig`](nebula_resource::ResourceConfig)) requires a
 /// `HasSchema` bound and the implementer is using a primitive as a stub.
-/// Any production usage should wrap the primitive in a struct with
-/// `#[derive(Schema)]` instead.
+/// A bare scalar carries data of no record shape, so it advertises the
+/// gradual-typing `Any` rather than an empty record. Any production usage
+/// should wrap the primitive in a struct with `#[derive(Schema)]` instead.
 macro_rules! empty_has_schema_for {
     ($($t:ty),* $(,)?) => {
         $(
             impl HasSchema for $t {
                 fn schema() -> ValidSchema {
-                    empty_schema()
+                    any_schema()
                 }
             }
         )*
@@ -174,26 +194,60 @@ mod tests {
     }
 
     #[test]
-    fn unit_has_empty_schema() {
-        assert_eq!(<() as HasSchema>::schema().fields().len(), 0);
+    fn unit_has_empty_record_schema() {
+        let schema = <() as HasSchema>::schema();
+        assert_eq!(schema.fields().len(), 0);
+        assert_eq!(
+            schema.kind(),
+            crate::SchemaKind::Record,
+            "`()` is a genuine empty record, not the gradual `Any`"
+        );
     }
 
     #[test]
-    fn json_value_has_empty_schema() {
-        assert_eq!(<serde_json::Value as HasSchema>::schema().fields().len(), 0);
+    fn json_value_has_any_schema() {
+        let schema = <serde_json::Value as HasSchema>::schema();
+        assert_eq!(schema.fields().len(), 0);
+        assert_eq!(
+            schema.kind(),
+            crate::SchemaKind::Any,
+            "untyped JSON advertises the gradual `Any`, not an empty record"
+        );
     }
 
     #[test]
-    fn field_values_has_empty_schema() {
-        assert_eq!(<FieldValues as HasSchema>::schema().fields().len(), 0);
+    fn field_values_has_any_schema() {
+        let schema = <FieldValues as HasSchema>::schema();
+        assert_eq!(schema.fields().len(), 0);
+        assert_eq!(schema.kind(), crate::SchemaKind::Any);
     }
 
     #[test]
-    fn empty_schema_is_cached() {
-        let a = <() as HasSchema>::schema();
-        let b = <serde_json::Value as HasSchema>::schema();
-        // Same Arc — shared cache entry.
-        assert_eq!(a, b);
+    fn primitive_stub_has_any_schema() {
+        assert_eq!(<i32 as HasSchema>::schema().kind(), crate::SchemaKind::Any);
+        assert_eq!(
+            <String as HasSchema>::schema().kind(),
+            crate::SchemaKind::Any
+        );
+    }
+
+    #[test]
+    fn unit_and_any_are_distinct_but_each_cached() {
+        let unit_a = <() as HasSchema>::schema();
+        let unit_b = <() as HasSchema>::schema();
+        let any_a = <serde_json::Value as HasSchema>::schema();
+        let any_b = <FieldValues as HasSchema>::schema();
+
+        // Each constructor returns a shared, cached `Arc`.
+        assert!(unit_a.ptr_eq(&unit_b), "`()` schema is cached");
+        assert!(any_a.ptr_eq(&any_b), "the `Any` schema is shared");
+
+        // But the empty record and the gradual `Any` are NOT the same schema:
+        // distinguishing them is the whole point of the Top/Bottom split.
+        assert_ne!(
+            unit_a, any_a,
+            "an empty record must not compare equal to the gradual `Any`"
+        );
     }
 
     #[test]

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -175,7 +175,7 @@ pub use builder::{
     BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
     ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,
 };
-pub use compat::{SchemaIncompat, is_assignable};
+pub use compat::{SchemaIncompat, is_assignable, is_assignable_schema};
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -175,7 +175,7 @@ pub use builder::{
     BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
     ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,
 };
-pub use compat::{SchemaIncompat, is_assignable, is_assignable_schema};
+pub use compat::{SchemaIncompat, is_assignable_schema};
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -238,7 +238,7 @@ pub use schema::{Schema, SchemaBuilder};
 pub use secret::{SECRET_REDACTED, SecretBytes, SecretString, SecretValue, SecretWire};
 pub use transformer::Transformer;
 pub use validated::{
-    FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, ValidSchema, ValidValues,
+    FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, SchemaKind, ValidSchema, ValidValues,
 };
 pub use value::{EXPRESSION_KEY, FieldValue, FieldValues};
 pub use widget::{

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -534,6 +534,7 @@ impl SchemaBuilder {
         build_index(&fields, &mut index, &mut flags);
 
         Ok(ValidSchema::from_inner(ValidSchemaInner {
+            kind: crate::SchemaKind::Record,
             fields,
             index,
             flags,

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -155,8 +155,17 @@ impl<'de> Deserialize<'de> for ValidSchema {
             root_rules: Vec<nebula_validator::Rule>,
         }
         let repr = ValidSchemaRepr::deserialize(deserializer)?;
-        // `Any` carries no fields or rules — return the shared `any()` instance.
         if repr.kind == SchemaKind::Any {
+            // Fail closed: an `Any` schema carries no constraints. A payload
+            // tagged `Any` that also lists `fields`/`root_rules` is malformed
+            // (mistagged, or from a mixed-version producer); silently returning
+            // the unconstrained `any()` would drop every constraint and make
+            // validation fully permissive. Reject it instead.
+            if !repr.fields.is_empty() || !repr.root_rules.is_empty() {
+                return Err(serde::de::Error::custom(
+                    "schema tagged `kind: \"any\"` must not carry `fields` or `root_rules`",
+                ));
+            }
             return Ok(Self::any());
         }
         let mut b = repr.fields.into_iter().fold(
@@ -2108,6 +2117,58 @@ mod tests {
         let back: ValidSchema = serde_json::from_value(wire).unwrap();
         assert_eq!(schema.root_rules(), back.root_rules());
         assert_eq!(schema.fields().len(), back.fields().len());
+    }
+
+    #[test]
+    fn deserialize_bare_any_is_accepted() {
+        use serde_json::json;
+
+        let decoded: ValidSchema = serde_json::from_value(json!({"kind": "any"})).unwrap();
+        assert_eq!(decoded.kind(), SchemaKind::Any);
+        assert!(decoded.fields().is_empty());
+    }
+
+    #[test]
+    fn deserialize_any_carrying_fields_is_rejected() {
+        use serde_json::json;
+
+        // Build a real typed schema, then mistag it as `Any` while keeping its
+        // `fields`. Accepting this would silently drop every field constraint.
+        let typed = Schema::builder()
+            .add(Field::string(field_key!("x")).required())
+            .build()
+            .unwrap();
+        let mut wire = serde_json::to_value(&typed).unwrap();
+        wire["kind"] = json!("any");
+
+        let result: Result<ValidSchema, _> = serde_json::from_value(wire);
+        assert!(
+            result.is_err(),
+            "a schema tagged `kind: any` that still carries fields must be rejected, not \
+             silently coerced to the unconstrained `Any`"
+        );
+    }
+
+    #[test]
+    fn deserialize_any_carrying_root_rules_is_rejected() {
+        use nebula_validator::{Predicate, Rule};
+        use serde_json::json;
+
+        let with_rules = Schema::builder()
+            .add(Field::string(field_key!("x")))
+            .root_rule(Rule::predicate(Predicate::eq("x", json!("a")).unwrap()))
+            .build()
+            .unwrap();
+        let mut wire = serde_json::to_value(&with_rules).unwrap();
+        wire["kind"] = json!("any");
+        // Drop fields so only `root_rules` remains to prove the rule branch fires.
+        wire["fields"] = json!([]);
+
+        let result: Result<ValidSchema, _> = serde_json::from_value(wire);
+        assert!(
+            result.is_err(),
+            "a schema tagged `kind: any` that still carries root_rules must be rejected"
+        );
     }
 
     #[test]

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -58,9 +58,33 @@ pub struct FieldHandle {
     pub depth: u8,
 }
 
+/// Whether a schema describes a concrete record of typed fields, or the
+/// gradual-typing `Any` whose shape is unknown.
+///
+/// `()` and a `#[derive(Schema)]` struct (even one with zero fields) are
+/// [`Record`](SchemaKind::Record); `serde_json::Value` / [`FieldValues`] — inputs
+/// that advertise no fixed shape — are [`Any`](SchemaKind::Any). The two were
+/// previously indistinguishable (both an empty schema), which let an `Any` and an
+/// empty record compare equal and collapse in the type-DAG (the Top/Bottom
+/// collapse). Keeping them apart is the foundation the assignability lattice
+/// builds on: an `Any` producer is gradually permissive, while a `Record`
+/// producer that emits no fields does *not* satisfy a consumer that requires them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SchemaKind {
+    /// A concrete record of typed fields (a derived struct, an empty struct, `()`).
+    #[default]
+    Record,
+    /// Gradual-typing `Any` — the shape is unknown (`serde_json::Value`).
+    Any,
+}
+
 /// Shared interior of a `ValidSchema`.
 #[derive(Debug)]
 pub struct ValidSchemaInner {
+    /// Whether this is a concrete record or the gradual-typing `Any`.
+    pub kind: SchemaKind,
     /// Top-level ordered fields.
     pub fields: Vec<Field>,
     /// Flat index from `FieldPath` → `FieldHandle` for O(1) path lookup.
@@ -87,7 +111,9 @@ pub struct ValidSchema(pub(crate) Arc<ValidSchemaInner>);
 impl PartialEq for ValidSchema {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
-            || (self.0.fields == other.0.fields && self.0.root_rules == other.0.root_rules)
+            || (self.0.kind == other.0.kind
+                && self.0.fields == other.0.fields
+                && self.0.root_rules == other.0.root_rules)
     }
 }
 
@@ -96,16 +122,21 @@ impl Eq for ValidSchema {}
 impl Serialize for ValidSchema {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
-        if self.0.root_rules.is_empty() {
-            let mut s = serializer.serialize_struct("ValidSchema", 1)?;
-            s.serialize_field("fields", &self.0.fields)?;
-            s.end()
-        } else {
-            let mut s = serializer.serialize_struct("ValidSchema", 2)?;
-            s.serialize_field("fields", &self.0.fields)?;
-            s.serialize_field("root_rules", &self.0.root_rules)?;
-            s.end()
+        // `kind` is emitted only for `Any` (the non-default), so every existing
+        // `Record` schema keeps its `{"fields": [...]}` wire shape and a reader
+        // that pre-dates `kind` still round-trips it as a record.
+        let emit_kind = self.0.kind != SchemaKind::Record;
+        let has_rules = !self.0.root_rules.is_empty();
+        let len = 1 + usize::from(emit_kind) + usize::from(has_rules);
+        let mut s = serializer.serialize_struct("ValidSchema", len)?;
+        if emit_kind {
+            s.serialize_field("kind", &self.0.kind)?;
         }
+        s.serialize_field("fields", &self.0.fields)?;
+        if has_rules {
+            s.serialize_field("root_rules", &self.0.root_rules)?;
+        }
+        s.end()
     }
 }
 
@@ -114,12 +145,20 @@ impl<'de> Deserialize<'de> for ValidSchema {
         /// Transparent wrapper that mirrors `Schema`'s serde representation.
         #[derive(Deserialize)]
         struct ValidSchemaRepr {
+            /// Defaults to [`SchemaKind::Record`], so wire data that pre-dates
+            /// `kind` (`{"fields": [...]}`) round-trips as a record.
+            #[serde(default)]
+            kind: SchemaKind,
             #[serde(default)]
             fields: Vec<Field>,
             #[serde(default)]
             root_rules: Vec<nebula_validator::Rule>,
         }
         let repr = ValidSchemaRepr::deserialize(deserializer)?;
+        // `Any` carries no fields or rules — return the shared `any()` instance.
+        if repr.kind == SchemaKind::Any {
+            return Ok(Self::any());
+        }
         let mut b = repr.fields.into_iter().fold(
             crate::schema::SchemaBuilder::default(),
             super::schema::SchemaBuilder::add,
@@ -152,6 +191,7 @@ impl ValidSchema {
         EMPTY
             .get_or_init(|| {
                 Self::from_inner(ValidSchemaInner {
+                    kind: SchemaKind::Record,
                     fields: Vec::new(),
                     index: IndexMap::new(),
                     flags: SchemaFlags::default(),
@@ -159,6 +199,36 @@ impl ValidSchema {
                 })
             })
             .clone()
+    }
+
+    /// Shared gradual-typing `Any` `ValidSchema` — cheap `Arc` clone.
+    ///
+    /// Use this for inputs whose shape is unknown at the type level
+    /// (`serde_json::Value`, [`FieldValues`], primitives that carry no record
+    /// structure). It is field-less like [`empty`](Self::empty),
+    /// but its [`kind`](Self::kind) is [`SchemaKind::Any`], so the assignability
+    /// lattice treats it as the gradual `Any` rather than an empty record —
+    /// keeping the two from collapsing into one another in the type-DAG.
+    pub fn any() -> Self {
+        use std::sync::OnceLock;
+        static ANY: OnceLock<ValidSchema> = OnceLock::new();
+        ANY.get_or_init(|| {
+            Self::from_inner(ValidSchemaInner {
+                kind: SchemaKind::Any,
+                fields: Vec::new(),
+                index: IndexMap::new(),
+                flags: SchemaFlags::default(),
+                root_rules: Vec::new(),
+            })
+        })
+        .clone()
+    }
+
+    /// Whether this schema is a concrete [`Record`](SchemaKind::Record) or the
+    /// gradual-typing [`Any`](SchemaKind::Any).
+    #[must_use]
+    pub fn kind(&self) -> SchemaKind {
+        self.0.kind
     }
 
     /// Return `true` when two `ValidSchema` values share the same backing

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -81,7 +81,13 @@ pub enum SchemaKind {
 }
 
 /// Shared interior of a `ValidSchema`.
+///
+/// An implementation detail: the only constructor is the crate-private
+/// `ValidSchema::from_inner`, so this struct is never built or matched outside
+/// `nebula-schema`. `#[non_exhaustive]` records that intent and lets new fields
+/// (like `kind`) be added without it being an external breaking change.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ValidSchemaInner {
     /// Whether this is a concrete record or the gradual-typing `Any`.
     pub kind: SchemaKind,
@@ -101,10 +107,15 @@ pub struct ValidSchemaInner {
 ///
 /// Cheap to clone — backed by `Arc`.
 ///
-/// Serde: serializes as `{"fields": [...]}` when there are no root rules, or
-/// `{"fields": [...], "root_rules": [...]}` when [`ValidSchemaInner::root_rules`]
-/// is non-empty. Deserialization rebuilds through [`SchemaBuilder`](crate::schema::SchemaBuilder);
-/// invalid wire data returns a [`serde::de::Error`] (lint failures are not panics).
+/// Serde: a [`SchemaKind::Record`] serializes as `{"fields": [...]}` (plus
+/// `"root_rules": [...]` when [`ValidSchemaInner::root_rules`] is non-empty) —
+/// no `kind` tag, so the wire shape is identical to before `kind` existed and a
+/// payload with a missing `kind` deserializes back as a record. A
+/// [`SchemaKind::Any`] serializes as `{"kind": "any", "fields": []}`.
+/// Deserialization rebuilds a record through [`SchemaBuilder`](crate::schema::SchemaBuilder)
+/// (invalid wire data returns a [`serde::de::Error`]; lint failures are not
+/// panics), and **fails closed** if a payload tagged `kind: "any"` carries any
+/// `fields`/`root_rules` instead of silently dropping those constraints.
 #[derive(Debug, Clone)]
 pub struct ValidSchema(pub(crate) Arc<ValidSchemaInner>);
 

--- a/crates/schema/tests/valid_schema_roundtrip.rs
+++ b/crates/schema/tests/valid_schema_roundtrip.rs
@@ -4,7 +4,7 @@
 //! schemas declared by plugin authors must survive a JSON round-trip without
 //! losing field shape.
 
-use nebula_schema::{Field, Schema, ValidSchema, field_key};
+use nebula_schema::{Field, Schema, SchemaKind, ValidSchema, field_key};
 
 #[test]
 fn valid_schema_json_roundtrip_preserves_fields() {
@@ -32,6 +32,27 @@ fn valid_schema_empty_roundtrip() {
     assert_eq!(empty, decoded);
 
     // Lock wire shape: protocol-version 3 consumers rely on this exact JSON
-    // for zero-field schemas.
+    // for zero-field schemas. The empty *record* must stay `kind`-less so it
+    // round-trips unchanged through readers that pre-date `SchemaKind`.
     assert_eq!(json, r#"{"fields":[]}"#);
+    assert_eq!(empty.kind(), SchemaKind::Record);
+}
+
+#[test]
+fn valid_schema_any_roundtrip_preserves_kind() {
+    let any = ValidSchema::any();
+
+    let json = serde_json::to_string(&any).expect("serialize");
+    // Unlike the empty record, the gradual `Any` carries an explicit `kind`
+    // tag so it does not decode back as an empty record.
+    assert_eq!(json, r#"{"kind":"any","fields":[]}"#);
+
+    let decoded: ValidSchema = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(decoded.kind(), SchemaKind::Any);
+    assert_eq!(any, decoded);
+
+    // The empty record and the gradual `Any` serialize differently and must
+    // not compare equal after a round-trip.
+    let empty = Schema::builder().build().unwrap();
+    assert_ne!(decoded, empty);
 }

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -119,8 +119,8 @@ pub enum WorkflowError {
     /// node's input schema on this connection (ADR-0100 TypeDAG T3).
     ///
     /// Emitted by [`crate::validate::validate_workflow_with_resolver`] when
-    /// both endpoints resolve and `nebula_schema::is_assignable` returns an
-    /// incompatibility. Structural errors (unknown nodes, cycles, …) are
+    /// both endpoints resolve and `nebula_schema::is_assignable_schema` returns
+    /// an incompatibility. Structural errors (unknown nodes, cycles, …) are
     /// reported first; this error only fires when both nodes are structurally
     /// valid and both schemas are resolvable from the catalog.
     ///

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -1017,8 +1017,8 @@ mod tests {
 
     /// Top/Bottom split enforced on a real edge: a producer whose `Output = ()`
     /// (an empty *record*, not the gradual `Any`) does NOT satisfy a consumer
-    /// that hard-requires a field. This is exactly the scenario the slice-level
-    /// `is_assignable` missed — it treated the empty output as `Any` and passed.
+    /// that hard-requires a field. This is exactly the scenario the old
+    /// kind-blind slice check missed — it treated the empty output as `Any`.
     #[test]
     fn empty_record_output_does_not_satisfy_required_input() {
         let (def, a, b) = two_node_def();

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use nebula_schema::is_assignable;
+use nebula_schema::is_assignable_schema;
 
 use crate::{
     definition::{CURRENT_SCHEMA_VERSION, RetryConfig, WorkflowDefinition},
@@ -188,7 +188,7 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
 /// Runs every structural check that [`validate_workflow`] performs, then for
 /// each [`Connection`](crate::Connection) whose **both** endpoints can be
 /// resolved by `resolver`, calls
-/// `nebula_schema::is_assignable(producer.output, consumer.input)`.
+/// `nebula_schema::is_assignable_schema(producer.output, consumer.input)`.
 ///
 /// An edge is **skipped** (fail-open, ADR-0100 T3.2) when **any** of the
 /// following hold:
@@ -273,11 +273,14 @@ pub fn validate_workflow_with_resolver(
             continue;
         };
 
-        // Run the directional assignability check: producer output ⊆ consumer input.
-        if let Err(incompat) = is_assignable(
-            producer_schemas.output.fields(),
-            consumer_schemas.input.fields(),
-        ) {
+        // Run the directional, kind-aware assignability check: producer output
+        // ⊆ consumer input. `is_assignable_schema` honors the `SchemaKind`
+        // Top/Bottom split, so a producer whose `Output = ()` (an empty record)
+        // does not satisfy a consumer that hard-requires a field, while an
+        // untyped `serde_json::Value` (`Any`) producer still passes.
+        if let Err(incompat) =
+            is_assignable_schema(&producer_schemas.output, &consumer_schemas.input)
+        {
             errors.push(WorkflowError::PortSchemaIncompatible(Box::new(
                 crate::error::PortSchemaIncompatDetails {
                     from_node: conn.from_node.clone(),
@@ -1010,6 +1013,92 @@ mod tests {
         };
         assert_eq!(details.from_node, a, "from_node must be the producer node");
         assert_eq!(details.to_node, b, "to_node must be the consumer node");
+    }
+
+    /// Top/Bottom split enforced on a real edge: a producer whose `Output = ()`
+    /// (an empty *record*, not the gradual `Any`) does NOT satisfy a consumer
+    /// that hard-requires a field. This is exactly the scenario the slice-level
+    /// `is_assignable` missed — it treated the empty output as `Any` and passed.
+    #[test]
+    fn empty_record_output_does_not_satisfy_required_input() {
+        let (def, a, b) = two_node_def();
+
+        // Producer emits nothing (`()` → empty record); consumer requires `needed`.
+        let producer_output = ValidSchema::empty();
+        let consumer_input = single_field_schema("needed", true);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty(),
+                output: producer_output,
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: consumer_input,
+                output: ValidSchema::empty(),
+            },
+        );
+
+        let resolver = MapResolver(schemas);
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+
+        let schema_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| matches!(e, WorkflowError::PortSchemaIncompatible(_)))
+            .collect();
+        assert_eq!(
+            schema_errors.len(),
+            1,
+            "an empty-record output feeding a required input must be rejected; got: {errors:?}"
+        );
+        let Some(WorkflowError::PortSchemaIncompatible(details)) = schema_errors.first().copied()
+        else {
+            panic!("expected PortSchemaIncompatible; got: {errors:?}");
+        };
+        assert_eq!(details.from_node, a);
+        assert_eq!(details.to_node, b);
+    }
+
+    /// Contrast with the empty-record case: an untyped `Any` output
+    /// (`serde_json::Value` → [`ValidSchema::any`]) still satisfies a required
+    /// consumer — gradual typing's escape hatch is preserved, so untyped flows
+    /// are not falsely rejected.
+    #[test]
+    fn any_output_satisfies_required_input() {
+        let (def, _, _) = two_node_def();
+
+        let producer_output = ValidSchema::any();
+        let consumer_input = single_field_schema("needed", true);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty(),
+                output: producer_output,
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: consumer_input,
+                output: ValidSchema::empty(),
+            },
+        );
+
+        let resolver = MapResolver(schemas);
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::PortSchemaIncompatible(_))),
+            "an `Any` output must still satisfy a required input (gradual escape); got: {errors:?}"
+        );
     }
 
     /// Fail-open: when the resolver returns `None` for one endpoint,


### PR DESCRIPTION
## What

Ends the nebula-schema **Top/Bottom collapse**: `()` and `serde_json::Value` previously resolved to the *same* empty `ValidSchema`, compared equal, and an empty producer silently satisfied any consumer. This PR distinguishes them at the type level **and enforces the distinction** on real producer→consumer edges.

## Layers (3 commits)

1. **Type-level split** — `SchemaKind { Record (default), Any }` on `ValidSchema`; `ValidSchema::any()`; `HasSchema` routing (`()` → empty *record*; `Value`/`FieldValues`/primitive stubs → `Any`); `kind` in structural `PartialEq`; serde back-compat (a `Record` keeps the legacy `{"fields":[…]}` wire shape, only `Any` emits `"kind":"any"`, missing `kind` deserializes as `Record`).
2. **Enforcement + fail-closed** — kind-aware `is_assignable_schema(&ValidSchema,&ValidSchema)`: `Any` on either side is the gradual escape; two concrete records run strict width-subtyping with **no** empty-producer escape (empty record producer fails a required consumer; empty record consumer still accepts anything). The workflow per-edge validator and the action output-evolution check migrate to it. Deserialize **fails closed** when a payload tagged `kind:"any"` also carries `fields`/`root_rules`.
3. **Adversarial-review hardening** — `is_assignable_schema` is now the **sole** public assignability entry (the gradual slice-level `is_assignable` had zero production callers and was a strictly-more-permissive footgun → demoted to a `#[cfg(test)]` helper); added the missing tests the review flagged; `#[non_exhaustive]` on `ValidSchemaInner`; doc corrections.

## Resolves the two earlier review notes

- **P1 (enforcement was inert)** — the split now bites on real edges via `is_assignable_schema`, not only at the equality/serde level. Workflow edge: an `Output = ()` producer feeding a required input is rejected; an `Any` producer still passes.
- **P2 (fail-closed)** — a mistagged/mixed-version `kind:"any"` payload carrying constraints is rejected instead of silently becoming fully permissive.

## Tests (highlights)

- `empty_record_output_does_not_satisfy_required_input` + `any_output_satisfies_required_input` (workflow edge).
- `empty_record_producer_does_not_satisfy_required_consumer`, `both_any_schemas_are_compatible`, strict recursion into nested Object / List-item leaves (strict-vs-gradual contrast).
- `output_schema_collapsed_to_empty_record_same_major_is_rejected` + `…_to_any_…_is_allowed` (metadata evolution).
- `deserialize_any_carrying_fields_is_rejected` / `…_root_rules_…`; serde round-trip + wire-shape guards.

## Verification

`cargo nextest run --workspace` — **5618 passed, 1 skipped, 0 failed**. `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings` green. (A 4-lens adversarial review workflow was run on the diff; all findings are addressed in commit 3 — fail-closed lens came back clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)