### PR TITLE
feat(schema): ternary Assignability lattice + strict workflow schema mode

### DIFF
--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -173,10 +173,9 @@ pub fn is_assignable_schema(
     // surfaced as its first incompatibility (depth-first, consumer-field order).
     match explain_assignable(producer, consumer) {
         Assignability::Yes | Assignability::Unknown(_) => Ok(()),
-        Assignability::No(incompats) => match incompats.into_iter().next() {
-            Some(first) => Err(first),
-            None => Ok(()),
-        },
+        // `into_verdict` only builds `No` from a non-empty list, so `next()` is
+        // always `Some`; `map_or` keeps this total without a panic path.
+        Assignability::No(incompats) => incompats.into_iter().next().map_or(Ok(()), Err),
     }
 }
 
@@ -228,9 +227,25 @@ pub enum UnknownReason {
     /// A matched `Number` pair narrows float→int: the producer may emit a
     /// non-integral value the consumer cannot represent, but a static check
     /// cannot tell whether it ever will.
+    ///
+    /// This is deliberately `Unknown`, not a hard `No` (contrast the
+    /// empty-record producer, which *provably* emits nothing and so is `No`):
+    /// the schema layer has no integral-domain refinement, so a `float` producer
+    /// is not *provably* non-integral. A future numeric-refinement type could
+    /// promote this to `Yes` or `No`; until then it is genuinely undecidable.
     NumberWidening {
         /// Key of the number field.
         key: FieldKey,
+    },
+    /// An undecidable reason found inside a nested `Object` or `List` field,
+    /// carrying the enclosing field `key` so the path is not lost (mirrors
+    /// [`SchemaIncompat::NestedIncompat`]). Nesting composes: an `Object` two
+    /// levels deep yields `NestedUnknown { a, NestedUnknown { b, .. } }`.
+    NestedUnknown {
+        /// Key of the enclosing container field.
+        key: FieldKey,
+        /// The undecidable reason found inside the container.
+        inner: Box<UnknownReason>,
     },
 }
 
@@ -255,6 +270,7 @@ impl core::fmt::Display for UnknownReason {
                     "field `{key}` narrows float to integer (possible precision loss)"
                 )
             },
+            Self::NestedUnknown { key, inner } => write!(f, "in field `{key}`: {inner}"),
         }
     }
 }
