### PR TITLE
feat(schema): direction-typed Input/Output schemas (ADR-0100 C15)

### DIFF
--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -382,6 +382,17 @@ impl ActionMetadata {
         &self.output_schema
     }
 
+    /// The output schema tagged with producer polarity (ADR-0100 C15).
+    ///
+    /// A single place to wrap `output_schema` into an
+    /// [`OutputSchema`](nebula_schema::OutputSchema), so callers feeding the
+    /// TypeDAG assignability API need not restate `OutputSchema::new(...)`. When
+    /// the `HasOutputSchema` trait split lands this becomes its impl site.
+    #[must_use]
+    pub fn typed_output_schema(&self) -> nebula_schema::OutputSchema {
+        nebula_schema::OutputSchema::new(self.output_schema.clone())
+    }
+
     /// Set the isolation level for dispatch routing.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_isolation_level(mut self, level: IsolationLevel) -> Self {
@@ -456,9 +467,12 @@ impl ActionMetadata {
         // dropped or narrowed a field old consumers relied on — a silent breaking
         // change on a same-major upgrade (including a collapse to `Output = ()`,
         // which an untyped `Any` would have masked).
-        let new_output = nebula_schema::OutputSchema::new(self.output_schema.clone());
-        let old_output = nebula_schema::OutputSchema::new(previous.output_schema.clone());
-        if same_major && new_output.is_compatible_successor_of(&old_output).is_err() {
+        if same_major
+            && self
+                .typed_output_schema()
+                .is_compatible_successor_of(&previous.typed_output_schema())
+                .is_err()
+        {
             return Err(MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump);
         }
 

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -448,17 +448,17 @@ impl ActionMetadata {
             return Err(MetadataCompatibilityError::PortsChangeWithoutMajorBump);
         }
 
-        // TypeDAG output-schema assignability: the NEW output is the producer;
-        // the OLD output is the consumer (downstream nodes were typed against it).
-        // If `is_assignable_schema` returns Err the new output dropped or changed
-        // a field that old consumers required — that is a silent breaking change
-        // on a same-major upgrade. A major version bump is required. The
-        // kind-aware check also catches a new output collapsing to an empty
-        // record (`Output = ()`), which an untyped `Any` would have masked.
-        if same_major
-            && nebula_schema::is_assignable_schema(&self.output_schema, &previous.output_schema)
-                .is_err()
-        {
+        // TypeDAG output-schema evolution: does the NEW output still satisfy
+        // everything consumers typed against the OLD output required? This is an
+        // *output-vs-output* successor check, not a producer→consumer edge, so it
+        // uses `OutputSchema::is_compatible_successor_of` rather than the
+        // direction-typed `is_assignable_schema`. An `Err` means the new output
+        // dropped or narrowed a field old consumers relied on — a silent breaking
+        // change on a same-major upgrade (including a collapse to `Output = ()`,
+        // which an untyped `Any` would have masked).
+        let new_output = nebula_schema::OutputSchema::new(self.output_schema.clone());
+        let old_output = nebula_schema::OutputSchema::new(previous.output_schema.clone());
+        if same_major && new_output.is_compatible_successor_of(&old_output).is_err() {
             return Err(MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump);
         }
 

--- a/crates/api/src/domain/workflow/resolver.rs
+++ b/crates/api/src/domain/workflow/resolver.rs
@@ -70,8 +70,10 @@ impl NodeSchemaResolver for CatalogSchemaResolver {
         };
 
         Some(NodeIoSchemas {
-            input: metadata.base.schema.clone(),
-            output: metadata.output_schema,
+            // Tag the catalog schemas with their dataflow polarity (ADR-0100 C15):
+            // a node's declared input is the consumer side, its output the producer.
+            input: metadata.base.schema.clone().into(),
+            output: metadata.output_schema.into(),
         })
     }
 }
@@ -193,16 +195,18 @@ mod tests {
         let schemas = resolver.io_schemas(&action_key, None).unwrap();
 
         assert_eq!(
-            schemas.input, input,
+            schemas.input.as_schema(),
+            &input,
             "input schema must match caller-supplied base.schema"
         );
         assert_eq!(
-            schemas.output, expected_output,
+            schemas.output.as_schema(),
+            &expected_output,
             "output schema must match TypedOut::schema() (type-stamped by InstanceFactory)"
         );
         // Non-vacuous: the output schema must be non-empty so the assertion is meaningful.
         assert!(
-            !schemas.output.fields().is_empty(),
+            !schemas.output.as_schema().fields().is_empty(),
             "TypedOut schema must be non-empty (test would be vacuous otherwise)"
         );
     }
@@ -250,12 +254,13 @@ mod tests {
             .expect("version 1.0.0 is registered; io_schemas must return Some");
 
         assert_eq!(
-            schemas.input, input,
+            schemas.input.as_schema(),
+            &input,
             "versioned hit: input schema must match caller-supplied base.schema"
         );
         assert_eq!(
-            schemas.output,
-            TypedOut::schema(),
+            schemas.output.as_schema(),
+            &TypedOut::schema(),
             "versioned hit: output schema must match TypedOut::schema()"
         );
     }

--- a/crates/schema/CHANGELOG.md
+++ b/crates/schema/CHANGELOG.md
@@ -12,6 +12,16 @@ covers the full set of issues raised in the nebula-schema code review.
 
 ### ⚠ Breaking Changes
 
+- **Assignability is direction-typed (ADR-0100 C15).**  `is_assignable_schema`
+  and `explain_assignable` changed signature from `(&ValidSchema, &ValidSchema)`
+  to `(&OutputSchema, &InputSchema)`, so transposing producer and consumer is now
+  a compile error.  Callers wrap a `ValidSchema` with `OutputSchema::new` /
+  `InputSchema::new` (or `.into()`).  Output-vs-output *evolution* moved to the
+  new `OutputSchema::is_compatible_successor_of`.  `NodeIoSchemas` (in
+  `nebula-workflow`) now carries `InputSchema` / `OutputSchema` instead of bare
+  `ValidSchema`.  The newtypes are `#[repr(transparent)]` and serde-transparent —
+  **the wire format is unchanged**.
+
 - **KDF removed from the schema layer.**  `KdfParams`, `KdfError`, the
   `MIN_KDF_*` / `MAX_KDF_*` / `DEFAULT_KDF_OUTPUT_BYTES` constants,
   `KdfParams::hash_password`, and `SecretField::kdf(...)` are deleted, along

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -212,26 +212,6 @@ pub fn explain_assignable(producer: &OutputSchema, consumer: &InputSchema) -> As
     explain_assignable_core(producer.as_schema(), consumer.as_schema())
 }
 