@@ -312,10 +328,11 @@ impl Explain {
 }
 
 impl Explain {
-    /// Fold a nested sub-traversal's findings into this accumulator, wrapping
-    /// each nested incompatibility in [`SchemaIncompat::NestedIncompat`] under
-    /// `key`. Unknown reasons already carry their own field key, so they are
-    /// lifted unwrapped.
+    /// Fold a nested sub-traversal's findings into this accumulator under `key`,
+    /// wrapping each nested incompatibility in [`SchemaIncompat::NestedIncompat`]
+    /// and each undecidable reason in [`UnknownReason::NestedUnknown`] — so both
+    /// channels keep the enclosing-field path (e.g. `config.token` rather than a
+    /// bare `token` that two sibling objects could both produce).
     fn wrap_nested(&mut self, key: &FieldKey, sub: Explain) {
         for inner in sub.incompat {
             self.incompat.push(SchemaIncompat::NestedIncompat {
@@ -323,12 +340,18 @@ impl Explain {
                 inner: Box::new(inner),
             });
         }
-        self.unknown.extend(sub.unknown);
+        for inner in sub.unknown {
+            self.unknown.push(UnknownReason::NestedUnknown {
+                key: key.clone(),
+                inner: Box::new(inner),
+            });
+        }
     }
 }
 
-/// Collect-all field-slice traversal, shared by [`explain_assignable`] (strict)
-/// and the test-only gradual slice check. Pushes every incompatibility and every
+/// Collect-all field-slice traversal, shared by [`explain_assignable`] (which
+/// passes `strict = true`) and the test-only `explain_slice` helper (which
+/// controls `strict` explicitly). Pushes every incompatibility and every
 /// undecidable reason into `acc` in depth-first, consumer-field order; it never
 /// early-returns, so the caller always sees the full picture.
 fn collect_fields(
@@ -1046,5 +1069,125 @@ mod tests {
             ),
             other => panic!("a provable incompatibility must dominate Unknown, got {other:?}"),
         }
+    }
+
+    /// A `Mode`-vs-`Mode` pair is `Unknown(ModeVariance)` (sum-type variance is
+    /// not modeled) yet passes the binary check. The one reclassified leniency
+    /// otherwise lacking an oracle.
+    #[test]
+    fn explain_mode_variance_is_unknown() {
+        let mode_schema = || {
+            crate::Schema::builder()
+                .add(Field::mode(fk("m")).variant("v", "V", Field::string(fk("x"))))
+                .build()
+                .unwrap()
+        };
+        let producer = mode_schema();
+        let consumer = mode_schema();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::Unknown(vec![UnknownReason::ModeVariance { key: fk("m") }]),
+        );
+        assert!(is_assignable_schema(&producer, &consumer).is_ok());
+    }
+
+    /// An undecidable field nested inside an `Object` keeps its path: the reason
+    /// is `NestedUnknown { config, DynamicLoaderBacked { d } }`, not a bare
+    /// `DynamicLoaderBacked { d }` that a sibling object's `d` could alias.
+    #[test]
+    fn explain_nested_object_unknown_preserves_path() {
+        let producer = crate::Schema::builder()
+            .add(Field::object(fk("config")).add(Field::dynamic(fk("d"))))
+            .build()
+            .unwrap();
+        // Consumer's nested `d` is optional, so the only finding is the Unknown
+        // (no MissingRequiredField to dominate it).
+        let consumer = crate::Schema::builder()
+            .add(Field::object(fk("config")).add(Field::string(fk("d"))))
+            .build()
+            .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::Unknown(vec![UnknownReason::NestedUnknown {
+                key: fk("config"),
+                inner: Box::new(UnknownReason::DynamicLoaderBacked { key: fk("d") }),
+            }]),
+        );
+    }
+
+    /// An undecidable field nested inside a `List` item keeps both the list key
+    /// and the item key: `NestedUnknown { items, NestedUnknown { item, .. } }`.
+    #[test]
+    fn explain_nested_list_unknown_preserves_path() {
+        let producer = crate::Schema::builder()
+            .add(
+                Field::list(fk("items"))
+                    .item(Field::object(fk("item")).add(Field::dynamic(fk("d")))),
+            )
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(
+                Field::list(fk("items"))
+                    .item(Field::object(fk("item")).add(Field::string(fk("d")))),
+            )
+            .build()
+            .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::Unknown(vec![UnknownReason::NestedUnknown {
+                key: fk("items"),
+                inner: Box::new(UnknownReason::NestedUnknown {
+                    key: fk("item"),
+                    inner: Box::new(UnknownReason::DynamicLoaderBacked { key: fk("d") }),
+                }),
+            }]),
+        );
+    }
+
+    /// `No` dominates `Unknown` even when they arise in DIFFERENT nested
+    /// containers: a missing-required in object `a` wins over a dynamic field in
+    /// sibling object `b`, and the `Unknown` is dropped.
+    #[test]
+    fn explain_no_dominates_unknown_across_containers() {
+        let producer = crate::Schema::builder()
+            .add(Field::object(fk("a"))) // empty — can't satisfy a's required child
+            .add(Field::object(fk("b")).add(Field::dynamic(fk("d"))))
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(Field::object(fk("a")).add(Field::string(fk("need")).required()))
+            .add(Field::object(fk("b")).add(Field::string(fk("d"))))
+            .build()
+            .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::No(vec![SchemaIncompat::NestedIncompat {
+                key: fk("a"),
+                inner: Box::new(SchemaIncompat::MissingRequiredField { key: fk("need") }),
+            }]),
+            "No dominates across containers; the sibling Unknown is dropped"
+        );
+    }
+
+    #[test]
+    fn unknown_reason_display_is_human_readable() {
+        assert_eq!(
+            UnknownReason::OpaqueProducer.to_string(),
+            "producer schema is an opaque `Any` (shape unknown)"
+        );
+        assert_eq!(
+            UnknownReason::DynamicLoaderBacked { key: fk("tok") }.to_string(),
+            "field `tok` is dynamic/computed (resolved at runtime)"
+        );
+        // Nested reasons render their path prefix.
+        assert_eq!(
+            UnknownReason::NestedUnknown {
+                key: fk("cfg"),
+                inner: Box::new(UnknownReason::ModeVariance { key: fk("m") }),
+            }
+            .to_string(),
+            "in field `cfg`: field `m` is a `Mode` sum type (variance not modeled)"
+        );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -141,12 +141,13 @@ pub enum SchemaIncompat {
 /// - **`File` and `Select` cardinality** — the `multiple` flag (scalar vs.
 ///   array) is checked for equality; a mismatch returns
 ///   [`SchemaIncompat::CardinalityMismatch`].
-/// - **`Mode` fields** — `Mode`-vs-`Mode` is treated as compatible regardless
-///   of variant payloads (lenient, never false-rejects). Real union-variance
-///   compatibility is deferred to an ADR-0100 addendum.
-/// - **`Number` integer vs. float** — both carry `type_name() == "number"` and
-///   are treated as compatible. Numeric-widening subtyping is deferred to an
-///   ADR-0100 addendum.
+/// - **`Mode` fields** — `Mode`-vs-`Mode` passes the binary check (never
+///   false-rejects), but [`explain_assignable`] reports it as
+///   [`UnknownReason::ModeVariance`]: sum-type variance is not modeled.
+/// - **`Number` integer vs. float** — both carry `type_name() == "number"`.
+///   int→float is provably compatible; float→int passes the binary check but is
+///   [`UnknownReason::NumberWidening`] in [`explain_assignable`] (possible
+///   precision loss).
 ///
 /// # Errors
 ///
@@ -166,36 +167,185 @@ pub fn is_assignable_schema(
     producer: &ValidSchema,
     consumer: &ValidSchema,
 ) -> Result<(), SchemaIncompat> {
-    // Gradual `Any` on either side is the escape hatch.
-    if producer.kind() == SchemaKind::Any || consumer.kind() == SchemaKind::Any {
-        return Ok(());
+    // Binary view of the ternary verdict: `Yes` and `Unknown` (not statically
+    // refuted) both pass — this keeps the gradual escape (untyped producers,
+    // Dynamic/Mode/Number leniencies) green. Only a definite `No` is an error,
+    // surfaced as its first incompatibility (depth-first, consumer-field order).
+    match explain_assignable(producer, consumer) {
+        Assignability::Yes | Assignability::Unknown(_) => Ok(()),
+        Assignability::No(incompats) => match incompats.into_iter().next() {
+            Some(first) => Err(first),
+            None => Ok(()),
+        },
     }
-    // Both are concrete records: strict width-subtyping, no empty-producer escape.
-    fields_assignable(producer.fields(), consumer.fields(), true)
+}
+
+/// The three-valued (Cue/GraphQL-style) assignability verdict: a producer
+/// schema is provably assignable, provably not, or **not statically decidable**.
+///
+/// Unlike [`is_assignable_schema`] — which collapses to a binary `Ok`/`Err` and
+/// returns only the *first* incompatibility — this verdict separates "not
+/// provable" ([`Unknown`](Assignability::Unknown)) from "provably wrong"
+/// ([`No`](Assignability::No)) and collects **every** finding, so a strict
+/// validator can block on unprovable edges while a gradual one passes them. The
+/// `No`/`Unknown` lists are non-empty in their respective variants.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Assignability {
+    /// The producer is provably assignable to the consumer.
+    Yes,
+    /// The producer is provably **not** assignable; carries every incompatibility
+    /// found (depth-first, consumer-field order), not just the first.
+    No(Vec<SchemaIncompat>),
+    /// Assignability cannot be decided statically (e.g. a loader-backed
+    /// `Dynamic` field, an opaque `Any` producer, sum-type `Mode` variance, or
+    /// a float→int narrowing). **Not** fail-open: a strict policy treats this as
+    /// a blocked edge; a gradual policy passes it.
+    Unknown(Vec<UnknownReason>),
+}
+
+/// Why an edge's assignability is [`Unknown`](Assignability::Unknown) — each
+/// case is a place where the type system cannot currently *prove* compatibility
+/// nor refute it.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnknownReason {
+    /// The producer schema is the gradual `Any` ([`SchemaKind::Any`]): it may
+    /// emit anything, so it is not provably compatible with a typed consumer.
+    OpaqueProducer,
+    /// A matched field is `Dynamic`/`Computed` (loader- or expression-backed),
+    /// so its concrete shape is unknown until runtime.
+    DynamicLoaderBacked {
+        /// Key of the dynamic field.
+        key: FieldKey,
+    },
+    /// A matched `Mode` (sum-type) pair: variant-level variance is not modeled,
+    /// so neither compatibility nor a conflict is proven.
+    ModeVariance {
+        /// Key of the `Mode` field.
+        key: FieldKey,
+    },
+    /// A matched `Number` pair narrows float→int: the producer may emit a
+    /// non-integral value the consumer cannot represent, but a static check
+    /// cannot tell whether it ever will.
+    NumberWidening {
+        /// Key of the number field.
+        key: FieldKey,
+    },
+}
+
+impl core::fmt::Display for UnknownReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::OpaqueProducer => {
+                write!(f, "producer schema is an opaque `Any` (shape unknown)")
+            },
+            Self::DynamicLoaderBacked { key } => {
+                write!(f, "field `{key}` is dynamic/computed (resolved at runtime)")
+            },
+            Self::ModeVariance { key } => {
+                write!(
+                    f,
+                    "field `{key}` is a `Mode` sum type (variance not modeled)"
+                )
+            },
+            Self::NumberWidening { key } => {
+                write!(
+                    f,
+                    "field `{key}` narrows float to integer (possible precision loss)"
+                )
+            },
+        }
+    }
+}
+
+/// Full three-valued assignability: collects **all** incompatibilities and all
+/// "not decidable" reasons rather than stopping at the first.
+///
+/// Honors the [`SchemaKind`] Top/Bottom split like [`is_assignable_schema`]: an
+/// `Any` consumer accepts anything ([`Yes`](Assignability::Yes)); an `Any`
+/// producer is [`Unknown(OpaqueProducer)`](UnknownReason::OpaqueProducer); two
+/// concrete records run strict width-subtyping. The verdict precedence is
+/// `No` (any provable incompatibility) ▸ `Unknown` (any undecidable field) ▸
+/// `Yes`.
+///
+/// The leniencies that [`is_assignable_schema`] silently passes are surfaced
+/// here as [`Unknown`](Assignability::Unknown) instead of being hidden in `Ok`,
+/// so a strict workflow validator can block them. See [`UnknownReason`].
+#[must_use]
+pub fn explain_assignable(producer: &ValidSchema, consumer: &ValidSchema) -> Assignability {
+    // An `Any` consumer accepts anything — provably compatible.
+    if consumer.kind() == SchemaKind::Any {
+        return Assignability::Yes;
+    }
+    // An `Any` producer may emit anything: not refuted, but not provable either.
+    if producer.kind() == SchemaKind::Any {
+        return Assignability::Unknown(vec![UnknownReason::OpaqueProducer]);
+    }
+    let mut acc = Explain::default();
+    collect_fields(producer.fields(), consumer.fields(), true, &mut acc);
+    acc.into_verdict()
 }
 
 // ── Private core ─────────────────────────────────────────────────────────────
 
-/// Core field-slice assignability loop, shared between the top-level entry
-/// point and recursive `Object`/`List` descent.
-///
-/// Keeping this as a separate private function avoids constructing throwaway
-/// `Schema` values for nested object/list fields during recursion.
-fn fields_assignable(
+/// Accumulator for the collect-all traversal: every provable incompatibility
+/// and every undecidable reason, in depth-first / consumer-field order.
+#[derive(Default)]
+struct Explain {
+    incompat: Vec<SchemaIncompat>,
+    unknown: Vec<UnknownReason>,
+}
+
+impl Explain {
+    /// Collapse to a verdict: `No` if any incompatibility (a provable conflict
+    /// dominates), else `Unknown` if any undecidable field, else `Yes`.
+    fn into_verdict(self) -> Assignability {
+        if !self.incompat.is_empty() {
+            Assignability::No(self.incompat)
+        } else if !self.unknown.is_empty() {
+            Assignability::Unknown(self.unknown)
+        } else {
+            Assignability::Yes
+        }
+    }
+}
+
+impl Explain {
+    /// Fold a nested sub-traversal's findings into this accumulator, wrapping
+    /// each nested incompatibility in [`SchemaIncompat::NestedIncompat`] under
+    /// `key`. Unknown reasons already carry their own field key, so they are
+    /// lifted unwrapped.
+    fn wrap_nested(&mut self, key: &FieldKey, sub: Explain) {
+        for inner in sub.incompat {
+            self.incompat.push(SchemaIncompat::NestedIncompat {
+                key: key.clone(),
+                inner: Box::new(inner),
+            });
+        }
+        self.unknown.extend(sub.unknown);
+    }
+}
+
+/// Collect-all field-slice traversal, shared by [`explain_assignable`] (strict)
+/// and the test-only gradual slice check. Pushes every incompatibility and every
+/// undecidable reason into `acc` in depth-first, consumer-field order; it never
+/// early-returns, so the caller always sees the full picture.
+fn collect_fields(
     producer_fields: &[Field],
     consumer_fields: &[Field],
     strict: bool,
-) -> Result<(), SchemaIncompat> {
-    // An empty consumer requires nothing — always satisfiable, both modes.
+    acc: &mut Explain,
+) {
+    // An empty consumer requires nothing.
     if consumer_fields.is_empty() {
-        return Ok(());
+        return;
     }
-    // Gradual mode: an empty producer is the untyped/opaque `Any` escape. In
-    // strict mode the producer is a concrete record that emits exactly these
-    // fields, so an empty producer must face the per-field required check below
-    // (and will fail any hard-required consumer field).
+    // Gradual mode: an empty producer is the untyped/opaque `Any` escape. Strict
+    // mode (the kind-aware path) gives it no escape — an empty record emits no
+    // fields and must face the per-field required check below.
     if !strict && producer_fields.is_empty() {
-        return Ok(());
+        return;
     }
 
     for consumer_field in consumer_fields {
@@ -209,113 +359,111 @@ fn fields_assignable(
 
         match producer_fields.iter().find(|pf| pf.key() == consumer_key) {
             None if is_hard_required => {
-                return Err(SchemaIncompat::MissingRequiredField {
+                acc.incompat.push(SchemaIncompat::MissingRequiredField {
                     key: consumer_key.clone(),
                 });
             },
-            None => {
-                // Optional consumer field absent from producer — fine under
-                // width subtyping.
-                continue;
-            },
+            // Optional consumer field absent from producer — fine under width subtyping.
+            None => {},
             Some(producer_field) => {
-                field_pair_assignable(consumer_key, producer_field, consumer_field, strict)?;
+                collect_pair(consumer_key, producer_field, consumer_field, strict, acc);
             },
         }
     }
-
-    Ok(())
 }
 
-/// Check a matched field pair (same key, both present).
+/// Classify a matched field pair (same key, both present), pushing into `acc`.
 ///
-/// - `Dynamic`/`Computed` on either side → Any escape → `Ok`.
-/// - `File`/`File` and `Select`/`Select` → check `multiple` equality →
-///   [`SchemaIncompat::CardinalityMismatch`] if they differ.
-/// - Same structural variant with nested fields → recurse; wrap inner error in
-///   [`SchemaIncompat::NestedIncompat`].
-/// - Different structural variants (different `type_name`) →
-///   [`SchemaIncompat::FieldTypeMismatch`].
-/// - Same primitive variant → `Ok`.
-///
-/// ## Mode fields
-///
-/// `Mode`-vs-`Mode` falls through to `type_name()` equality → always `Ok`
-/// regardless of variant payloads.
-/// NOTE: `Mode` is a sum type; sum-type variance (contravariant on the
-/// argument side) is the opposite of record width-subtyping and is deferred to
-/// an ADR-0100 addendum. This arm is intentionally lenient — it never
-/// false-rejects a `Mode` pair.
-fn field_pair_assignable(
+/// Provable conflicts (cardinality, type mismatch, nested) become
+/// [`SchemaIncompat`]; the leniencies the binary check silently passes —
+/// `Dynamic`/`Computed`, `Mode` variance, and float→int narrowing — become
+/// [`UnknownReason`] so a strict policy can see them. `Number` int→float
+/// widening and equal primitive variants are provably compatible (nothing
+/// pushed).
+fn collect_pair(
     key: &FieldKey,
     producer_field: &Field,
     consumer_field: &Field,
     strict: bool,
-) -> Result<(), SchemaIncompat> {
-    // Any escape: Dynamic or Computed on either side matches anything. This
-    // per-field gradual escape holds in both modes — a `Dynamic`/`Computed`
-    // field is explicitly `Any`-typed regardless of the enclosing record's kind.
+    acc: &mut Explain,
+) {
+    // Dynamic/Computed on either side: loader/expression-backed, concrete shape
+    // unknown until runtime — not statically provable in either direction.
     if matches!(producer_field, Field::Dynamic(_) | Field::Computed(_))
         || matches!(consumer_field, Field::Dynamic(_) | Field::Computed(_))
     {
-        return Ok(());
+        acc.unknown
+            .push(UnknownReason::DynamicLoaderBacked { key: key.clone() });
+        return;
     }
 
     match (producer_field, consumer_field) {
         (Field::File(p), Field::File(c)) => {
             if p.multiple != c.multiple {
-                return Err(SchemaIncompat::CardinalityMismatch {
+                acc.incompat.push(SchemaIncompat::CardinalityMismatch {
                     key: key.clone(),
                     producer_multiple: p.multiple,
                     consumer_multiple: c.multiple,
                 });
             }
-            Ok(())
         },
         (Field::Select(p), Field::Select(c)) => {
             if p.multiple != c.multiple {
-                return Err(SchemaIncompat::CardinalityMismatch {
+                acc.incompat.push(SchemaIncompat::CardinalityMismatch {
                     key: key.clone(),
                     producer_multiple: p.multiple,
                     consumer_multiple: c.multiple,
                 });
             }
-            Ok(())
         },
         (Field::Object(producer_obj), Field::Object(consumer_obj)) => {
-            fields_assignable(&producer_obj.fields, &consumer_obj.fields, strict).map_err(|inner| {
-                SchemaIncompat::NestedIncompat {
-                    key: key.clone(),
-                    inner: Box::new(inner),
-                }
-            })
+            let mut sub = Explain::default();
+            collect_fields(&producer_obj.fields, &consumer_obj.fields, strict, &mut sub);
+            acc.wrap_nested(key, sub);
         },
         (Field::List(producer_list), Field::List(consumer_list)) => {
             match (&producer_list.item, &consumer_list.item) {
-                // Either side has no typed item schema — Any escape.
-                (None, _) | (_, None) => Ok(()),
+                // Either side has no typed item schema — Any escape (provably Yes).
+                (None, _) | (_, None) => {},
                 (Some(producer_item), Some(consumer_item)) => {
-                    field_pair_assignable(key, producer_item, consumer_item, strict).map_err(
-                        |inner| SchemaIncompat::NestedIncompat {
-                            key: key.clone(),
-                            inner: Box::new(inner),
-                        },
-                    )
+                    // The nested context is the list field `key`, but the inner
+                    // incompatibility is labeled with the *item's* key (not the
+                    // list key — that conflation was the old list-item-key bug).
+                    let mut sub = Explain::default();
+                    collect_pair(
+                        consumer_item.key(),
+                        producer_item,
+                        consumer_item,
+                        strict,
+                        &mut sub,
+                    );
+                    acc.wrap_nested(key, sub);
                 },
             }
         },
-        // For all other variant pairs: same type_name = compatible.
-        // Note: Mode-vs-Mode is intentionally lenient — see fn-level NOTE above.
-        // Note: Number integer-vs-float both have type_name "number" — deferred to ADR-0100 addendum.
+        (Field::Number(p), Field::Number(c)) => {
+            // int→float widening is safe (provably Yes). float→int narrowing may
+            // lose precision — but a float producer could still only ever emit
+            // integral values, so it is not provably wrong: Unknown, not No.
+            if !p.integer && c.integer {
+                acc.unknown
+                    .push(UnknownReason::NumberWidening { key: key.clone() });
+            }
+        },
+        (Field::Mode(_), Field::Mode(_)) => {
+            // Sum-type variance is not modeled (it runs opposite to record
+            // width-subtyping) — neither proven compatible nor refuted.
+            acc.unknown
+                .push(UnknownReason::ModeVariance { key: key.clone() });
+        },
+        // All other pairs: same type_name = compatible; different = type mismatch.
         _ => {
-            if producer_field.type_name() == consumer_field.type_name() {
-                Ok(())
-            } else {
-                Err(SchemaIncompat::FieldTypeMismatch {
+            if producer_field.type_name() != consumer_field.type_name() {
+                acc.incompat.push(SchemaIncompat::FieldTypeMismatch {
                     key: key.clone(),
                     producer: producer_field.type_name(),
                     consumer: consumer_field.type_name(),
-                })
+                });
             }
         },
     }
@@ -337,9 +485,23 @@ mod tests {
     /// [`is_assignable_schema`], which honors the `SchemaKind` Top/Bottom split.
     /// Retained here to exercise the shared per-field matching logic (type
     /// mismatch, cardinality, nesting) and the gradual empty-producer escape
-    /// directly on `&[Field]` without building a `ValidSchema` per case.
+    /// directly on `&[Field]` without building a `ValidSchema` per case. Mirrors
+    /// the binary mapping: `Yes`/`Unknown` ⇒ `Ok`, `No` ⇒ first incompatibility.
     fn is_assignable(producer: &[Field], consumer: &[Field]) -> Result<(), SchemaIncompat> {
-        fields_assignable(producer, consumer, false)
+        match explain_slice(producer, consumer, false) {
+            Assignability::Yes | Assignability::Unknown(_) => Ok(()),
+            Assignability::No(incompats) => match incompats.into_iter().next() {
+                Some(first) => Err(first),
+                None => Ok(()),
+            },
+        }
+    }
+
+    /// Test-only collect-all over raw slices, with explicit `strict` control.
+    fn explain_slice(producer: &[Field], consumer: &[Field], strict: bool) -> Assignability {
+        let mut acc = Explain::default();
+        collect_fields(producer, consumer, strict, &mut acc);
+        acc.into_verdict()
     }
 
     // ── Compatible: producer has all required consumer fields + extra ──────
@@ -504,12 +666,14 @@ mod tests {
             .item(Field::number(fk("item")))
             .required()
             .into()];
+        // Outer NestedIncompat is keyed by the list field (`values`); the inner
+        // mismatch is keyed by the *item* (`item`), not the list key.
         assert_eq!(
             is_assignable(&producer, &consumer),
             Err(SchemaIncompat::NestedIncompat {
                 key: fk("values"),
                 inner: Box::new(SchemaIncompat::FieldTypeMismatch {
-                    key: fk("values"),
+                    key: fk("item"),
                     producer: "string",
                     consumer: "number",
                 }),
@@ -706,10 +870,9 @@ mod tests {
     }
 
     // ── Strict-mode recursion: `strict` must reach nested Object / List leaves ──
-    // These drive the private core directly (the public `is_assignable_schema`
-    // delegates record subtyping to `fields_assignable(.., strict = true)`), and
-    // contrast strict vs gradual at depth so a dropped `strict` argument in the
-    // Object/List recursion arms goes RED.
+    // These drive the collect-all core via `explain_slice` and contrast strict
+    // vs gradual at depth, so a dropped `strict` argument in the Object/List
+    // recursion arms goes RED.
 
     /// An empty nested-object producer does NOT satisfy a consumer whose nested
     /// object hard-requires a field — under strict mode, one level deep. Gradual
@@ -722,23 +885,24 @@ mod tests {
             .into()];
 
         assert_eq!(
-            fields_assignable(&producer, &consumer, true),
-            Err(SchemaIncompat::NestedIncompat {
+            explain_slice(&producer, &consumer, true),
+            Assignability::No(vec![SchemaIncompat::NestedIncompat {
                 key: fk("config"),
                 inner: Box::new(SchemaIncompat::MissingRequiredField { key: fk("host") }),
-            }),
+            }]),
             "strict mode must recurse into the empty producer object and fail the required field"
         );
         assert_eq!(
-            fields_assignable(&producer, &consumer, false),
-            Ok(()),
+            explain_slice(&producer, &consumer, false),
+            Assignability::Yes,
             "gradual mode escapes the empty nested producer — confirms the strict flag is what bites"
         );
     }
 
     /// A list whose item is an empty object does NOT satisfy a consumer list
     /// whose item object hard-requires a field — strict propagates List → item →
-    /// Object. Gradual mode escapes it.
+    /// Object. Gradual mode escapes it. The inner context key is the *item*
+    /// (`item`), the outer is the list (`items`).
     #[test]
     fn strict_rejects_empty_nested_list_item_producer() {
         let producer = [Field::list(fk("items"))
@@ -749,20 +913,138 @@ mod tests {
             .into()];
 
         assert_eq!(
-            fields_assignable(&producer, &consumer, true),
-            Err(SchemaIncompat::NestedIncompat {
+            explain_slice(&producer, &consumer, true),
+            Assignability::No(vec![SchemaIncompat::NestedIncompat {
                 key: fk("items"),
                 inner: Box::new(SchemaIncompat::NestedIncompat {
-                    key: fk("items"),
+                    key: fk("item"),
                     inner: Box::new(SchemaIncompat::MissingRequiredField { key: fk("id") }),
                 }),
-            }),
+            }]),
             "strict mode must recurse List -> item -> Object and fail the required field"
         );
         assert_eq!(
-            fields_assignable(&producer, &consumer, false),
-            Ok(()),
+            explain_slice(&producer, &consumer, false),
+            Assignability::Yes,
             "gradual mode escapes the empty list-item object — confirms strict propagation"
         );
+    }
+
+    // ── Ternary `explain_assignable`: Yes / No(all) / Unknown(reasons) ─────────
+
+    /// `explain_assignable` collects ALL incompatibilities, not just the first —
+    /// the property that makes it a CI/diagnostics channel rather than a gate.
+    #[test]
+    fn explain_collects_all_incompatibilities() {
+        let producer = required_record("present");
+        let consumer = crate::Schema::builder()
+            .add(Field::string(fk("missing_a")).required())
+            .add(Field::string(fk("missing_b")).required())
+            .build()
+            .unwrap();
+        match explain_assignable(&producer, &consumer) {
+            Assignability::No(incompats) => {
+                assert_eq!(
+                    incompats.len(),
+                    2,
+                    "both missing required fields are reported"
+                );
+                assert!(incompats.contains(&SchemaIncompat::MissingRequiredField {
+                    key: fk("missing_a")
+                }));
+                assert!(incompats.contains(&SchemaIncompat::MissingRequiredField {
+                    key: fk("missing_b")
+                }));
+            },
+            other => panic!("expected No(2), got {other:?}"),
+        }
+    }
+
+    /// An `Any` producer is `Unknown(OpaqueProducer)` — not provable — even
+    /// though the binary check passes it (gradual escape).
+    #[test]
+    fn explain_any_producer_is_unknown_opaque() {
+        let consumer = required_record("name");
+        assert_eq!(
+            explain_assignable(&ValidSchema::any(), &consumer),
+            Assignability::Unknown(vec![UnknownReason::OpaqueProducer]),
+        );
+        // The binary view still passes it.
+        assert!(is_assignable_schema(&ValidSchema::any(), &consumer).is_ok());
+    }
+
+    /// An `Any` consumer is provably `Yes` (it accepts anything).
+    #[test]
+    fn explain_any_consumer_is_yes() {
+        let producer = required_record("name");
+        assert_eq!(
+            explain_assignable(&producer, &ValidSchema::any()),
+            Assignability::Yes,
+        );
+    }
+
+    /// A `Dynamic` producer field is `Unknown(DynamicLoaderBacked)` in explain,
+    /// yet `Ok` in the binary check (the lofty per-field gradual escape).
+    #[test]
+    fn explain_dynamic_field_is_unknown_not_ok() {
+        let producer = crate::Schema::builder()
+            .add(Field::dynamic(fk("name")))
+            .build()
+            .unwrap();
+        let consumer = required_record("name");
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::Unknown(vec![UnknownReason::DynamicLoaderBacked { key: fk("name") }]),
+        );
+        assert!(is_assignable_schema(&producer, &consumer).is_ok());
+    }
+
+    /// Number int→float widens (provably `Yes`); float→int narrows
+    /// (`Unknown(NumberWidening)`, not a hard `No`).
+    #[test]
+    fn explain_number_widening_is_directional() {
+        let int_producer = crate::Schema::builder()
+            .add(Field::number(fk("n")).integer())
+            .build()
+            .unwrap();
+        let float_consumer = crate::Schema::builder()
+            .add(Field::number(fk("n")))
+            .build()
+            .unwrap();
+        // int -> float: safe widening.
+        assert_eq!(
+            explain_assignable(&int_producer, &float_consumer),
+            Assignability::Yes,
+        );
+        // float -> int: possible precision loss, undecidable.
+        assert_eq!(
+            explain_assignable(&float_consumer, &int_producer),
+            Assignability::Unknown(vec![UnknownReason::NumberWidening { key: fk("n") }]),
+        );
+        // Both pass the binary check (Unknown ⇒ Ok).
+        assert!(is_assignable_schema(&float_consumer, &int_producer).is_ok());
+    }
+
+    /// A definite incompatibility dominates an undecidable one: `No` ▸ `Unknown`.
+    #[test]
+    fn explain_no_dominates_unknown() {
+        let producer = crate::Schema::builder()
+            .add(Field::dynamic(fk("d")))
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(Field::dynamic(fk("d")))
+            .add(Field::string(fk("required_missing")).required())
+            .build()
+            .unwrap();
+        match explain_assignable(&producer, &consumer) {
+            Assignability::No(v) => assert_eq!(
+                v,
+                vec![SchemaIncompat::MissingRequiredField {
+                    key: fk("required_missing")
+                }]
+            ),
+            other => panic!("a provable incompatibility must dominate Unknown, got {other:?}"),
+        }
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -209,8 +209,11 @@ pub enum Assignability {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnknownReason {
-    /// The producer schema is the gradual `Any` ([`SchemaKind::Any`]): it may
-    /// emit anything, so it is not provably compatible with a typed consumer.
+    /// The producer side is opaque, so it cannot be *proven* to match a typed
+    /// consumer: either the producer schema is the gradual `Any`
+    /// ([`SchemaKind::Any`]), or a matched `List` field's producer item carries
+    /// no item schema while the consumer's item is typed (wrapped in a
+    /// [`NestedUnknown`](Self::NestedUnknown) under the list key).
     OpaqueProducer,
     /// A matched field is `Dynamic`/`Computed` (loader- or expression-backed),
     /// so its concrete shape is unknown until runtime.
@@ -253,7 +256,7 @@ impl core::fmt::Display for UnknownReason {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::OpaqueProducer => {
-                write!(f, "producer schema is an opaque `Any` (shape unknown)")
+                write!(f, "producer side is opaque (shape unknown)")
             },
             Self::DynamicLoaderBacked { key } => {
                 write!(f, "field `{key}` is dynamic/computed (resolved at runtime)")
@@ -292,6 +295,13 @@ impl core::fmt::Display for UnknownReason {
 pub fn explain_assignable(producer: &ValidSchema, consumer: &ValidSchema) -> Assignability {
     // An `Any` consumer accepts anything — provably compatible.
     if consumer.kind() == SchemaKind::Any {
+        return Assignability::Yes;
+    }
+    // An empty-record consumer requires nothing, so it accepts *any* producer —
+    // including an opaque `Any`. Decide this before the producer-`Any` check, or
+    // an untyped producer feeding a no-input downstream node (`Input = ()`) would
+    // be falsely flagged `Unknown`/`PortSchemaUndecidable` in Strict mode.
+    if consumer.fields().is_empty() {
         return Assignability::Yes;
     }
     // An `Any` producer may emit anything: not refuted, but not provable either.
@@ -446,7 +456,19 @@ fn collect_pair(
         },
         (Field::List(producer_list), Field::List(consumer_list)) => {
             match (&producer_list.item, &consumer_list.item) {
-                // Either side has no typed item schema — Any escape (provably Yes).
+                // Producer item untyped but consumer item typed: in the strict
+                // (kind-aware) path this is an opaque producer that cannot be
+                // *proven* to match the typed item — surface it as Unknown
+                // (mirrors the record-level empty-producer rule). The gradual
+                // slice path keeps the old producer-side Any escape.
+                (None, Some(_)) if strict => {
+                    acc.unknown.push(UnknownReason::NestedUnknown {
+                        key: key.clone(),
+                        inner: Box::new(UnknownReason::OpaqueProducer),
+                    });
+                },
+                // An untyped consumer item accepts any producer item (provably
+                // Yes); a gradual untyped producer item also escapes.
                 (None, _) | (_, None) => {},
                 (Some(producer_item), Some(consumer_item)) => {
                     // The nested context is the list field `key`, but the inner
@@ -1006,6 +1028,44 @@ mod tests {
         );
     }
 
+    /// An `Any` producer feeding a no-input (empty-record) consumer is provably
+    /// `Yes`, NOT `Unknown` — the empty consumer requires nothing, so a strict
+    /// validator must not flag a `serde_json::Value` → order-only edge.
+    #[test]
+    fn explain_any_producer_into_empty_record_consumer_is_yes() {
+        assert_eq!(
+            explain_assignable(&ValidSchema::any(), &ValidSchema::empty()),
+            Assignability::Yes,
+        );
+    }
+
+    /// An untyped producer list item against a *typed* consumer item is opaque:
+    /// strict ⇒ `Unknown(NestedUnknown { items, OpaqueProducer })`, gradual ⇒
+    /// `Yes` (producer-side escape preserved).
+    ///
+    /// Driven via `explain_slice` on raw `Field`s, not `explain_assignable`: a
+    /// built `ValidSchema` can never carry an item-less list (the builder lint
+    /// rejects it — `lint.rs` `missing_item_schema`), so this case is
+    /// unreachable through the public `ValidSchema` API. The `collect_pair` core
+    /// is kept total/correct for it regardless (mirrors the record-level
+    /// empty-producer rule), and the gradual slice form does reach it.
+    #[test]
+    fn explain_untyped_producer_list_item_is_unknown_for_typed_consumer() {
+        let p = [Field::list(fk("items")).into()];
+        let c = [Field::list(fk("items"))
+            .item(Field::string(fk("item")))
+            .into()];
+
+        assert_eq!(
+            explain_slice(&p, &c, true),
+            Assignability::Unknown(vec![UnknownReason::NestedUnknown {
+                key: fk("items"),
+                inner: Box::new(UnknownReason::OpaqueProducer),
+            }]),
+        );
+        assert_eq!(explain_slice(&p, &c, false), Assignability::Yes);
+    }
+
     /// A `Dynamic` producer field is `Unknown(DynamicLoaderBacked)` in explain,
     /// yet `Ok` in the binary check (the lofty per-field gradual escape).
     #[test]
@@ -1174,7 +1234,7 @@ mod tests {
     fn unknown_reason_display_is_human_readable() {
         assert_eq!(
             UnknownReason::OpaqueProducer.to_string(),
-            "producer schema is an opaque `Any` (shape unknown)"
+            "producer side is opaque (shape unknown)"
         );
         assert_eq!(
             UnknownReason::DynamicLoaderBacked { key: fk("tok") }.to_string(),

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -175,7 +175,9 @@ pub use builder::{
     BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
     ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,
 };
-pub use compat::{SchemaIncompat, is_assignable_schema};
+pub use compat::{
+    Assignability, SchemaIncompat, UnknownReason, explain_assignable, is_assignable_schema,
+};
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -118,15 +118,17 @@ pub enum WorkflowError {
     /// The producer node's output schema is not assignable to the consumer
     /// node's input schema on this connection (ADR-0100 TypeDAG T3).
     ///
-    /// Emitted by [`crate::validate::validate_workflow_with_resolver`] when
-    /// both endpoints resolve and `nebula_schema::is_assignable_schema` returns
-    /// an incompatibility. Structural errors (unknown nodes, cycles, …) are
-    /// reported first; this error only fires when both nodes are structurally
-    /// valid and both schemas are resolvable from the catalog.
+    /// Emitted by [`crate::validate::validate_workflow_with_resolver`] when both
+    /// endpoints resolve and `nebula_schema::explain_assignable` returns
+    /// [`Assignability::No`](nebula_schema::Assignability::No) — a provable
+    /// incompatibility. (An undecidable [`Unknown`](nebula_schema::Assignability::Unknown)
+    /// verdict is [`Self::PortSchemaUndecidable`] in Strict mode, not this.)
+    /// Structural errors (unknown nodes, cycles, …) are reported first; this
+    /// error only fires when both nodes are structurally valid and both schemas
+    /// are resolvable from the catalog.
     ///
-    /// The payload is `Box`ed because the struct is large (two `NodeKey`s,
-    /// two `Option<String>`s, one `String`) and boxing keeps the `WorkflowError`
-    /// enum small enough to satisfy `clippy::result_large_err`.
+    /// The payload is `Box`ed to keep the `WorkflowError` enum small enough to
+    /// satisfy `clippy::result_large_err`.
     #[classify(category = "validation", code = "WORKFLOW:PORT_SCHEMA_INCOMPATIBLE")]
     #[error("port schema incompatible: {0}")]
     PortSchemaIncompatible(Box<PortSchemaIncompatDetails>),
@@ -168,11 +170,19 @@ pub enum WorkflowError {
     },
 }
 
+/// Join a slice of `Display` items with `"; "` (shared by the two payload
+/// `Display` impls below).
+fn join_display<T: std::fmt::Display>(items: &[T]) -> String {
+    items
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 /// Payload for [`WorkflowError::PortSchemaIncompatible`].
 ///
-/// Kept separate and `Box`ed on the enum to satisfy `clippy::result_large_err`
-/// — the combined size of two `NodeKey`s, two `Option<String>`s, and one
-/// `String` exceeds the 128-byte threshold for the `result_large_err` lint.
+/// Kept separate and `Box`ed on the enum to satisfy `clippy::result_large_err`.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct PortSchemaIncompatDetails {
@@ -184,9 +194,10 @@ pub struct PortSchemaIncompatDetails {
     pub from_port: Option<String>,
     /// The target input port, if named (`None` = default flow input).
     pub to_port: Option<String>,
-    /// Human-readable description of the first incompatibility found
-    /// (from [`nebula_schema::SchemaIncompat`]'s `Display` impl).
-    pub reason: String,
+    /// Every incompatibility found on this edge (depth-first, consumer-field
+    /// order), structured for programmatic inspection. The `Display` impl joins
+    /// their [`nebula_schema::SchemaIncompat`] descriptions with `"; "`.
+    pub incompatibilities: Vec<nebula_schema::SchemaIncompat>,
 }
 
 impl std::fmt::Display for PortSchemaIncompatDetails {
@@ -196,7 +207,11 @@ impl std::fmt::Display for PortSchemaIncompatDetails {
         write!(
             f,
             "{}.{} \u{2192} {}.{}: {}",
-            self.from_node, from_port, self.to_node, to_port, self.reason
+            self.from_node,
+            from_port,
+            self.to_node,
+            to_port,
+            join_display(&self.incompatibilities)
         )
     }
 }
@@ -216,9 +231,11 @@ pub struct PortSchemaUndecidableDetails {
     pub from_port: Option<String>,
     /// The target input port, if named (`None` = default flow input).
     pub to_port: Option<String>,
-    /// Human-readable list of why the edge is undecidable (from
-    /// [`nebula_schema::UnknownReason`]'s `Display`, joined with `; `).
-    pub reasons: String,
+    /// Every reason the edge is undecidable, structured so a policy can route on
+    /// them (e.g. suppress [`OpaqueProducer`](nebula_schema::UnknownReason::OpaqueProducer)
+    /// while blocking [`ModeVariance`](nebula_schema::UnknownReason::ModeVariance))
+    /// without string-parsing. The `Display` impl joins their descriptions with `"; "`.
+    pub reasons: Vec<nebula_schema::UnknownReason>,
 }
 
 impl std::fmt::Display for PortSchemaUndecidableDetails {
@@ -228,7 +245,11 @@ impl std::fmt::Display for PortSchemaUndecidableDetails {
         write!(
             f,
             "{}.{} \u{2192} {}.{}: {}",
-            self.from_node, from_port, self.to_node, to_port, self.reasons
+            self.from_node,
+            from_port,
+            self.to_node,
+            to_port,
+            join_display(&self.reasons)
         )
     }
 }

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -131,6 +131,22 @@ pub enum WorkflowError {
     #[error("port schema incompatible: {0}")]
     PortSchemaIncompatible(Box<PortSchemaIncompatDetails>),
 
+    /// The producer→consumer edge is **not statically decidable** under
+    /// [`SchemaCheckMode::Strict`](crate::validate::SchemaCheckMode) (ADR-0100
+    /// TypeDAG): the assignability verdict was
+    /// [`nebula_schema::Assignability::Unknown`] — a loader-backed `Dynamic`
+    /// field, an opaque `Any` producer, `Mode` sum-type variance, or a float→int
+    /// narrowing — so compatibility could be neither proven nor refuted.
+    ///
+    /// Never emitted under
+    /// [`SchemaCheckMode::Gradual`](crate::validate::SchemaCheckMode), which
+    /// passes undecidable edges (the default, preserving untyped
+    /// `serde_json::Value` workflows). Boxed for the same `result_large_err`
+    /// reason as [`Self::PortSchemaIncompatible`].
+    #[classify(category = "validation", code = "WORKFLOW:PORT_SCHEMA_UNDECIDABLE")]
+    #[error("port schema undecidable: {0}")]
+    PortSchemaUndecidable(Box<PortSchemaUndecidableDetails>),
+
     /// A `RetryConfig` (per-node or workflow-default) violates the validity
     /// rules: `max_attempts == 0`, `max_delay_ms < initial_delay_ms`,
     /// `backoff_multiplier <= 0` or non-finite, or `initial_delay_ms == 0`
@@ -181,6 +197,38 @@ impl std::fmt::Display for PortSchemaIncompatDetails {
             f,
             "{}.{} \u{2192} {}.{}: {}",
             self.from_node, from_port, self.to_node, to_port, self.reason
+        )
+    }
+}
+
+/// Payload for [`WorkflowError::PortSchemaUndecidable`].
+///
+/// Kept separate and `Box`ed on the enum for the same `clippy::result_large_err`
+/// reason as [`PortSchemaIncompatDetails`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct PortSchemaUndecidableDetails {
+    /// The producer (source) node key.
+    pub from_node: NodeKey,
+    /// The consumer (target) node key.
+    pub to_node: NodeKey,
+    /// The source output port, if named (`None` = default `"main"`).
+    pub from_port: Option<String>,
+    /// The target input port, if named (`None` = default flow input).
+    pub to_port: Option<String>,
+    /// Human-readable list of why the edge is undecidable (from
+    /// [`nebula_schema::UnknownReason`]'s `Display`, joined with `; `).
+    pub reasons: String,
+}
+
+impl std::fmt::Display for PortSchemaUndecidableDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let from_port = self.from_port.as_deref().unwrap_or("main");
+        let to_port = self.to_port.as_deref().unwrap_or("default");
+        write!(
+            f,
+            "{}.{} \u{2192} {}.{}: {}",
+            self.from_node, from_port, self.to_node, to_port, self.reasons
         )
     }
 }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -43,12 +43,15 @@ pub use definition::{
     Annotation, CURRENT_SCHEMA_VERSION, CheckpointingConfig, ErrorStrategy, NodePosition,
     RetryConfig, TriggerBinding, UiMetadata, Viewport, WorkflowConfig, WorkflowDefinition,
 };
-pub use error::{PortSchemaIncompatDetails, WorkflowError};
+pub use error::{PortSchemaIncompatDetails, PortSchemaUndecidableDetails, WorkflowError};
 pub use graph::DependencyGraph;
 /// Re-export the shared serde helper so internal `crate::serde_duration_opt` still resolves.
 pub(crate) use nebula_core::serde_helpers::duration_opt_ms as serde_duration_opt;
 pub use node::{NodeDefinition, ParamValue, RateLimit, SlotBinding};
 pub use resolver::{NodeIoSchemas, NodeSchemaResolver};
 pub use state::NodeState;
-pub use validate::{ValidatedWorkflow, validate_workflow, validate_workflow_with_resolver};
+pub use validate::{
+    SchemaCheckMode, ValidatedWorkflow, validate_workflow, validate_workflow_with_resolver,
+    validate_workflow_with_resolver_mode,
+};
 pub use version::Version;

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use nebula_schema::is_assignable_schema;
+use nebula_schema::{Assignability, explain_assignable};
 
 use crate::{
     definition::{CURRENT_SCHEMA_VERSION, RetryConfig, WorkflowDefinition},
@@ -183,12 +183,48 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
     errors
 }
 
+/// Policy for how the TypeDAG per-edge schema check treats an **undecidable**
+/// assignability verdict ([`nebula_schema::Assignability::Unknown`] — a
+/// loader-backed `Dynamic` field, an opaque `Any` producer, `Mode` sum-type
+/// variance, or a float→int narrowing).
+///
+/// A provable incompatibility ([`No`](nebula_schema::Assignability::No)) is
+/// always reported regardless of mode; this only governs the `Unknown` middle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum SchemaCheckMode {
+    /// Undecidable edges **pass** (warn-and-pass). The default — preserves
+    /// untyped `serde_json::Value` / `Dynamic` workflows. Behaves exactly like
+    /// the binary [`nebula_schema::is_assignable_schema`].
+    #[default]
+    Gradual,
+    /// Undecidable edges are **blocked** with
+    /// [`WorkflowError::PortSchemaUndecidable`] carrying the reasons. Use when a
+    /// workflow must be provably well-typed before activation.
+    Strict,
+}
+
+/// Validate a workflow definition and run the TypeDAG per-edge schema check in
+/// [`SchemaCheckMode::Gradual`] (the back-compatible default — undecidable edges
+/// pass). See [`validate_workflow_with_resolver_mode`] to choose the mode.
+#[must_use]
+pub fn validate_workflow_with_resolver(
+    definition: &WorkflowDefinition,
+    resolver: &dyn NodeSchemaResolver,
+) -> Vec<WorkflowError> {
+    validate_workflow_with_resolver_mode(definition, resolver, SchemaCheckMode::Gradual)
+}
+
 /// Validate a workflow definition and run the TypeDAG per-edge schema check.
 ///
 /// Runs every structural check that [`validate_workflow`] performs, then for
 /// each [`Connection`](crate::Connection) whose **both** endpoints can be
-/// resolved by `resolver`, calls
-/// `nebula_schema::is_assignable_schema(producer.output, consumer.input)`.
+/// resolved by `resolver`, computes
+/// `nebula_schema::explain_assignable(producer.output, consumer.input)` and
+/// reports per `mode`: a [`No`](nebula_schema::Assignability::No) verdict is
+/// always a [`WorkflowError::PortSchemaIncompatible`]; an
+/// [`Unknown`](nebula_schema::Assignability::Unknown) verdict is a
+/// [`WorkflowError::PortSchemaUndecidable`] only in [`SchemaCheckMode::Strict`].
 ///
 /// An edge is **skipped** (fail-open, ADR-0100 T3.2) when **any** of the
 /// following hold:
@@ -213,16 +249,19 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
 /// - `definition` — the workflow to validate.
 /// - `resolver` — a `dyn NodeSchemaResolver` supplied by the caller; the
 ///   workflow crate never imports `ActionRegistry` directly.
+/// - `mode` — how undecidable edges are treated (see [`SchemaCheckMode`]).
 ///
 /// # Returns
 ///
 /// All [`WorkflowError`]s collected (structural + schema), in encounter order:
 /// structural errors come first (from [`validate_workflow`]), followed by any
-/// [`WorkflowError::PortSchemaIncompatible`] variants in connection order.
+/// [`WorkflowError::PortSchemaIncompatible`] / [`WorkflowError::PortSchemaUndecidable`]
+/// variants in connection order.
 #[must_use]
-pub fn validate_workflow_with_resolver(
+pub fn validate_workflow_with_resolver_mode(
     definition: &WorkflowDefinition,
     resolver: &dyn NodeSchemaResolver,
+    mode: SchemaCheckMode,
 ) -> Vec<WorkflowError> {
     let mut errors = validate_workflow(definition);
 
@@ -274,22 +313,48 @@ pub fn validate_workflow_with_resolver(
         };
 
         // Run the directional, kind-aware assignability check: producer output
-        // ⊆ consumer input. `is_assignable_schema` honors the `SchemaKind`
-        // Top/Bottom split, so a producer whose `Output = ()` (an empty record)
-        // does not satisfy a consumer that hard-requires a field, while an
-        // untyped `serde_json::Value` (`Any`) producer still passes.
-        if let Err(incompat) =
-            is_assignable_schema(&producer_schemas.output, &consumer_schemas.input)
-        {
-            errors.push(WorkflowError::PortSchemaIncompatible(Box::new(
-                crate::error::PortSchemaIncompatDetails {
-                    from_node: conn.from_node.clone(),
-                    to_node: conn.to_node.clone(),
-                    from_port: conn.from_port.clone(),
-                    to_port: conn.to_port.clone(),
-                    reason: incompat.to_string(),
-                },
-            )));
+        // ⊆ consumer input. `explain_assignable` honors the `SchemaKind`
+        // Top/Bottom split (an `Output = ()` empty record does not satisfy a
+        // consumer that hard-requires a field; an untyped `Any` producer is
+        // `Unknown`, not a hard error).
+        match explain_assignable(&producer_schemas.output, &consumer_schemas.input) {
+            // Provably incompatible: always a hard error, with every finding.
+            Assignability::No(incompats) => {
+                let reason = incompats
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                errors.push(WorkflowError::PortSchemaIncompatible(Box::new(
+                    crate::error::PortSchemaIncompatDetails {
+                        from_node: conn.from_node.clone(),
+                        to_node: conn.to_node.clone(),
+                        from_port: conn.from_port.clone(),
+                        to_port: conn.to_port.clone(),
+                        reason,
+                    },
+                )));
+            },
+            // Undecidable: blocked only in Strict mode; Gradual warns-and-passes.
+            Assignability::Unknown(reasons) if mode == SchemaCheckMode::Strict => {
+                let reasons = reasons
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                errors.push(WorkflowError::PortSchemaUndecidable(Box::new(
+                    crate::error::PortSchemaUndecidableDetails {
+                        from_node: conn.from_node.clone(),
+                        to_node: conn.to_node.clone(),
+                        from_port: conn.from_port.clone(),
+                        to_port: conn.to_port.clone(),
+                        reasons,
+                    },
+                )));
+            },
+            // `Yes`, an `Unknown` in Gradual mode, or any future verdict variant
+            // (the enum is `#[non_exhaustive]`): pass the edge.
+            _ => {},
         }
     }
 
@@ -357,7 +422,23 @@ impl ValidatedWorkflow {
         definition: WorkflowDefinition,
         resolver: &dyn NodeSchemaResolver,
     ) -> Result<Self, Vec<WorkflowError>> {
-        let errors = validate_workflow_with_resolver(&definition, resolver);
+        Self::validate_with_resolver_mode(definition, resolver, SchemaCheckMode::Gradual)
+    }
+
+    /// Like [`Self::validate_with_resolver`] but with an explicit
+    /// [`SchemaCheckMode`]. [`SchemaCheckMode::Strict`] additionally rejects
+    /// undecidable edges ([`WorkflowError::PortSchemaUndecidable`]), so the
+    /// resulting witness is provably well-typed, not merely not-refuted.
+    ///
+    /// # Errors
+    ///
+    /// Returns every [`WorkflowError`] collected (structural + schema).
+    pub fn validate_with_resolver_mode(
+        definition: WorkflowDefinition,
+        resolver: &dyn NodeSchemaResolver,
+        mode: SchemaCheckMode,
+    ) -> Result<Self, Vec<WorkflowError>> {
+        let errors = validate_workflow_with_resolver_mode(&definition, resolver, mode);
         if errors.is_empty() {
             Ok(Self(definition))
         } else {
@@ -1278,6 +1359,149 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, WorkflowError::PortSchemaIncompatible(_))),
             "expected PortSchemaIncompatible in errors; got: {errors:?}"
+        );
+    }
+
+    // ── SchemaCheckMode: Gradual vs Strict on undecidable edges ───────────────
+
+    /// Build a producer schema whose single field is `Dynamic` (loader-backed) —
+    /// an output that yields an `Unknown` verdict against a typed consumer.
+    fn dynamic_field_schema(key: &str) -> ValidSchema {
+        Schema::builder()
+            .add(Field::dynamic(FieldKey::new(key).unwrap()))
+            .build()
+            .unwrap()
+    }
+
+    /// Build the producer-dynamic / consumer-required edge used by the mode tests.
+    fn undecidable_edge_schemas() -> HashMap<String, NodeIoSchemas> {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty(),
+                output: dynamic_field_schema("data"),
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: single_field_schema("data", true),
+                output: ValidSchema::empty(),
+            },
+        );
+        schemas
+    }
+
+    /// Gradual mode (the default) warns-and-passes an undecidable edge: a
+    /// `Dynamic` producer output feeding a required consumer input yields no
+    /// schema error — untyped/dynamic workflows keep working.
+    #[test]
+    fn gradual_mode_passes_undecidable_dynamic_edge() {
+        let (def, _, _) = two_node_def();
+        let resolver = MapResolver(undecidable_edge_schemas());
+
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+        assert!(
+            !errors.iter().any(|e| matches!(
+                e,
+                WorkflowError::PortSchemaUndecidable(_) | WorkflowError::PortSchemaIncompatible(_)
+            )),
+            "gradual mode must pass an undecidable (Dynamic) edge; got: {errors:?}"
+        );
+    }
+
+    /// Strict mode blocks the same undecidable edge with exactly one
+    /// `PortSchemaUndecidable` (and no `PortSchemaIncompatible`, since it is not
+    /// a provable conflict).
+    #[test]
+    fn strict_mode_blocks_undecidable_dynamic_edge() {
+        let (def, a, b) = two_node_def();
+        let resolver = MapResolver(undecidable_edge_schemas());
+
+        let errors = validate_workflow_with_resolver_mode(&def, &resolver, SchemaCheckMode::Strict);
+
+        let undecidable: Vec<_> = errors
+            .iter()
+            .filter(|e| matches!(e, WorkflowError::PortSchemaUndecidable(_)))
+            .collect();
+        assert_eq!(
+            undecidable.len(),
+            1,
+            "strict mode must block the undecidable edge; got: {errors:?}"
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::PortSchemaIncompatible(_))),
+            "an undecidable edge is not a hard incompatibility; got: {errors:?}"
+        );
+        let Some(WorkflowError::PortSchemaUndecidable(details)) = undecidable.first().copied()
+        else {
+            panic!("expected PortSchemaUndecidable; got: {errors:?}");
+        };
+        assert_eq!(details.from_node, a);
+        assert_eq!(details.to_node, b);
+    }
+
+    /// Strict mode does NOT reclassify a provable conflict: a genuinely
+    /// incompatible edge is still `PortSchemaIncompatible`, never
+    /// `PortSchemaUndecidable`.
+    #[test]
+    fn strict_mode_still_reports_hard_incompatible_as_incompatible() {
+        let (def, _, _) = two_node_def();
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty(),
+                output: single_field_schema("a", true),
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: single_field_schema("b", true), // requires `b`, absent
+                output: ValidSchema::empty(),
+            },
+        );
+        let resolver = MapResolver(schemas);
+
+        let errors = validate_workflow_with_resolver_mode(&def, &resolver, SchemaCheckMode::Strict);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::PortSchemaIncompatible(_))),
+            "a provable conflict stays PortSchemaIncompatible in strict mode; got: {errors:?}"
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::PortSchemaUndecidable(_))),
+            "a provable conflict must not be reported as undecidable; got: {errors:?}"
+        );
+    }
+
+    /// `ValidatedWorkflow::validate_with_resolver_mode(Strict)` rejects an
+    /// undecidable graph, while the gradual witness accepts it.
+    #[test]
+    fn validated_workflow_strict_rejects_undecidable_gradual_accepts() {
+        let (def, _, _) = two_node_def();
+        let resolver = MapResolver(undecidable_edge_schemas());
+
+        assert!(
+            ValidatedWorkflow::validate_with_resolver(def.clone(), &resolver).is_ok(),
+            "gradual witness accepts an undecidable edge"
+        );
+
+        let errors =
+            ValidatedWorkflow::validate_with_resolver_mode(def, &resolver, SchemaCheckMode::Strict)
+                .expect_err("strict witness must reject an undecidable edge");
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::PortSchemaUndecidable(_))),
+            "expected PortSchemaUndecidable; got: {errors:?}"
         );
     }
 }

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -318,30 +318,20 @@ pub fn validate_workflow_with_resolver_mode(
         // consumer that hard-requires a field; an untyped `Any` producer is
         // `Unknown`, not a hard error).
         match explain_assignable(&producer_schemas.output, &consumer_schemas.input) {
-            // Provably incompatible: always a hard error, with every finding.
-            Assignability::No(incompats) => {
-                let reason = incompats
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join("; ");
+            // Provably incompatible: always a hard error, carrying every finding.
+            Assignability::No(incompatibilities) => {
                 errors.push(WorkflowError::PortSchemaIncompatible(Box::new(
                     crate::error::PortSchemaIncompatDetails {
                         from_node: conn.from_node.clone(),
                         to_node: conn.to_node.clone(),
                         from_port: conn.from_port.clone(),
                         to_port: conn.to_port.clone(),
-                        reason,
+                        incompatibilities,
                     },
                 )));
             },
             // Undecidable: blocked only in Strict mode; Gradual warns-and-passes.
             Assignability::Unknown(reasons) if mode == SchemaCheckMode::Strict => {
-                let reasons = reasons
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join("; ");
                 errors.push(WorkflowError::PortSchemaUndecidable(Box::new(
                     crate::error::PortSchemaUndecidableDetails {
                         from_node: conn.from_node.clone(),
@@ -403,12 +393,16 @@ impl ValidatedWorkflow {
     }
 
     /// Validate `definition` with both structural checks and the TypeDAG
-    /// per-edge schema check, then wrap it as a dispatch witness on success.
+    /// per-edge schema check in [`SchemaCheckMode::Gradual`], then wrap it as a
+    /// dispatch witness on success.
     ///
-    /// Runs [`validate_workflow_with_resolver`], which collects all structural
-    /// errors (identical to [`Self::validate`]) plus per-edge
+    /// A `Gradual`-hardcoded convenience over
+    /// [`Self::validate_with_resolver_mode`]: collects all structural errors
+    /// (identical to [`Self::validate`]) plus per-edge
     /// [`WorkflowError::PortSchemaIncompatible`] errors when both endpoint
-    /// schemas can be resolved from `resolver`.
+    /// schemas resolve. Undecidable edges pass; use
+    /// [`Self::validate_with_resolver_mode`] with [`SchemaCheckMode::Strict`] to
+    /// reject them ([`WorkflowError::PortSchemaUndecidable`]).
     ///
     /// An edge whose producer or consumer returns `None` from `resolver` is
     /// silently skipped (fail-open — ADR-0100 T3.2). Passing a resolver that
@@ -1442,6 +1436,67 @@ mod tests {
         };
         assert_eq!(details.from_node, a);
         assert_eq!(details.to_node, b);
+        // The structured reason is the producer's `Dynamic` output field `data`.
+        assert_eq!(
+            details.reasons,
+            vec![nebula_schema::UnknownReason::DynamicLoaderBacked {
+                key: FieldKey::new("data").unwrap()
+            }],
+            "reasons carries the structured UnknownReason, not just a string"
+        );
+        assert!(
+            details.to_string().contains("dynamic"),
+            "Display renders the reason; got: {details}"
+        );
+    }
+
+    /// A provably-incompatible edge with TWO missing required fields carries
+    /// BOTH in `incompatibilities` (the collect-all behavior) — guards against a
+    /// regression to first-error-only.
+    #[test]
+    fn incompatible_edge_carries_all_findings() {
+        let (def, _, _) = two_node_def();
+        let consumer_input = Schema::builder()
+            .add(Field::string(FieldKey::new("a").unwrap()).required())
+            .add(Field::string(FieldKey::new("b").unwrap()).required())
+            .build()
+            .unwrap();
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty(),
+                output: ValidSchema::empty(), // empty record — supplies neither `a` nor `b`
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: consumer_input,
+                output: ValidSchema::empty(),
+            },
+        );
+        let resolver = MapResolver(schemas);
+
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+        let incompat: Vec<_> = errors
+            .iter()
+            .filter_map(|e| match e {
+                WorkflowError::PortSchemaIncompatible(d) => Some(d),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(incompat.len(), 1, "one edge, one error; got: {errors:?}");
+        assert_eq!(
+            incompat[0].incompatibilities.len(),
+            2,
+            "both missing required fields are reported, not just the first"
+        );
+        let rendered = incompat[0].to_string();
+        assert!(
+            rendered.contains('a') && rendered.contains('b'),
+            "Display joins all findings; got: {rendered}"
+        );
     }
 
     /// Strict mode does NOT reclassify a provable conflict: a genuinely


### PR DESCRIPTION
## What

Step 3 of the nebula-schema fix-plan (C5). Adds a **three-valued** assignability channel on top of the binary check, so an *undecidable* edge becomes an explicit policy choice instead of a hidden `Ok`.

## schema — `Assignability` lattice

- `Assignability { Yes, No(Vec<SchemaIncompat>), Unknown(Vec<UnknownReason>) }` + `explain_assignable(&ValidSchema, &ValidSchema)`. A single **collect-all** traversal gathers every incompatibility (not just the first) and every "not statically decidable" reason. Verdict precedence: `No` ▸ `Unknown` ▸ `Yes`.
- Leniencies the binary check silently passed are now surfaced as `Unknown`: opaque `Any` producer (`OpaqueProducer`), `Dynamic`/`Computed` fields (`DynamicLoaderBacked`), `Mode` sum-type variance (`ModeVariance`), float→int narrowing (`NumberWidening`). int→float is provably `Yes`; an `Any` *consumer* is provably `Yes`.
- `UnknownReason::NestedUnknown { key, inner }` mirrors `SchemaIncompat::NestedIncompat`, so undecidable reasons inside nested Objects/Lists keep their path (`config.token`, not a bare `token`).
- `is_assignable_schema` (the binary public check — workflow validate + action metadata call it) now **delegates** to `explain_assignable` (`Yes`/`Unknown` ⇒ `Ok`, `No` ⇒ first incompat). Its behavior is unchanged — green edges stay green. The collect-all core replaces the old first-error traversal as the single source of truth.
- Fixes the list-item-key bug: a nested list-item incompatibility is now keyed by the **item**, not the enclosing list.

## workflow — `SchemaCheckMode`

- `SchemaCheckMode { Gradual (default), Strict }`. The per-edge validator consumes `explain_assignable`: `No` is always `PortSchemaIncompatible`; `Unknown` is the new `PortSchemaUndecidable` **only** under `Strict` — `Gradual` warns-and-passes (untyped/dynamic workflows keep working).
- `validate_workflow_with_resolver` stays `Gradual`; `…_mode` and `ValidatedWorkflow::validate_with_resolver_mode` opt into `Strict`.
- Both error payloads carry **structured** findings (`Vec<SchemaIncompat>` / `Vec<UnknownReason>`) with a `Display` that joins them — a strict policy can route on reasons without string-parsing.

## Review

A 4-lens adversarial review ran on the diff; the soundness lens found no logic bug. All findings are addressed in the second commit: `NestedUnknown` path preservation, structured error payloads, and the missing tests (ModeVariance oracle, nested-Unknown path, No-dominates-Unknown across containers, workflow multi-finding + structured reasons, `Display`).

## Verification

`cargo nextest run --workspace` — **5634 passed, 1 skipped, 0 failed**. `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema validation now supports Gradual and Strict modes for configurable per-edge compatibility checking.
  * Enhanced error reporting displays all incompatibilities and undecidable reasons instead of just the first error.

* **Bug Fixes**
  * Fixed nested list-item path bug where inner schema mismatches could be reported with incorrect field keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->