-impl OutputSchema {
-    /// Is `self` a backward-compatible **successor** of `prev` — does the new
-    /// output still satisfy everything consumers typed against the *old* output
-    /// required? An *output-vs-output* width-supertype check, distinct from the
-    /// producer→consumer edge relation, so it does **not** route through the
-    /// [`InputSchema`]-typed [`is_assignable_schema`].
-    ///
-    /// The action catalog's same-major compatibility gate uses this: an `Err`
-    /// means the new output dropped or narrowed a field old consumers relied on.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first [`SchemaIncompat`] (the new output `self` is the
-    /// producer, the old output `prev` the consumer-expectation).
-    #[must_use = "check the Result — an Err means the new output is not a compatible successor"]
-    pub fn is_compatible_successor_of(&self, prev: &OutputSchema) -> Result<(), SchemaIncompat> {
-        is_assignable_core(self.as_schema(), prev.as_schema())
-    }
-}
-
 /// The three-valued (Cue/GraphQL-style) assignability verdict: a producer
 /// schema is provably assignable, provably not, or **not statically decidable**.
 ///
@@ -1352,6 +1332,28 @@ mod tests {
             narrower.is_compatible_successor_of(&prev),
             Err(SchemaIncompat::MissingRequiredField { key: fk("result") }),
             "dropping a field old consumers required is a breaking successor"
+        );
+
+        // Gradual boundary at the relation level (not only via the metadata
+        // integration test): a new output that became the untyped `Any` cannot
+        // be proven breaking → Ok; one that collapsed to an empty record emits
+        // nothing the typed old output required → Err.
+        let any_new = OutputSchema::new(ValidSchema::any());
+        assert!(
+            any_new.is_compatible_successor_of(&prev).is_ok(),
+            "a new `Any` output is not provably breaking"
+        );
+        let empty_new = OutputSchema::new(ValidSchema::empty());
+        assert_eq!(
+            empty_new.is_compatible_successor_of(&prev),
+            Err(SchemaIncompat::MissingRequiredField { key: fk("result") }),
+            "an empty-record new output drops every field old consumers required"
+        );
+        // An `Any` *old* output imposed no constraints → any new output is Ok.
+        let any_prev = OutputSchema::new(ValidSchema::any());
+        assert!(
+            narrower.is_compatible_successor_of(&any_prev).is_ok(),
+            "an `Any` old output constrains nothing"
         );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -9,7 +9,7 @@
 //! `is_assignable_schema(&producer.output, &consumer.input)`. (An internal,
 //! kind-blind slice form is used only by this module's tests.)
 
-use crate::{Field, FieldKey, RequiredMode, SchemaKind, ValidSchema};
+use crate::{Field, FieldKey, InputSchema, OutputSchema, RequiredMode, SchemaKind, ValidSchema};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -80,34 +80,45 @@ pub enum SchemaIncompat {
 
 // ── Public entry point ───────────────────────────────────────────────────────
 
-/// Kind-aware structural width-subtyping: are producer values assignable where
-/// consumer values are expected? (`Output <: Input`, Liskov.)
+/// Kind-aware, **direction-typed** structural width-subtyping: is a producer's
+/// [`OutputSchema`] assignable where a consumer's [`InputSchema`] is expected?
+/// (`Output <: Input`, Liskov.)
 ///
-/// This is **the** public assignability check (ADR-0100 T1). The workflow
-/// per-edge validator (T3) and the action output-evolution check both call it,
-/// so the [`SchemaKind`] Top/Bottom split is enforced on real producer→consumer
-/// edges, not merely at the type/serde level.
+/// This is **the** public assignability check (ADR-0100 T1/C15). The workflow
+/// per-edge validator (T3) calls it, so the [`SchemaKind`] Top/Bottom split is
+/// enforced on real producer→consumer edges, not merely at the type/serde level
+/// — and the [`OutputSchema`]/[`InputSchema`] newtypes make swapping the two a
+/// compile error. (Output-vs-output *evolution* uses
+/// [`OutputSchema::is_compatible_successor_of`] instead.)
 ///
 /// ```rust
-/// use nebula_schema::{Field, Schema, ValidSchema, field_key, is_assignable_schema};
+/// use nebula_schema::{
+///     Field, InputSchema, OutputSchema, Schema, ValidSchema, field_key, is_assignable_schema,
+/// };
 ///
-/// let producer = Schema::builder()
-///     .add(Field::string(field_key!("name")).required())
-///     .add(Field::number(field_key!("extra")))
-///     .build()
-///     .unwrap();
-/// let consumer = Schema::builder()
-///     .add(Field::string(field_key!("name")).required())
-///     .build()
-///     .unwrap();
+/// let producer = OutputSchema::new(
+///     Schema::builder()
+///         .add(Field::string(field_key!("name")).required())
+///         .add(Field::number(field_key!("extra")))
+///         .build()
+///         .unwrap(),
+/// );
+/// let consumer = InputSchema::new(
+///     Schema::builder()
+///         .add(Field::string(field_key!("name")).required())
+///         .build()
+///         .unwrap(),
+/// );
 /// // Width subtyping: the producer has every required consumer field (+ extras).
 /// assert!(is_assignable_schema(&producer, &consumer).is_ok());
+/// // Swapping the arguments — `is_assignable_schema(&consumer, &producer)` —
+/// // would not compile: the polarity types enforce direction.
 ///
-/// // An empty *record* producer (`()`) provably emits nothing, so it does NOT
+/// // An empty *record* output (`()`) provably emits nothing, so it does NOT
 /// // satisfy a consumer that hard-requires a field …
-/// assert!(is_assignable_schema(&ValidSchema::empty(), &consumer).is_err());
+/// assert!(is_assignable_schema(&OutputSchema::new(ValidSchema::empty()), &consumer).is_err());
 /// // … whereas the gradual `Any` (`serde_json::Value`) still passes.
-/// assert!(is_assignable_schema(&ValidSchema::any(), &consumer).is_ok());
+/// assert!(is_assignable_schema(&OutputSchema::new(ValidSchema::any()), &consumer).is_ok());
 /// ```
 ///
 /// # Kinds (Top/Bottom split)
@@ -164,18 +175,60 @@ pub enum SchemaIncompat {
 ///   present on both sides but the `multiple` flag differs.
 #[must_use = "check the Result — an Err means the producer is not assignable to the consumer"]
 pub fn is_assignable_schema(
+    producer: &OutputSchema,
+    consumer: &InputSchema,
+) -> Result<(), SchemaIncompat> {
+    is_assignable_core(producer.as_schema(), consumer.as_schema())
+}
+
+/// Polarity-erased binary assignability core: `Yes`/`Unknown` ⇒ `Ok`, a definite
+/// `No` ⇒ its first incompatibility (depth-first, consumer-field order). Keeps
+/// the gradual escape (untyped producers, Dynamic/Mode/Number leniencies) green.
+/// Shared by the direction-typed [`is_assignable_schema`] (producer→consumer
+/// edges) and [`OutputSchema::is_compatible_successor_of`] (output-vs-output
+/// evolution).
+pub(crate) fn is_assignable_core(
     producer: &ValidSchema,
     consumer: &ValidSchema,
 ) -> Result<(), SchemaIncompat> {
-    // Binary view of the ternary verdict: `Yes` and `Unknown` (not statically
-    // refuted) both pass — this keeps the gradual escape (untyped producers,
-    // Dynamic/Mode/Number leniencies) green. Only a definite `No` is an error,
-    // surfaced as its first incompatibility (depth-first, consumer-field order).
-    match explain_assignable(producer, consumer) {
+    match explain_assignable_core(producer, consumer) {
         Assignability::Yes | Assignability::Unknown(_) => Ok(()),
         // `into_verdict` only builds `No` from a non-empty list, so `next()` is
         // always `Some`; `map_or` keeps this total without a panic path.
         Assignability::No(incompats) => incompats.into_iter().next().map_or(Ok(()), Err),
+    }
+}
+
+/// Direction-typed ternary assignability: the full [`Assignability`] verdict for
+/// a producer's [`OutputSchema`] against a consumer's [`InputSchema`].
+///
+/// The direction-typed wrapper over the polarity-erased core: taking the two
+/// distinct polarity newtypes means swapping producer and consumer is a compile
+/// error (ADR-0100 C15). See [`is_assignable_schema`] for the full rule set;
+/// this returns every finding plus the [`Unknown`](Assignability::Unknown)
+/// reasons a strict validator can block on.
+#[must_use]
+pub fn explain_assignable(producer: &OutputSchema, consumer: &InputSchema) -> Assignability {
+    explain_assignable_core(producer.as_schema(), consumer.as_schema())
+}
+
+impl OutputSchema {
+    /// Is `self` a backward-compatible **successor** of `prev` — does the new
+    /// output still satisfy everything consumers typed against the *old* output
+    /// required? An *output-vs-output* width-supertype check, distinct from the
+    /// producer→consumer edge relation, so it does **not** route through the
+    /// [`InputSchema`]-typed [`is_assignable_schema`].
+    ///
+    /// The action catalog's same-major compatibility gate uses this: an `Err`
+    /// means the new output dropped or narrowed a field old consumers relied on.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SchemaIncompat`] (the new output `self` is the
+    /// producer, the old output `prev` the consumer-expectation).
+    #[must_use = "check the Result — an Err means the new output is not a compatible successor"]
+    pub fn is_compatible_successor_of(&self, prev: &OutputSchema) -> Result<(), SchemaIncompat> {
+        is_assignable_core(self.as_schema(), prev.as_schema())
     }
 }
 
@@ -278,21 +331,22 @@ impl core::fmt::Display for UnknownReason {
     }
 }
 
-/// Full three-valued assignability: collects **all** incompatibilities and all
-/// "not decidable" reasons rather than stopping at the first.
+/// Polarity-erased ternary assignability core: collects **all** incompatibilities
+/// and all "not decidable" reasons rather than stopping at the first. Shared by
+/// the public, direction-typed [`explain_assignable`] and the binary
+/// [`is_assignable_core`] (and, through it, the directional
+/// [`is_assignable_schema`] and [`OutputSchema::is_compatible_successor_of`]).
 ///
-/// Honors the [`SchemaKind`] Top/Bottom split like [`is_assignable_schema`]: an
-/// `Any` consumer accepts anything ([`Yes`](Assignability::Yes)); an `Any`
-/// producer is [`Unknown(OpaqueProducer)`](UnknownReason::OpaqueProducer); two
-/// concrete records run strict width-subtyping. The verdict precedence is
-/// `No` (any provable incompatibility) ▸ `Unknown` (any undecidable field) ▸
-/// `Yes`.
-///
-/// The leniencies that [`is_assignable_schema`] silently passes are surfaced
-/// here as [`Unknown`](Assignability::Unknown) instead of being hidden in `Ok`,
-/// so a strict workflow validator can block them. See [`UnknownReason`].
+/// Honors the [`SchemaKind`] Top/Bottom split: an `Any` (or empty-record)
+/// consumer accepts anything ([`Yes`](Assignability::Yes)); an `Any` producer is
+/// [`Unknown(OpaqueProducer)`](UnknownReason::OpaqueProducer); two concrete
+/// records run strict width-subtyping. Verdict precedence: `No` (any provable
+/// incompatibility) ▸ `Unknown` (any undecidable field) ▸ `Yes`.
 #[must_use]
-pub fn explain_assignable(producer: &ValidSchema, consumer: &ValidSchema) -> Assignability {
+pub(crate) fn explain_assignable_core(
+    producer: &ValidSchema,
+    consumer: &ValidSchema,
+) -> Assignability {
     // An `Any` consumer accepts anything — provably compatible.
     if consumer.kind() == SchemaKind::Any {
         return Assignability::Yes;
@@ -547,6 +601,27 @@ mod tests {
         let mut acc = Explain::default();
         collect_fields(producer, consumer, strict, &mut acc);
         acc.into_verdict()
+    }
+
+    // Thin `ValidSchema`-taking wrappers that tag polarity, so the kind-aware
+    // tests below exercise the real direction-typed entry points without
+    // restating `OutputSchema::new`/`InputSchema::new` at every call site. They
+    // shadow the crate functions of the same name within this test module.
+    fn is_assignable_schema(
+        producer: &ValidSchema,
+        consumer: &ValidSchema,
+    ) -> Result<(), SchemaIncompat> {
+        super::is_assignable_schema(
+            &OutputSchema::new(producer.clone()),
+            &InputSchema::new(consumer.clone()),
+        )
+    }
+
+    fn explain_assignable(producer: &ValidSchema, consumer: &ValidSchema) -> Assignability {
+        super::explain_assignable(
+            &OutputSchema::new(producer.clone()),
+            &InputSchema::new(consumer.clone()),
+        )
     }
 
     // ── Compatible: producer has all required consumer fields + extra ──────
@@ -1248,6 +1323,35 @@ mod tests {
             }
             .to_string(),
             "in field `cfg`: field `m` is a `Mode` sum type (variance not modeled)"
+        );
+    }
+
+    // ── Directional types: `OutputSchema::is_compatible_successor_of` ─────────
+
+    /// Output-vs-output evolution: a new output that keeps every field old
+    /// consumers required (and adds more) is a compatible successor; one that
+    /// drops a required field is not. The new output is the producer, the old
+    /// output the consumer-expectation.
+    #[test]
+    fn output_schema_compatible_successor() {
+        let prev = OutputSchema::new(required_record("result"));
+        let wider = OutputSchema::new(
+            crate::Schema::builder()
+                .add(Field::string(fk("result")).required())
+                .add(Field::string(fk("extra")).required())
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            wider.is_compatible_successor_of(&prev).is_ok(),
+            "adding fields keeps old consumers satisfied"
+        );
+
+        let narrower = OutputSchema::new(required_record("other"));
+        assert_eq!(
+            narrower.is_compatible_successor_of(&prev),
+            Err(SchemaIncompat::MissingRequiredField { key: fk("result") }),
+            "dropping a field old consumers required is a breaking successor"
         );
     }
 }

--- a/crates/schema/src/directed.rs
+++ b/crates/schema/src/directed.rs
@@ -1,0 +1,167 @@
+//! Directional schema newtypes (ADR-0100 C15).
+//!
+//! A [`ValidSchema`] tagged with its dataflow **polarity** — [`Input`] (what a
+//! node consumes) or [`Output`] (what a node produces). The assignability
+//! relation takes `(&OutputSchema, &InputSchema)`, so swapping producer and
+//! consumer is a *compile* error rather than a silent logic bug: direction is
+//! enforced by the type system, not by discipline.
+//!
+//! The polarity lives on the **schema** (the port), not on every [`Field`] — a
+//! field is the same shape whether read or written; only the schema as a whole
+//! has a dataflow direction. The newtype is `#[repr(transparent)]` and serde-
+//! transparent, so it is zero-cost and does not change the wire format.
+//!
+//! [`Field`]: crate::Field
+
+use core::marker::PhantomData;
+
+use crate::ValidSchema;
+
+mod sealed {
+    /// Seals [`Polarity`](super::Polarity) so only this crate's [`Input`] and
+    /// [`Output`] can implement it.
+    pub trait Sealed {}
+}
+
+/// The dataflow direction of a schema. **Sealed**: only [`Input`] and
+/// [`Output`] implement it, so the set of polarities is closed.
+pub trait Polarity: sealed::Sealed + 'static {
+    /// Lowercase label (`"input"` / `"output"`) for diagnostics.
+    const LABEL: &'static str;
+}
+
+/// The **consumer** polarity: a node's `Input` schema — the shape it expects to
+/// receive. Uninhabited; used only as a compile-time marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Input {}
+
+/// The **producer** polarity: a node's `Output` schema — the shape it emits.
+/// Uninhabited; used only as a compile-time marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Output {}
+
+impl sealed::Sealed for Input {}
+impl Polarity for Input {
+    const LABEL: &'static str = "input";
+}
+
+impl sealed::Sealed for Output {}
+impl Polarity for Output {
+    const LABEL: &'static str = "output";
+}
+
+/// A [`ValidSchema`] tagged with its dataflow [`Polarity`] `P`.
+///
+/// `#[repr(transparent)]` over the schema — the polarity is a zero-sized
+/// compile-time marker. Prefer the [`InputSchema`] / [`OutputSchema`] aliases.
+#[repr(transparent)]
+#[derive(Debug, Clone)]
+pub struct DirectedSchema<P: Polarity> {
+    schema: ValidSchema,
+    _polarity: PhantomData<fn() -> P>,
+}
+
+/// A node's **input** (consumer) schema — what it expects to receive.
+pub type InputSchema = DirectedSchema<Input>;
+
+/// A node's **output** (producer) schema — what it emits.
+pub type OutputSchema = DirectedSchema<Output>;
+
+impl<P: Polarity> DirectedSchema<P> {
+    /// Tag a [`ValidSchema`] with polarity `P`.
+    #[must_use]
+    pub fn new(schema: ValidSchema) -> Self {
+        Self {
+            schema,
+            _polarity: PhantomData,
+        }
+    }
+
+    /// Borrow the underlying schema (drops the polarity tag).
+    #[must_use]
+    pub fn as_schema(&self) -> &ValidSchema {
+        &self.schema
+    }
+
+    /// Unwrap into the underlying [`ValidSchema`].
+    #[must_use]
+    pub fn into_schema(self) -> ValidSchema {
+        self.schema
+    }
+
+    /// The polarity label (`"input"` / `"output"`), for diagnostics.
+    #[must_use]
+    pub fn polarity(&self) -> &'static str {
+        P::LABEL
+    }
+}
+
+impl<P: Polarity> From<ValidSchema> for DirectedSchema<P> {
+    fn from(schema: ValidSchema) -> Self {
+        Self::new(schema)
+    }
+}
+
+// Two `DirectedSchema`s of the same polarity compare by their underlying schema
+// (the polarity is a phantom). Cross-polarity comparison does not type-check.
+impl<P: Polarity> PartialEq for DirectedSchema<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema == other.schema
+    }
+}
+
+// Serde-transparent: a `DirectedSchema` serializes exactly as its `ValidSchema`,
+// so the polarity is compile-time only and the wire format is unchanged.
+impl<P: Polarity> serde::Serialize for DirectedSchema<P> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.schema.serialize(serializer)
+    }
+}
+
+impl<'de, P: Polarity> serde::Deserialize<'de> for DirectedSchema<P> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        ValidSchema::deserialize(deserializer).map(Self::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_input() -> InputSchema {
+        InputSchema::new(ValidSchema::empty())
+    }
+
+    #[test]
+    fn wraps_and_unwraps_without_changing_schema() {
+        let schema = ValidSchema::empty();
+        let directed = OutputSchema::new(schema.clone());
+        assert_eq!(directed.as_schema(), &schema);
+        assert_eq!(directed.into_schema(), schema);
+    }
+
+    #[test]
+    fn polarity_label_reflects_type() {
+        assert_eq!(empty_input().polarity(), "input");
+        assert_eq!(OutputSchema::new(ValidSchema::empty()).polarity(), "output");
+    }
+
+    #[test]
+    fn serde_is_transparent_over_valid_schema() {
+        let directed = OutputSchema::new(ValidSchema::any());
+        let directed_json = serde_json::to_string(&directed).unwrap();
+        let bare_json = serde_json::to_string(&ValidSchema::any()).unwrap();
+        assert_eq!(
+            directed_json, bare_json,
+            "the polarity tag must not appear on the wire"
+        );
+        let decoded: OutputSchema = serde_json::from_str(&directed_json).unwrap();
+        assert_eq!(decoded, directed);
+    }
+
+    #[test]
+    fn from_valid_schema_tags_polarity() {
+        let _input: InputSchema = ValidSchema::empty().into();
+        let _output: OutputSchema = ValidSchema::empty().into();
+    }
+}

--- a/crates/schema/src/directed.rs
+++ b/crates/schema/src/directed.rs
@@ -23,8 +23,12 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// The dataflow direction of a schema. **Sealed**: only [`Input`] and
-/// [`Output`] implement it, so the set of polarities is closed.
+/// The dataflow direction of a schema.
+///
+/// This trait is **sealed** and cannot be implemented outside `nebula-schema`:
+/// only [`Input`] and [`Output`] implement it, so the set of polarities is
+/// closed. Callers use the [`InputSchema`] / [`OutputSchema`] aliases and never
+/// name this bound directly.
 pub trait Polarity: sealed::Sealed + 'static {
     /// Lowercase label (`"input"` / `"output"`) for diagnostics.
     const LABEL: &'static str;
@@ -69,6 +73,12 @@ pub type OutputSchema = DirectedSchema<Output>;
 
 impl<P: Polarity> DirectedSchema<P> {
     /// Tag a [`ValidSchema`] with polarity `P`.
+    ///
+    /// Infallible. The direction-aware **input-position** lint (rejecting
+    /// `Computed` / unresolved `Dynamic` fields in an [`InputSchema`]) is
+    /// deferred; when it lands it will arrive as an additive fallible
+    /// `TryFrom<ValidSchema>` constructor, leaving this one for schemas already
+    /// known to satisfy the position rules.
     #[must_use]
     pub fn new(schema: ValidSchema) -> Self {
         Self {
@@ -77,13 +87,21 @@ impl<P: Polarity> DirectedSchema<P> {
         }
     }
 
-    /// Borrow the underlying schema (drops the polarity tag).
+    /// Borrow the underlying schema, **discarding the polarity tag**.
+    ///
+    /// For storage / serde / interop. Do **not** feed the result back into an
+    /// assignability check as a `producer`/`consumer` — that round-trips through
+    /// untyped `ValidSchema` and defeats the direction guarantee. Use
+    /// [`is_assignable_schema`](crate::is_assignable_schema) /
+    /// [`explain_assignable`](crate::explain_assignable), which take the typed
+    /// newtypes directly.
     #[must_use]
     pub fn as_schema(&self) -> &ValidSchema {
         &self.schema
     }
 
-    /// Unwrap into the underlying [`ValidSchema`].
+    /// Unwrap into the underlying [`ValidSchema`], **discarding the polarity
+    /// tag** (see the caveat on [`as_schema`](Self::as_schema)).
     #[must_use]
     pub fn into_schema(self) -> ValidSchema {
         self.schema
@@ -107,6 +125,37 @@ impl<P: Polarity> From<ValidSchema> for DirectedSchema<P> {
 impl<P: Polarity> PartialEq for DirectedSchema<P> {
     fn eq(&self, other: &Self) -> bool {
         self.schema == other.schema
+    }
+}
+
+// The polarity phantom is irrelevant to equality and the inner `ValidSchema` is
+// `Eq`, so equality is a total equivalence — `InputSchema`/`OutputSchema` are
+// usable as map keys / in `HashSet`s.
+impl<P: Polarity> Eq for DirectedSchema<P> {}
+
+impl OutputSchema {
+    /// Is `self` a backward-compatible **successor** of `prev` — does the new
+    /// output still satisfy everything consumers typed against the *old* output
+    /// required? An *output-vs-output* width-supertype check, distinct from the
+    /// producer→consumer edge relation, so it does **not** route through the
+    /// [`InputSchema`]-typed [`is_assignable_schema`](crate::is_assignable_schema).
+    ///
+    /// The action catalog's same-major compatibility gate uses this: an `Err`
+    /// means the new output dropped or narrowed a field old consumers relied on.
+    /// An `Any` old output imposes no constraints (always `Ok`); an empty-record
+    /// new output provably satisfies nothing a typed old output required.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SchemaIncompat`](crate::SchemaIncompat) (the new
+    /// output `self` is the producer, the old output `prev` the
+    /// consumer-expectation).
+    #[must_use = "check the Result — an Err means the new output is not a compatible successor"]
+    pub fn is_compatible_successor_of(
+        &self,
+        prev: &OutputSchema,
+    ) -> Result<(), crate::SchemaIncompat> {
+        crate::compat::is_assignable_core(self.as_schema(), prev.as_schema())
     }
 }
 

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -127,6 +127,8 @@ pub mod builder;
 pub mod compat;
 /// Builds the validator predicate context (visibility/required) from schema fields + values.
 pub mod context;
+/// Directional schema newtypes (`InputSchema`/`OutputSchema`) — polarity-typed.
+pub mod directed;
 /// Error types for schema operations.
 pub mod error;
 /// Expression wrapper and [`ExpressionContext`] trait.
@@ -178,6 +180,7 @@ pub use builder::{
 pub use compat::{
     Assignability, SchemaIncompat, UnknownReason, explain_assignable, is_assignable_schema,
 };
+pub use directed::{DirectedSchema, Input, InputSchema, Output, OutputSchema, Polarity};
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };

--- a/crates/schema/tests/compile_fail/directional_assignable_swap.rs
+++ b/crates/schema/tests/compile_fail/directional_assignable_swap.rs
@@ -1,0 +1,14 @@
+//! Swapping producer and consumer in `is_assignable_schema` must not compile:
+//! the first argument is the producer's `OutputSchema`, the second the
+//! consumer's `InputSchema` (ADR-0100 C15 — direction enforced by the types).
+
+use nebula_schema::{InputSchema, OutputSchema, ValidSchema, is_assignable_schema};
+
+fn main() {
+    let input = InputSchema::new(ValidSchema::empty());
+    let output = OutputSchema::new(ValidSchema::empty());
+
+    // Correct direction would be `is_assignable_schema(&output, &input)`.
+    // Transposing them is a type error, not a silent logic bug.
+    let _ = is_assignable_schema(&input, &output);
+}

--- a/crates/schema/tests/compile_fail/directional_assignable_swap.stderr
+++ b/crates/schema/tests/compile_fail/directional_assignable_swap.stderr
@@ -1,0 +1,18 @@
+error[E0308]: arguments to this function are incorrect
+  --> tests/compile_fail/directional_assignable_swap.rs:13:13
+   |
+13 |     let _ = is_assignable_schema(&input, &output);
+   |             ^^^^^^^^^^^^^^^^^^^^ ------  ------- expected `&DirectedSchema<Input>`, found `&DirectedSchema<nebula_schema::Output>`
+   |                                  |
+   |                                  expected `&DirectedSchema<nebula_schema::Output>`, found `&DirectedSchema<Input>`
+   |
+note: function defined here
+  --> src/compat.rs
+   |
+   | pub fn is_assignable_schema(
+   |        ^^^^^^^^^^^^^^^^^^^^
+help: swap these arguments
+   |
+13 -     let _ = is_assignable_schema(&input, &output);
+13 +     let _ = is_assignable_schema(&output, &input);
+   |

--- a/crates/schema/tests/compile_fail/directional_eq_cross_polarity.rs
+++ b/crates/schema/tests/compile_fail/directional_eq_cross_polarity.rs
@@ -1,0 +1,13 @@
+//! Comparing an `InputSchema` to an `OutputSchema` must not compile: polarity is
+//! part of the type, so `PartialEq` only relates same-polarity schemas. An
+//! input port and an output port are never "equal" by construction (ADR-0100 C15).
+
+use nebula_schema::{InputSchema, OutputSchema, ValidSchema};
+
+fn main() {
+    let input = InputSchema::new(ValidSchema::empty());
+    let output = OutputSchema::new(ValidSchema::empty());
+
+    // Cross-polarity equality is a type error, not a runtime `false`.
+    let _ = input == output;
+}

--- a/crates/schema/tests/compile_fail/directional_eq_cross_polarity.stderr
+++ b/crates/schema/tests/compile_fail/directional_eq_cross_polarity.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+  --> tests/compile_fail/directional_eq_cross_polarity.rs:12:22
+   |
+12 |     let _ = input == output;
+   |                      ^^^^^^ expected `DirectedSchema<Input>`, found `DirectedSchema<Output>`
+   |
+   = note: expected struct `DirectedSchema<Input>`
+              found struct `DirectedSchema<nebula_schema::Output>`

--- a/crates/workflow/src/resolver.rs
+++ b/crates/workflow/src/resolver.rs
@@ -7,21 +7,23 @@
 //! `DefinitionRoutingResolver` precedent from ADR-0095 D1.
 
 use nebula_core::ActionKey;
-use nebula_schema::ValidSchema;
+use nebula_schema::{InputSchema, OutputSchema};
 use semver::Version;
 
 /// Input and output schemas for one workflow node, resolved from the action catalog.
 ///
-/// Both schemas are [`ValidSchema`] (cheap `Arc`-backed clones). An empty
-/// schema on either side acts as the `Any` escape hatch (ADR-0100 L2): a
-/// node that has not declared a typed schema is treated as untyped and
-/// compatible with any neighbour.
+/// Direction-typed (ADR-0100 C15): the input is an [`InputSchema`] (consumer)
+/// and the output an [`OutputSchema`] (producer), both cheap `Arc`-backed
+/// newtypes over `ValidSchema`, so the per-edge check
+/// `is_assignable_schema(&producer.output, &consumer.input)` cannot transpose
+/// the two. An empty/`Any` schema on either side still acts as the gradual
+/// escape (ADR-0100 L2): an untyped node is compatible with any neighbour.
 #[derive(Debug, Clone)]
 pub struct NodeIoSchemas {
     /// The schema describing this node's input (what it consumes).
-    pub input: ValidSchema,
+    pub input: InputSchema,
     /// The schema describing this node's output (what it produces).
-    pub output: ValidSchema,
+    pub output: OutputSchema,
 }
 
 /// Resolver that maps a workflow node's action identity to its I/O schemas.
@@ -62,7 +64,7 @@ pub trait NodeSchemaResolver: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use nebula_schema::{Field, FieldKey, Schema};
+    use nebula_schema::{Field, FieldKey, Schema, ValidSchema};
 
     use super::*;
 
@@ -78,8 +80,8 @@ mod tests {
     }
 
     struct StubResolver {
-        input: ValidSchema,
-        output: ValidSchema,
+        input: InputSchema,
+        output: OutputSchema,
     }
 
     impl NodeSchemaResolver for StubResolver {
@@ -100,12 +102,12 @@ mod tests {
         let input = schema_with_field("x", true);
         let output = schema_with_field("y", false);
         let schemas = NodeIoSchemas {
-            input: input.clone(),
-            output: output.clone(),
+            input: InputSchema::new(input.clone()),
+            output: OutputSchema::new(output.clone()),
         };
-        // Verify the Arc-backed cheap-clone invariant holds.
-        assert!(schemas.input.ptr_eq(&input));
-        assert!(schemas.output.ptr_eq(&output));
+        // Verify the Arc-backed cheap-clone invariant holds (through the newtype).
+        assert!(schemas.input.as_schema().ptr_eq(&input));
+        assert!(schemas.output.as_schema().ptr_eq(&output));
     }
 
     #[test]
@@ -114,11 +116,11 @@ mod tests {
         let input = schema_with_field("in_field", true);
         let output = schema_with_field("out_field", false);
         let resolver = StubResolver {
-            input: input.clone(),
-            output: output.clone(),
+            input: InputSchema::new(input.clone()),
+            output: OutputSchema::new(output.clone()),
         };
         let result = resolver.io_schemas(&action_key, None).unwrap();
-        assert!(result.input.ptr_eq(&input));
-        assert!(result.output.ptr_eq(&output));
+        assert!(result.input.as_schema().ptr_eq(&input));
+        assert!(result.output.as_schema().ptr_eq(&output));
     }
 }

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -1015,15 +1015,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: producer_output,
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1055,15 +1055,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: producer_output,
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1106,15 +1106,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: producer_output,
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1153,15 +1153,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: producer_output,
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1192,8 +1192,8 @@ mod tests {
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1247,15 +1247,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: producer_output,
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1299,15 +1299,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output,
+                input: ValidSchema::empty().into(),
+                output: output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input,
-                output: ValidSchema::empty(),
+                input: input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1332,15 +1332,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output,
+                input: ValidSchema::empty().into(),
+                output: output.into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input,
-                output: ValidSchema::empty(),
+                input: input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
 
@@ -1373,15 +1373,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: dynamic_field_schema("data"),
+                input: ValidSchema::empty().into(),
+                output: dynamic_field_schema("data").into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: single_field_schema("data", true),
-                output: ValidSchema::empty(),
+                input: single_field_schema("data", true).into(),
+                output: ValidSchema::empty().into(),
             },
         );
         schemas
@@ -1465,15 +1465,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: ValidSchema::empty(), // empty record — supplies neither `a` nor `b`
+                input: ValidSchema::empty().into(),
+                output: ValidSchema::empty().into(), // empty record — supplies neither `a` nor `b`
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: consumer_input,
-                output: ValidSchema::empty(),
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
             },
         );
         let resolver = MapResolver(schemas);
@@ -1509,15 +1509,15 @@ mod tests {
         schemas.insert(
             "producer.action".to_owned(),
             NodeIoSchemas {
-                input: ValidSchema::empty(),
-                output: single_field_schema("a", true),
+                input: ValidSchema::empty().into(),
+                output: single_field_schema("a", true).into(),
             },
         );
         schemas.insert(
             "consumer.action".to_owned(),
             NodeIoSchemas {
-                input: single_field_schema("b", true), // requires `b`, absent
-                output: ValidSchema::empty(),
+                input: single_field_schema("b", true).into(), // requires `b`, absent
+                output: ValidSchema::empty().into(),
             },
         );
         let resolver = MapResolver(schemas);

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -219,9 +219,11 @@ pub fn validate_workflow_with_resolver(
 ///
 /// Runs every structural check that [`validate_workflow`] performs, then for
 /// each [`Connection`](crate::Connection) whose **both** endpoints can be
-/// resolved by `resolver`, computes
-/// `nebula_schema::explain_assignable(producer.output, consumer.input)` and
-/// reports per `mode`: a [`No`](nebula_schema::Assignability::No) verdict is
+/// resolved by `resolver`, computes `nebula_schema::explain_assignable` over the
+/// polarity-typed `producer.output` ([`OutputSchema`](nebula_schema::OutputSchema))
+/// and `consumer.input` ([`InputSchema`](nebula_schema::InputSchema)) — the
+/// newtypes make transposing the two a compile error — and reports per `mode`:
+/// a [`No`](nebula_schema::Assignability::No) verdict is
 /// always a [`WorkflowError::PortSchemaIncompatible`]; an
 /// [`Unknown`](nebula_schema::Assignability::Unknown) verdict is a
 /// [`WorkflowError::PortSchemaUndecidable`] only in [`SchemaCheckMode::Strict`].


### PR DESCRIPTION
## What

Step 4 of the nebula-schema fix-plan (C15/C6). Makes dataflow **direction** a type-level property, so the assignability relation cannot transpose producer and consumer.

## schema — directional newtypes

- `directed.rs`: sealed `Polarity` (`Input`/`Output`) + `DirectedSchema<P>` `#[repr(transparent)]` over `ValidSchema`, with `InputSchema`/`OutputSchema` aliases. Serde-transparent (**wire format unchanged**), `Eq`, `From<ValidSchema>`.
- `is_assignable_schema` / `explain_assignable` now take `(&OutputSchema, &InputSchema)` — **swapping is a compile error** (trybuild guard `directional_assignable_swap`; the compiler even suggests "swap these arguments"). They delegate to a polarity-erased `*_core` shared with the evolution check, so the verdict logic is byte-identical to before.
- `OutputSchema::is_compatible_successor_of` — the *output-vs-output* evolution check (new output must still satisfy old consumers), a distinct relation from the producer→consumer edge, so it does **not** use the `InputSchema`-typed edge signature.

## per-port (C6)

- `NodeIoSchemas { input: InputSchema, output: OutputSchema }` — polarity lives on the port schema, not on every `Field`. The workflow per-edge validator now type-checks `(&producer.output, &consumer.input)` by construction; `nebula-api`'s catalog resolver tags the schemas at the boundary; the action output-evolution gate uses `is_compatible_successor_of` (via `ActionMetadata::typed_output_schema()`).
- `base.schema` / `ActionMetadata.output_schema` stay `ValidSchema` (shared catalog types), tagged with polarity at the `NodeIoSchemas` boundary.

## Deferred (noted, not stubbed)

The `HasInputSchema`/`HasOutputSchema` trait split and the direction-aware **input-position lint** (reject `Computed`/unresolved `Dynamic` in input) are follow-ups on this typing foundation. The lint will arrive as an additive `TryFrom<ValidSchema>` (documented on `DirectedSchema::new`).

## Review

A 4-lens adversarial review ran on the diff; the **regression lens came back clean** (migration complete, behavior-preserving). Findings addressed in commit 2: `Eq` impl, sealed-trait notice, `as_schema` direction caveat, the successor relation's gradual-boundary tests (`Any`/empty), `typed_output_schema()` accessor, cross-polarity-`==` compile-fail guard, and a CHANGELOG breaking-change entry.

## Verification

`cargo nextest run --workspace` — **5641 passed, 1 skipped, 0 failed**. `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings`, doc-tests, and both directional compile-fail guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Schema assignability API now requires direction-typed parameters: producer output schemas must be passed before consumer input schemas. Swapped arguments will fail at compile time rather than runtime.

* **New Features**
  * Introduced compile-time type safety for schema operations via direction-aware schema types.

* **Tests**
  * Added compile-fail tests ensuring schemas are passed in the correct producer-to-consumer direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->