### PR TITLE
feat(schema): injective canonical_bytes + ContentId (blake3) for values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1064,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1500,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -3886,6 +3918,7 @@ dependencies = [
 name = "nebula-schema"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "codspeed-criterion-compat",
  "hex",
  "indexmap",
@@ -6684,7 +6717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
 dependencies = [
  "base32",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "hmac 0.12.1",
  "sha1 0.10.6",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ lasso = { version = "0.7", features = ["multi-threaded"] }
 
 # Crypto
 aes-gcm = "0.10"
+blake3 = "1.5"
 sha2 = "0.11"
 hmac = "0.13"
 hex = "0.4"

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 indexmap = { workspace = true }
+blake3 = { workspace = true }
 smallvec = { workspace = true }
 regex = { workspace = true }
 schemars = { version = "1.0", optional = true }
@@ -65,6 +66,10 @@ path = "tests/proptest/path_roundtrip.rs"
 [[test]]
 name = "proptest_serde_preserves"
 path = "tests/proptest/serde_preserves.rs"
+
+[[test]]
+name = "proptest_canonical_bytes"
+path = "tests/proptest/canonical_bytes.rs"
 
 [[test]]
 name = "json_schema_smoke"

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -242,7 +242,7 @@ pub use transformer::Transformer;
 pub use validated::{
     FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, SchemaKind, ValidSchema, ValidValues,
 };
-pub use value::{EXPRESSION_KEY, FieldValue, FieldValues};
+pub use value::{ContentId, EXPRESSION_KEY, FieldValue, FieldValues, VALUE_CANON_VERSION};
 pub use widget::{
     BooleanWidget, CodeWidget, ListWidget, NumberWidget, ObjectWidget, SecretWidget, SelectWidget,
     StringWidget,

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -1,7 +1,7 @@
 //! Validated schema handles — proof-tokens.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     future::Future,
     pin::Pin,
     sync::{Arc, LazyLock},
@@ -1606,12 +1606,14 @@ fn validate_literal_value(
                 let duplicate_index = items_typed.map_or_else(
                     || {
                         if let FieldValue::Literal(serde_json::Value::Array(arr)) = value {
-                            first_duplicate_index(arr.iter().cloned())
+                            first_duplicate_index(
+                                arr.iter().map(|item| FieldValue::Literal(item.clone())),
+                            )
                         } else {
                             None
                         }
                     },
-                    |items_fv| first_duplicate_index(items_fv.iter().map(FieldValue::to_json)),
+                    |items_fv| first_duplicate_index(items_fv.iter().cloned()),
                 );
                 if let Some(idx) = duplicate_index {
                     report.push(
@@ -1845,22 +1847,25 @@ fn validate_literal_value(
     }
 }
 
-fn first_duplicate_index(values: impl IntoIterator<Item = serde_json::Value>) -> Option<usize> {
-    let mut seen: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+fn first_duplicate_index(values: impl IntoIterator<Item = FieldValue>) -> Option<usize> {
+    // Bucket by injective `canonical_bytes`, so `1` and `1.0` (and key-permuted
+    // objects) count as equal — fixing the `"1"`-vs-`"1.0"` false negative the
+    // old `serde_json::to_string` bucketing missed.
+    let mut seen_canon: HashSet<Vec<u8>> = HashSet::new();
+    // Secret-bearing items have no canonical form; fall back to structural
+    // `PartialEq` (constant-time inside `SecretValue`) so a unique list that
+    // contains secrets is still validated rather than erroring.
+    let mut seen_opaque: Vec<FieldValue> = Vec::new();
     for (idx, value) in values.into_iter().enumerate() {
-        // serde_json::Value does not implement Hash. Bucket by canonical
-        // string form (`serde_json::to_string` is infallible for `Value`
-        // because all map keys are strings), then confirm equality within
-        // the bucket to preserve exact semantics.
-        let key = serde_json::to_string(&value)
-            .expect("serde_json::Value::to_string is infallible for valid JSON");
-        if let Some(bucket) = seen.get_mut(&key) {
-            if bucket.iter().any(|prior| prior == &value) {
+        if let Ok(canon) = value.canonical_bytes() {
+            if !seen_canon.insert(canon) {
                 return Some(idx);
             }
-            bucket.push(value);
+        } else if seen_opaque.contains(&value) {
+            // No canonical form (e.g. a secret) — fall back to structural PartialEq.
+            return Some(idx);
         } else {
-            seen.insert(key, vec![value]);
+            seen_opaque.push(value);
         }
     }
     None

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -271,7 +271,7 @@ impl FieldValue {
         let mut out = Vec::new();
         out.extend_from_slice(CANON_DOMAIN);
         out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
-        self.write_canonical(&mut out)?;
+        self.write_canonical(&mut out, 0)?;
         Ok(out)
     }
 
@@ -294,26 +294,40 @@ impl FieldValue {
     }
 
     /// Recursive canonical writer for a [`FieldValue`].
+    ///
+    /// `depth` bounds the recursion at [`MAX_VALUE_DEPTH`] (shared with
+    /// `write_canon_json` so the FieldValue + raw-JSON nesting is counted
+    /// together): `FieldValue::from_json` preserves over-deep subtrees as a
+    /// `Literal` instead of rejecting them, so an adversarial deeply-nested value
+    /// can reach here — bounding the descent turns a stack overflow into a typed
+    /// `recursion_limit` error.
     #[expect(
         clippy::result_large_err,
         reason = "ValidationError is intentionally large; callers are on the validation path"
     )]
-    fn write_canonical(&self, out: &mut Vec<u8>) -> Result<(), crate::error::ValidationError> {
+    fn write_canonical(
+        &self,
+        out: &mut Vec<u8>,
+        depth: u8,
+    ) -> Result<(), crate::error::ValidationError> {
+        if depth > MAX_VALUE_DEPTH {
+            return Err(canon_recursion_limit());
+        }
         match self {
             // A `Literal` carries a raw JSON value (including `Array`/`Object`
             // when keys were not valid `FieldKey`s — `from_json` preserves them),
             // canonicalized by the JSON writer below.
-            Self::Literal(value) => write_canon_json(value, out)?,
+            Self::Literal(value) => write_canon_json(value, out, depth)?,
             Self::Expression(expr) => {
                 out.push(TAG_EXPRESSION);
                 write_lp(out, expr.source().as_bytes());
             },
-            Self::Object(map) => write_canon_object(map, out)?,
+            Self::Object(map) => write_canon_object(map, out, depth)?,
             Self::List(items) => {
                 out.push(TAG_LIST);
                 write_varint(out, items.len() as u64);
                 for item in items {
-                    item.write_canonical(out)?;
+                    item.write_canonical(out, depth.saturating_add(1))?;
                 }
             },
             Self::Mode { mode, value } => {
@@ -322,7 +336,7 @@ impl FieldValue {
                 match value {
                     Some(inner) => {
                         out.push(1);
-                        inner.write_canonical(out)?;
+                        inner.write_canonical(out, depth.saturating_add(1))?;
                     },
                     None => out.push(0),
                 }
@@ -405,6 +419,15 @@ fn non_canonical_float() -> crate::error::ValidationError {
         .build()
 }
 
+/// `recursion_limit` — value nesting exceeds [`MAX_VALUE_DEPTH`] during
+/// canonicalization (an over-deep value that `from_json` preserved as a
+/// `Literal` is rejected here rather than overflowing the stack).
+fn canon_recursion_limit() -> crate::error::ValidationError {
+    crate::error::ValidationError::builder("recursion_limit")
+        .message("value nesting exceeds the maximum canonicalization depth")
+        .build()
+}
+
 /// Append a length-prefixed byte string (varint length + bytes) — prevents
 /// `"a" + "b"` from aliasing `"ab"`.
 fn write_lp(out: &mut Vec<u8>, bytes: &[u8]) {
@@ -437,6 +460,7 @@ fn write_varint(out: &mut Vec<u8>, mut value: u64) {
 fn write_canon_object(
     map: &IndexMap<FieldKey, FieldValue>,
     out: &mut Vec<u8>,
+    depth: u8,
 ) -> Result<(), crate::error::ValidationError> {
     out.push(TAG_OBJECT);
     let mut entries: Vec<(&FieldKey, &FieldValue)> = map.iter().collect();
@@ -444,17 +468,25 @@ fn write_canon_object(
     write_varint(out, entries.len() as u64);
     for (key, value) in entries {
         write_lp(out, key.as_str().as_bytes());
-        value.write_canonical(out)?;
+        value.write_canonical(out, depth.saturating_add(1))?;
     }
     Ok(())
 }
 
 /// Canonicalize a raw `serde_json::Value` (used for `FieldValue::Literal`).
+/// `depth` continues the shared recursion bound (see `write_canonical`).
 #[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
-fn write_canon_json(value: &Value, out: &mut Vec<u8>) -> Result<(), crate::error::ValidationError> {
+fn write_canon_json(
+    value: &Value,
+    out: &mut Vec<u8>,
+    depth: u8,
+) -> Result<(), crate::error::ValidationError> {
+    if depth > MAX_VALUE_DEPTH {
+        return Err(canon_recursion_limit());
+    }
     match value {
         Value::Null => out.push(TAG_NULL),
         Value::Bool(b) => {
@@ -470,7 +502,7 @@ fn write_canon_json(value: &Value, out: &mut Vec<u8>) -> Result<(), crate::error
             out.push(TAG_JSON_ARRAY);
             write_varint(out, items.len() as u64);
             for item in items {
-                write_canon_json(item, out)?;
+                write_canon_json(item, out, depth.saturating_add(1))?;
             }
         },
         Value::Object(map) => {
@@ -480,7 +512,7 @@ fn write_canon_json(value: &Value, out: &mut Vec<u8>) -> Result<(), crate::error
             write_varint(out, entries.len() as u64);
             for (key, child) in entries {
                 write_lp(out, key.as_bytes());
-                write_canon_json(child, out)?;
+                write_canon_json(child, out, depth.saturating_add(1))?;
             }
         },
     }
@@ -857,7 +889,7 @@ impl FieldValues {
         let mut out = Vec::new();
         out.extend_from_slice(CANON_DOMAIN);
         out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
-        write_canon_object(&self.0, &mut out)?;
+        write_canon_object(&self.0, &mut out, 0)?;
         Ok(out)
     }
 
@@ -1498,6 +1530,24 @@ mod tests {
             &bytes[16..18],
             &VALUE_CANON_VERSION.to_be_bytes(),
             "the version prefix is pinned"
+        );
+    }
+
+    /// An over-deep value (which `from_json` preserves as a `Literal` rather than
+    /// rejecting) must error with `recursion_limit`, not overflow the stack.
+    #[test]
+    fn canon_rejects_over_deep_value() {
+        let mut deep = Value::Null;
+        for _ in 0..(MAX_VALUE_DEPTH as usize + 5) {
+            deep = Value::Array(vec![deep]);
+        }
+        let value = FieldValue::Literal(deep);
+        assert_eq!(
+            value
+                .canonical_bytes()
+                .expect_err("over-deep value must error, not overflow")
+                .code,
+            "recursion_limit"
         );
     }
 }

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -182,7 +182,11 @@ impl FieldValue {
         }
     }
 
-    /// Encode into canonical JSON wire format.
+    /// Encode into the JSON **wire** format (round-trips through serde).
+    ///
+    /// This is *not* a canonical / injective encoding — object key order is the
+    /// insertion order and numbers keep their JSON spelling. For a stable
+    /// content hash / dedup key use [`Self::canonical_bytes`].
     pub fn to_json(&self) -> Value {
         match self {
             Self::Literal(v) => v.clone(),
@@ -232,6 +236,280 @@ impl FieldValue {
     pub const fn is_expression(&self) -> bool {
         matches!(self, Self::Expression(_))
     }
+
+    /// Injective canonical byte encoding of this value (content-addressing /
+    /// dedup / idempotency key — **not** a wire format; see [`Self::to_json`]).
+    ///
+    /// Two values produce identical bytes **iff** they are canonically equal,
+    /// independent of insertion order: object keys are emitted sorted, every
+    /// variant carries a leading 1-byte tag (so a list and an object, or an
+    /// expression and a string, can never collide), strings/bytes are
+    /// length-prefixed (so `"a" + "b"` cannot alias `"ab"`), and counts are
+    /// varint-framed. Numbers are normalized: an integral value is emitted as an
+    /// integer regardless of JSON spelling, so `1`, `1.0`, and `-0.0` share one
+    /// encoding (the `"1"`-vs-`"1.0"` dedup fix). The output is prefixed with a
+    /// domain separator and [`VALUE_CANON_VERSION`], so bumping the version
+    /// re-keys every hash.
+    ///
+    /// # Errors
+    ///
+    /// Returns `secret.not_hashable` if the value contains a
+    /// [`SecretLiteral`](Self::SecretLiteral): secrets must never enter a
+    /// content hash / dedup key (a deterministic hash of a low-entropy secret is
+    /// a confirmation oracle, and a `<redacted>` placeholder would collide
+    /// distinct secrets). Returns `value.non_canonical_float` for a non-finite
+    /// float (defensive: `serde_json::Number` is always finite today).
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, crate::error::ValidationError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(CANON_DOMAIN);
+        out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+        self.write_canonical(&mut out)?;
+        Ok(out)
+    }
+
+    /// Content identifier — `blake3` over [`canonical_bytes`](Self::canonical_bytes).
+    ///
+    /// Equal structures yield equal ids automatically (Unison-style), so dedup /
+    /// cache keys / versions need no name or semver. Field *names* still enter
+    /// the id (object keys are part of the canon), unlike a pure structural hash.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`canonical_bytes`](Self::canonical_bytes) — a secret-bearing
+    /// value has no content id by design.
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn content_id(&self) -> Result<ContentId, crate::error::ValidationError> {
+        Ok(ContentId(blake3::hash(&self.canonical_bytes()?).into()))
+    }
+
+    /// Recursive canonical writer for a [`FieldValue`].
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    fn write_canonical(&self, out: &mut Vec<u8>) -> Result<(), crate::error::ValidationError> {
+        match self {
+            // A `Literal` carries a raw JSON value (including `Array`/`Object`
+            // when keys were not valid `FieldKey`s — `from_json` preserves them),
+            // canonicalized by the JSON writer below.
+            Self::Literal(value) => write_canon_json(value, out)?,
+            Self::Expression(expr) => {
+                out.push(TAG_EXPRESSION);
+                write_lp(out, expr.source().as_bytes());
+            },
+            Self::Object(map) => {
+                out.push(TAG_OBJECT);
+                let mut entries: Vec<(&FieldKey, &Self)> = map.iter().collect();
+                entries.sort_unstable_by(|(a, _), (b, _)| {
+                    a.as_str().as_bytes().cmp(b.as_str().as_bytes())
+                });
+                write_varint(out, entries.len() as u64);
+                for (key, value) in entries {
+                    write_lp(out, key.as_str().as_bytes());
+                    value.write_canonical(out)?;
+                }
+            },
+            Self::List(items) => {
+                out.push(TAG_LIST);
+                write_varint(out, items.len() as u64);
+                for item in items {
+                    item.write_canonical(out)?;
+                }
+            },
+            Self::Mode { mode, value } => {
+                out.push(TAG_MODE);
+                write_lp(out, mode.as_str().as_bytes());
+                match value {
+                    Some(inner) => {
+                        out.push(1);
+                        inner.write_canonical(out)?;
+                    },
+                    None => out.push(0),
+                }
+            },
+            // Secrets never enter a content hash (see `canonical_bytes` docs).
+            Self::SecretLiteral(_) => return Err(secret_not_hashable()),
+        }
+        Ok(())
+    }
+}
+
+// Note: `FieldValue` is intentionally `PartialEq` but not `Eq` here. Its derived
+// `PartialEq` *is* a total equivalence (`serde_json::Number` is always finite, so
+// no `NaN`), so `impl Eq` would be sound — but adding it ripples
+// `clippy::derive_partial_eq_without_eq` onto every `PartialEq`-deriving type that
+// transitively contains a `FieldValue`. That additive `Eq` rollout is a separate
+// focused pass; content-addressing here keys off `canonical_bytes` / `ContentId`,
+// not `FieldValue: Eq`.
+
+/// Domain separator prepended to every [`FieldValue::canonical_bytes`] output,
+/// so a value canon can never be confused with bytes from another protocol.
+const CANON_DOMAIN: &[u8] = b"nbschema-value-v";
+
+/// Version of the value-canonicalization format. **Separate** from the schema
+/// wire version — a bump here re-keys every content hash / dedup bucket.
+pub const VALUE_CANON_VERSION: u16 = 1;
+
+// 1-byte variant tags, emitted before content so variants are non-confusable.
+// `Literal` scalars reuse the JSON scalar tags; `Literal(Array/Object)` get
+// JSON-container tags distinct from the typed `List`/`Object` tags.
+const TAG_NULL: u8 = 0x01;
+const TAG_BOOL: u8 = 0x02;
+const TAG_INT: u8 = 0x03;
+const TAG_FLOAT: u8 = 0x04;
+const TAG_STRING: u8 = 0x05;
+const TAG_LIST: u8 = 0x06;
+const TAG_OBJECT: u8 = 0x07;
+const TAG_EXPRESSION: u8 = 0x08;
+const TAG_MODE: u8 = 0x09;
+// 0x0A is reserved for an opt-in secret commitment (keyed blake3), deferred.
+const TAG_JSON_ARRAY: u8 = 0x0B;
+const TAG_JSON_OBJECT: u8 = 0x0C;
+
+/// A 32-byte content identifier (`blake3` of a canonical encoding).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContentId([u8; 32]);
+
+impl ContentId {
+    /// Borrow the raw 32-byte digest.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// `secret.not_hashable` — a secret cannot enter a content hash / dedup key.
+fn secret_not_hashable() -> crate::error::ValidationError {
+    crate::error::ValidationError::builder("secret.not_hashable")
+        .message("secret values must not enter a content hash or dedup key")
+        .build()
+}
+
+/// `value.non_canonical_float` — a non-finite float has no canonical encoding.
+fn non_canonical_float() -> crate::error::ValidationError {
+    crate::error::ValidationError::builder("value.non_canonical_float")
+        .message("non-finite floats (NaN / ±Inf) have no canonical encoding")
+        .build()
+}
+
+/// Append a length-prefixed byte string (varint length + bytes) — prevents
+/// `"a" + "b"` from aliasing `"ab"`.
+fn write_lp(out: &mut Vec<u8>, bytes: &[u8]) {
+    write_varint(out, bytes.len() as u64);
+    out.extend_from_slice(bytes);
+}
+
+/// Append an unsigned LEB128 varint.
+fn write_varint(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+/// Canonicalize a raw `serde_json::Value` (used for `FieldValue::Literal`).
+#[expect(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+fn write_canon_json(value: &Value, out: &mut Vec<u8>) -> Result<(), crate::error::ValidationError> {
+    match value {
+        Value::Null => out.push(TAG_NULL),
+        Value::Bool(b) => {
+            out.push(TAG_BOOL);
+            out.push(u8::from(*b));
+        },
+        Value::Number(number) => write_canon_number(number, out)?,
+        Value::String(string) => {
+            out.push(TAG_STRING);
+            write_lp(out, string.as_bytes());
+        },
+        Value::Array(items) => {
+            out.push(TAG_JSON_ARRAY);
+            write_varint(out, items.len() as u64);
+            for item in items {
+                write_canon_json(item, out)?;
+            }
+        },
+        Value::Object(map) => {
+            out.push(TAG_JSON_OBJECT);
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_unstable_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
+            write_varint(out, entries.len() as u64);
+            for (key, child) in entries {
+                write_lp(out, key.as_bytes());
+                write_canon_json(child, out)?;
+            }
+        },
+    }
+    Ok(())
+}
+
+/// Canonicalize a number: integers and integral floats normalize to one
+/// `i128`-BE integer encoding (`1` ≡ `1.0` ≡ `-0.0`); other finite floats use
+/// their IEEE-754 big-endian bits; non-finite floats are rejected.
+#[expect(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+fn write_canon_number(
+    number: &serde_json::Number,
+    out: &mut Vec<u8>,
+) -> Result<(), crate::error::ValidationError> {
+    if let Some(int) = number.as_i64() {
+        out.push(TAG_INT);
+        out.extend_from_slice(&i128::from(int).to_be_bytes());
+        return Ok(());
+    }
+    if let Some(uint) = number.as_u64() {
+        out.push(TAG_INT);
+        out.extend_from_slice(&i128::from(uint).to_be_bytes());
+        return Ok(());
+    }
+    // Float (serde_json::Number is always finite, but guard defensively).
+    let float = number.as_f64().ok_or_else(non_canonical_float)?;
+    if !float.is_finite() {
+        return Err(non_canonical_float());
+    }
+    // Integral float in the exact-integer range normalizes to the integer
+    // encoding (so `1.0` ≡ `1`, and `-0.0` ≡ `0`).
+    const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_992.0; // 2^53
+    if float.fract() == 0.0 && float.abs() < MAX_EXACT_INT_F64 {
+        out.push(TAG_INT);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "float is integral and |float| < 2^53, so the cast is exact"
+        )]
+        let as_int = float as i128;
+        out.extend_from_slice(&as_int.to_be_bytes());
+        return Ok(());
+    }
+    out.push(TAG_FLOAT);
+    out.extend_from_slice(&float.to_be_bytes());
+    Ok(())
 }
 
 impl Serialize for FieldValue {
@@ -536,6 +814,47 @@ impl FieldValues {
             FieldValue::Literal(v) => v.as_f64(),
             _ => None,
         }
+    }
+
+    /// Injective canonical byte encoding of this value store (insertion-order
+    /// independent). Identical to the canon of the equivalent
+    /// [`FieldValue::Object`], so the two content-address the same. See
+    /// [`FieldValue::canonical_bytes`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `secret.not_hashable` for a secret-bearing value, or
+    /// `value.non_canonical_float` for a non-finite float.
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, crate::error::ValidationError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(CANON_DOMAIN);
+        out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+        out.push(TAG_OBJECT);
+        let mut entries: Vec<(&FieldKey, &FieldValue)> = self.0.iter().collect();
+        entries.sort_unstable_by(|(a, _), (b, _)| a.as_str().as_bytes().cmp(b.as_str().as_bytes()));
+        write_varint(&mut out, entries.len() as u64);
+        for (key, value) in entries {
+            write_lp(&mut out, key.as_str().as_bytes());
+            value.write_canonical(&mut out)?;
+        }
+        Ok(out)
+    }
+
+    /// Content identifier — `blake3` over [`canonical_bytes`](Self::canonical_bytes).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`canonical_bytes`](Self::canonical_bytes).
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn content_id(&self) -> Result<ContentId, crate::error::ValidationError> {
+        Ok(ContentId(blake3::hash(&self.canonical_bytes()?).into()))
     }
 }
 
@@ -879,5 +1198,133 @@ mod tests {
         let parsed = FieldValue::from_json(src.clone());
         let back = parsed.to_json();
         assert_eq!(back, src);
+    }
+
+    // ── canonical_bytes / ContentId ──────────────────────────────────────────
+
+    fn canon(value: &FieldValue) -> Vec<u8> {
+        value.canonical_bytes().expect("canonicalizable")
+    }
+
+    fn fk(s: &str) -> FieldKey {
+        FieldKey::new(s).unwrap()
+    }
+
+    /// Integers and integral floats share one encoding (`1` ≡ `1.0` ≡ `-0.0`),
+    /// but a non-integral float is distinct. This is the `"1"`-vs-`"1.0"` dedup fix.
+    #[test]
+    fn canon_normalizes_integral_numbers() {
+        let int = FieldValue::Literal(json!(1));
+        let float = FieldValue::Literal(json!(1.0));
+        let neg_zero = FieldValue::Literal(Value::from(-0.0_f64));
+        let zero = FieldValue::Literal(json!(0));
+        assert_eq!(canon(&int), canon(&float), "1 and 1.0 share a canon");
+        assert_eq!(canon(&neg_zero), canon(&zero), "-0.0 and 0 share a canon");
+
+        let frac = FieldValue::Literal(json!(1.5));
+        assert_ne!(canon(&int), canon(&frac), "1 and 1.5 differ");
+    }
+
+    /// Length-prefixing prevents `["a","b"]` from aliasing `["ab"]`, and the
+    /// per-variant tags keep a typed `List`/`Object` distinct from a JSON one.
+    #[test]
+    fn canon_is_injective_across_shapes() {
+        let ab = FieldValue::List(vec![
+            FieldValue::Literal(json!("a")),
+            FieldValue::Literal(json!("b")),
+        ]);
+        let concat = FieldValue::List(vec![FieldValue::Literal(json!("ab"))]);
+        assert_ne!(
+            canon(&ab),
+            canon(&concat),
+            "length-prefix blocks concatenation alias"
+        );
+
+        let empty_list = FieldValue::List(vec![]);
+        let empty_obj = FieldValue::Object(IndexMap::new());
+        assert_ne!(
+            canon(&empty_list),
+            canon(&empty_obj),
+            "list tag != object tag"
+        );
+
+        // A `Literal(json object)` (invalid-key path) is distinct from a typed
+        // `Object`, even with the same logical content.
+        let literal_obj = FieldValue::Literal(json!({"k": 1}));
+        let mut typed = IndexMap::new();
+        typed.insert(fk("k"), FieldValue::Literal(json!(1)));
+        let typed_obj = FieldValue::Object(typed);
+        assert_ne!(
+            canon(&literal_obj),
+            canon(&typed_obj),
+            "JSON object tag != typed object tag"
+        );
+    }
+
+    /// Object canon is independent of key insertion order.
+    #[test]
+    fn canon_object_key_order_invariant() {
+        let mut forward = IndexMap::new();
+        forward.insert(fk("alpha"), FieldValue::Literal(json!(1)));
+        forward.insert(fk("beta"), FieldValue::Literal(json!(2)));
+        forward.insert(fk("gamma"), FieldValue::Literal(json!(3)));
+
+        let mut reversed = IndexMap::new();
+        reversed.insert(fk("gamma"), FieldValue::Literal(json!(3)));
+        reversed.insert(fk("beta"), FieldValue::Literal(json!(2)));
+        reversed.insert(fk("alpha"), FieldValue::Literal(json!(1)));
+
+        assert_eq!(
+            canon(&FieldValue::Object(forward)),
+            canon(&FieldValue::Object(reversed)),
+            "key order must not affect the canon"
+        );
+    }
+
+    /// A secret value has no canonical form — it must not enter a content hash.
+    #[test]
+    fn canon_rejects_secret() {
+        let secret = FieldValue::SecretLiteral(SecretValue::String(
+            crate::secret::SecretString::new("hunter2".to_owned()),
+        ));
+        let err = secret
+            .canonical_bytes()
+            .expect_err("secrets are not hashable");
+        assert_eq!(err.code, "secret.not_hashable");
+        assert!(
+            secret.content_id().is_err(),
+            "content_id propagates the rejection"
+        );
+    }
+
+    #[test]
+    fn content_id_is_deterministic_and_hex() {
+        let value = FieldValue::Object({
+            let mut map = IndexMap::new();
+            map.insert(fk("k"), FieldValue::Literal(json!("v")));
+            map
+        });
+        let id_a = value.content_id().unwrap();
+        let id_b = value.content_id().unwrap();
+        assert_eq!(id_a, id_b, "same value, same id");
+        let hex = id_a.to_string();
+        assert_eq!(hex.len(), 64, "32 bytes render as 64 hex chars");
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// A `FieldValues` store canonicalizes identically to the equivalent typed
+    /// `FieldValue::Object`.
+    #[test]
+    fn field_values_canon_matches_equivalent_object() {
+        let values = FieldValues::from_json(json!({"a": 1, "b": "x"})).unwrap();
+        let mut map = IndexMap::new();
+        map.insert(fk("a"), FieldValue::Literal(json!(1)));
+        map.insert(fk("b"), FieldValue::Literal(json!("x")));
+        let object = FieldValue::Object(map);
+        assert_eq!(
+            values.canonical_bytes().unwrap(),
+            canon(&object),
+            "a value store and the equivalent object share a canon"
+        );
     }
 }

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -251,6 +251,10 @@ impl FieldValue {
     /// domain separator and [`VALUE_CANON_VERSION`], so bumping the version
     /// re-keys every hash.
     ///
+    /// Canonical equality is therefore **coarser** than `FieldValue: PartialEq`:
+    /// `Literal(1)` and `Literal(1.0)` are *not* `==` (distinct `serde_json::Number`s)
+    /// yet share a canon / [`ContentId`]. Do not assume equal ids imply `==`.
+    ///
     /// # Errors
     ///
     /// Returns `secret.not_hashable` if the value contains a
@@ -304,18 +308,7 @@ impl FieldValue {
                 out.push(TAG_EXPRESSION);
                 write_lp(out, expr.source().as_bytes());
             },
-            Self::Object(map) => {
-                out.push(TAG_OBJECT);
-                let mut entries: Vec<(&FieldKey, &Self)> = map.iter().collect();
-                entries.sort_unstable_by(|(a, _), (b, _)| {
-                    a.as_str().as_bytes().cmp(b.as_str().as_bytes())
-                });
-                write_varint(out, entries.len() as u64);
-                for (key, value) in entries {
-                    write_lp(out, key.as_str().as_bytes());
-                    value.write_canonical(out)?;
-                }
-            },
+            Self::Object(map) => write_canon_object(map, out)?,
             Self::List(items) => {
                 out.push(TAG_LIST);
                 write_varint(out, items.len() as u64);
@@ -369,7 +362,11 @@ const TAG_LIST: u8 = 0x06;
 const TAG_OBJECT: u8 = 0x07;
 const TAG_EXPRESSION: u8 = 0x08;
 const TAG_MODE: u8 = 0x09;
-// 0x0A is reserved for an opt-in secret commitment (keyed blake3), deferred.
+// 0x0A is reserved for an opt-in secret commitment, deferred. When implemented
+// it MUST use a keyed / domain-separated hash (e.g. `blake3::keyed_hash` with an
+// ephemeral per-process key), never the unkeyed `blake3::hash` used for content
+// ids — an unkeyed hash of a low-entropy secret is a brute-forceable oracle,
+// the exact property `secret.not_hashable` exists to prevent.
 const TAG_JSON_ARRAY: u8 = 0x0B;
 const TAG_JSON_OBJECT: u8 = 0x0C;
 
@@ -428,6 +425,28 @@ fn write_varint(out: &mut Vec<u8>, mut value: u64) {
             break;
         }
     }
+}
+
+/// Canonicalize a typed object body (`TAG_OBJECT` + sorted entries). Shared by
+/// [`FieldValue::Object`]'s arm and [`FieldValues::canonical_bytes`] so the two
+/// content-address identically *by construction*, not by a single example test.
+#[expect(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+fn write_canon_object(
+    map: &IndexMap<FieldKey, FieldValue>,
+    out: &mut Vec<u8>,
+) -> Result<(), crate::error::ValidationError> {
+    out.push(TAG_OBJECT);
+    let mut entries: Vec<(&FieldKey, &FieldValue)> = map.iter().collect();
+    entries.sort_unstable_by(|(a, _), (b, _)| a.as_str().as_bytes().cmp(b.as_str().as_bytes()));
+    write_varint(out, entries.len() as u64);
+    for (key, value) in entries {
+        write_lp(out, key.as_str().as_bytes());
+        value.write_canonical(out)?;
+    }
+    Ok(())
 }
 
 /// Canonicalize a raw `serde_json::Value` (used for `FieldValue::Literal`).
@@ -494,14 +513,19 @@ fn write_canon_number(
     if !float.is_finite() {
         return Err(non_canonical_float());
     }
-    // Integral float in the exact-integer range normalizes to the integer
-    // encoding (so `1.0` ≡ `1`, and `-0.0` ≡ `0`).
-    const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_992.0; // 2^53
-    if float.fract() == 0.0 && float.abs() < MAX_EXACT_INT_F64 {
+    // An integral float that fits in `i128` normalizes to the integer encoding,
+    // so the same integer hashes identically however JSON spelled it (`5` ≡ `5.0`,
+    // `-0.0` ≡ `0`). The bound must cover the whole `i64`/`u64` range (not just
+    // 2^53), or an integer near 2^63 would diverge from its own float spelling:
+    // `5e18 as i64` takes the integer path while `5e18_f64` would take the float
+    // path. 2^127 is the `i128` limit; a larger integral float has no `i64`/`u64`
+    // counterpart, so it stays a float (no spelling ambiguity to resolve).
+    let i128_bound = 2.0_f64.powi(127);
+    if float.fract() == 0.0 && float.abs() < i128_bound {
         out.push(TAG_INT);
         #[expect(
             clippy::cast_possible_truncation,
-            reason = "float is integral and |float| < 2^53, so the cast is exact"
+            reason = "float is integral and |float| < 2^127 (the i128 bound), so the cast is exact"
         )]
         let as_int = float as i128;
         out.extend_from_slice(&as_int.to_be_bytes());
@@ -833,14 +857,7 @@ impl FieldValues {
         let mut out = Vec::new();
         out.extend_from_slice(CANON_DOMAIN);
         out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
-        out.push(TAG_OBJECT);
-        let mut entries: Vec<(&FieldKey, &FieldValue)> = self.0.iter().collect();
-        entries.sort_unstable_by(|(a, _), (b, _)| a.as_str().as_bytes().cmp(b.as_str().as_bytes()));
-        write_varint(&mut out, entries.len() as u64);
-        for (key, value) in entries {
-            write_lp(&mut out, key.as_str().as_bytes());
-            value.write_canonical(&mut out)?;
-        }
+        write_canon_object(&self.0, &mut out)?;
         Ok(out)
     }
 
@@ -1325,6 +1342,162 @@ mod tests {
             values.canonical_bytes().unwrap(),
             canon(&object),
             "a value store and the equivalent object share a canon"
+        );
+    }
+
+    /// The normalization invariant must hold across the WHOLE i64/u64 range, not
+    /// only |x| < 2^53: an integer near 2^63 spelled as int vs as float must
+    /// still share a canon. (Guards against the off-by-`<` at the 2^53 bound.)
+    #[test]
+    fn canon_normalizes_large_integers() {
+        for n in [
+            9_007_199_254_740_992_i64,     // 2^53 (the old boundary, exclusive)
+            9_007_199_254_740_994_i64,     // 2^53 + 2 (next exact f64 integer above 2^53)
+            4_503_599_627_370_497_i64,     // odd, within 2^53
+            1_152_921_504_606_846_976_i64, // 2^60
+        ] {
+            // Only test values that round-trip exactly through f64 (so the float
+            // spelling denotes the same integer).
+            #[expect(clippy::cast_precision_loss, reason = "checked exact below")]
+            let as_float = n as f64;
+            #[expect(clippy::cast_possible_truncation, reason = "checked exact below")]
+            let back = as_float as i64;
+            if back != n {
+                continue;
+            }
+            let int = FieldValue::Literal(json!(n));
+            let float = FieldValue::Literal(Value::from(as_float));
+            assert_eq!(
+                canon(&int),
+                canon(&float),
+                "{n} as int and as float must share a canon"
+            );
+        }
+    }
+
+    /// A secret nested inside a container still rejects (recursion propagates it).
+    #[test]
+    fn canon_rejects_nested_secret() {
+        let secret = || {
+            FieldValue::SecretLiteral(SecretValue::String(crate::secret::SecretString::new(
+                "s".to_owned(),
+            )))
+        };
+        let in_list = FieldValue::List(vec![FieldValue::Literal(json!(1)), secret()]);
+        let mut map = IndexMap::new();
+        map.insert(fk("k"), secret());
+        let in_object = FieldValue::Object(map);
+        let in_mode = FieldValue::Mode {
+            mode: fk("m"),
+            value: Some(Box::new(secret())),
+        };
+        for value in [in_list, in_object, in_mode] {
+            assert_eq!(
+                value
+                    .canonical_bytes()
+                    .expect_err("nested secret rejects")
+                    .code,
+                "secret.not_hashable"
+            );
+        }
+    }
+
+    /// `Mode` discriminator: `None`, `Some`, and a different mode key are all
+    /// distinct (the presence byte 0/1 and the mode key matter).
+    #[test]
+    fn canon_mode_variants_are_distinct() {
+        let none = FieldValue::Mode {
+            mode: fk("m"),
+            value: None,
+        };
+        let some = FieldValue::Mode {
+            mode: fk("m"),
+            value: Some(Box::new(FieldValue::Literal(json!(0)))),
+        };
+        let other_key = FieldValue::Mode {
+            mode: fk("n"),
+            value: None,
+        };
+        assert_ne!(canon(&none), canon(&some));
+        assert_ne!(canon(&none), canon(&other_key));
+        assert_ne!(canon(&some), canon(&other_key));
+    }
+
+    /// Empty string, list, and object are mutually distinct and non-degenerate.
+    #[test]
+    fn canon_empty_containers_are_distinct() {
+        let empty_string = FieldValue::Literal(json!(""));
+        let empty_list = FieldValue::List(vec![]);
+        let empty_object = FieldValue::Object(IndexMap::new());
+        let canons = [
+            canon(&empty_string),
+            canon(&empty_list),
+            canon(&empty_object),
+        ];
+        for (i, a) in canons.iter().enumerate() {
+            for b in &canons[i + 1..] {
+                assert_ne!(a, b, "empty containers must not alias");
+            }
+        }
+    }
+
+    /// A `Literal(JSON array)` (invalid-key path) must not collide with a typed
+    /// `List` of the same items (`TAG_JSON_ARRAY` != `TAG_LIST`).
+    #[test]
+    fn canon_literal_array_distinct_from_typed_list() {
+        let literal = FieldValue::Literal(json!([1, 2]));
+        let typed = FieldValue::List(vec![
+            FieldValue::Literal(json!(1)),
+            FieldValue::Literal(json!(2)),
+        ]);
+        assert_ne!(canon(&literal), canon(&typed));
+    }
+
+    #[test]
+    fn content_id_separates_distinct_values() {
+        let a = FieldValues::from_json(json!({"n": 1})).unwrap();
+        let b = FieldValues::from_json(json!({"n": 2})).unwrap();
+        assert_ne!(
+            a.content_id().unwrap(),
+            b.content_id().unwrap(),
+            "distinct values must have distinct content ids"
+        );
+    }
+
+    /// Multi-byte varint: a 200-element string length encodes as LEB128
+    /// `[0xC8, 0x01]` (200 = 0x48 | continuation, then 1).
+    #[test]
+    fn canon_varint_is_multibyte_for_large_lengths() {
+        let long = "a".repeat(200);
+        let bytes = canon(&FieldValue::Literal(json!(long)));
+        // After domain (16) + version (2) + TAG_STRING (1) comes the varint length.
+        assert_eq!(
+            &bytes[19..21],
+            &[0xC8, 0x01],
+            "200 encodes as a 2-byte varint"
+        );
+    }
+
+    /// Golden bytes — freeze the exact on-the-wire content-address format so any
+    /// silent re-keying (tag value, framing order, version) is a loud failure.
+    #[test]
+    fn canon_golden_bytes() {
+        let value = FieldValues::from_json(json!({"a": 1})).unwrap();
+        let bytes = value.canonical_bytes().unwrap();
+
+        let mut expected = b"nbschema-value-v".to_vec();
+        expected.extend_from_slice(&[0x00, 0x01]); // VALUE_CANON_VERSION = 1
+        expected.push(0x07); // TAG_OBJECT
+        expected.push(0x01); // entry count (varint 1)
+        expected.extend_from_slice(&[0x01, b'a']); // key "a" (len 1 + bytes)
+        expected.push(0x03); // TAG_INT
+        expected.extend_from_slice(&1_i128.to_be_bytes()); // value 1 (i128 BE)
+
+        assert_eq!(bytes, expected, "canonical format must not drift");
+        assert_eq!(
+            &bytes[16..18],
+            &VALUE_CANON_VERSION.to_be_bytes(),
+            "the version prefix is pinned"
         );
     }
 }

--- a/crates/schema/tests/proptest/canonical_bytes.rs
+++ b/crates/schema/tests/proptest/canonical_bytes.rs
@@ -29,13 +29,28 @@ fn json_strategy() -> impl Strategy<Value = Value> {
 }
 
 proptest! {
-    /// `canonical_bytes` is a pure function of the value: cloning never changes it.
+    /// `canonical_bytes` is a pure, **succeeding** function over the secret-free,
+    /// finite-float domain, prefixed with the domain separator + version.
     #[test]
     fn canon_is_deterministic(v in json_strategy()) {
         let fv = FieldValue::from_json(v);
-        let once = fv.canonical_bytes();
-        let twice = fv.canonical_bytes();
-        prop_assert_eq!(once.ok(), twice.ok());
+        let once = fv.canonical_bytes().expect("json_strategy is secret-free and finite");
+        let twice = fv.canonical_bytes().expect("deterministic");
+        prop_assert_eq!(&once, &twice);
+        prop_assert!(once.starts_with(b"nbschema-value-v"), "carries the domain separator");
+        prop_assert_eq!(&once[16..18], &[0x00, 0x01], "carries VALUE_CANON_VERSION = 1");
+    }
+
+    /// Cross-shape injectivity over random content: a single-element list and a
+    /// single-key object wrapping the SAME value never collide (distinct tags).
+    #[test]
+    fn canon_distinguishes_list_from_object(v in json_strategy()) {
+        let as_list = FieldValue::from_json(json!([v]));
+        let as_object = FieldValue::from_json(json!({ "k": v }));
+        prop_assert_ne!(
+            as_list.canonical_bytes().unwrap(),
+            as_object.canonical_bytes().unwrap()
+        );
     }
 
     /// Object key insertion order does not affect the canon: a value built from a

--- a/crates/schema/tests/proptest/canonical_bytes.rs
+++ b/crates/schema/tests/proptest/canonical_bytes.rs
@@ -1,0 +1,78 @@
+//! Proptest: algebraic laws of `FieldValue::canonical_bytes`.
+//!
+//! The canon is the basis for content-addressing / dedup, so its two
+//! load-bearing properties — determinism and injectivity — are checked against
+//! randomly generated values rather than only hand-picked cases.
+
+use nebula_schema::{FieldValue, FieldValues};
+use proptest::prelude::*;
+use serde_json::{Value, json};
+
+/// A bounded recursive strategy for JSON values (the input domain of
+/// `FieldValue::from_json`). Kept shallow so the recursive collections stay cheap.
+fn json_strategy() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(|n| json!(n)),
+        // Integral floats exercise the `1.0`-normalizes-to-`1` path.
+        (-1000i64..1000).prop_map(|n| json!(n as f64)),
+        "[a-z]{0,6}".prop_map(Value::String),
+    ];
+    leaf.prop_recursive(3, 16, 4, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..4).prop_map(Value::Array),
+            prop::collection::hash_map("[a-z]{1,4}", inner, 0..4)
+                .prop_map(|m| Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+proptest! {
+    /// `canonical_bytes` is a pure function of the value: cloning never changes it.
+    #[test]
+    fn canon_is_deterministic(v in json_strategy()) {
+        let fv = FieldValue::from_json(v);
+        let once = fv.canonical_bytes();
+        let twice = fv.canonical_bytes();
+        prop_assert_eq!(once.ok(), twice.ok());
+    }
+
+    /// Object key insertion order does not affect the canon: a value built from a
+    /// JSON object equals the same object built from its key-reversed form.
+    #[test]
+    fn canon_ignores_object_key_order(
+        pairs in prop::collection::vec(("[a-z]{1,4}", any::<i64>()), 1..6)
+    ) {
+        // Collapse to unique keys (first occurrence wins) so forward and reverse
+        // describe the SAME mapping in opposite insertion orders — otherwise a
+        // duplicate key would make "last inserted wins" diverge between the two.
+        let mut unique: Vec<(String, i64)> = Vec::new();
+        for (k, n) in &pairs {
+            if !unique.iter().any(|(seen, _)| seen == k) {
+                unique.push((k.clone(), *n));
+            }
+        }
+        let mut forward = serde_json::Map::new();
+        for (k, n) in &unique {
+            forward.insert(k.clone(), json!(n));
+        }
+        let mut reverse = serde_json::Map::new();
+        for (k, n) in unique.iter().rev() {
+            reverse.insert(k.clone(), json!(n));
+        }
+        let a = FieldValue::from_json(Value::Object(forward));
+        let b = FieldValue::from_json(Value::Object(reverse));
+        prop_assert_eq!(a.canonical_bytes().unwrap(), b.canonical_bytes().unwrap());
+    }
+
+    /// Injectivity sample: two values that differ only in one integer field have
+    /// distinct canons (the canon never silently collapses distinct data).
+    #[test]
+    fn canon_separates_distinct_values(a in any::<i64>(), b in any::<i64>()) {
+        prop_assume!(a != b);
+        let va = FieldValues::from_json(json!({"n": a})).unwrap();
+        let vb = FieldValues::from_json(json!({"n": b})).unwrap();
+        prop_assert_ne!(va.canonical_bytes().unwrap(), vb.canonical_bytes().unwrap());
+    }
+}

--- a/crates/schema/tests/validate_schema.rs
+++ b/crates/schema/tests/validate_schema.rs
@@ -506,6 +506,28 @@ fn list_unique_distinct_values_ok() {
     assert!(schema.validate(&values).is_ok());
 }
 
+/// `unique` now compares by canonical value, so `1` and `1.0` (the same number
+/// spelled two ways) count as a duplicate — the `"1"`-vs-`"1.0"` dedup fix. The
+/// old `serde_json::to_string` bucketing wrongly accepted this list.
+#[test]
+fn list_unique_treats_int_and_float_as_duplicate() {
+    let schema = Schema::builder()
+        .add(
+            Field::list(fk("items"))
+                .item(Field::number(fk("it")))
+                .unique(),
+        )
+        .build()
+        .unwrap();
+    let values = FieldValues::from_json(json!({"items": [1, 1.0]})).unwrap();
+    let report = schema.validate(&values).unwrap_err();
+    assert!(
+        report.errors().any(|e| e.code == "items.unique"),
+        "1 and 1.0 are the same number; got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn required_multi_file_empty_array_emits_required() {
     let schema = Schema::builder()


### PR DESCRIPTION
## What

The audit **root-blocker**: content-addressing / dedup / idempotency all rode `serde_json::to_string`, which is not injective (object key order, `1` vs `1.0`) and collapsed every secret to `<redacted>` (distinct secrets → one hash). This adds a real injective value canon + a content id.

## schema

- `FieldValue::canonical_bytes()` / `FieldValues::canonical_bytes()`: a TLV-framed **injective** encoding — per-variant 1-byte tags (a list, a typed object, and a raw JSON object can never collide), **sorted** object keys (order-independent), length-prefixed strings (`"a"+"b"` ≠ `"ab"`), varint counts, and number normalization so `1` ≡ `1.0` ≡ `-0.0` across the **whole i64/u64 range** while non-finite floats are rejected. Output carries a domain separator + `VALUE_CANON_VERSION`. **Not** a wire format (`to_json` doc corrected).
- Secrets **fail closed**: `SecretLiteral` → `Err(secret.not_hashable)` (recursively), so a secret never enters a content hash / dedup key — not a colliding `<redacted>` placeholder. The opt-in keyed commitment (tag 0x0A) is a deferred additive feature.
- `ContentId` = `blake3(canonical_bytes)` (new `blake3` workspace dep, cargo-deny clean) + hex `Display`; `content_id()` on both types.
- `first_duplicate_index` (list-`unique`) now buckets by `canonical_bytes`, fixing the `"1"`-vs-`"1.0"` false negative; secret items fall back to constant-time `PartialEq`.

## Review

A 4-lens **security/injectivity** review ran on the diff and **caught a P0**: the integral-float→int normalization was bounded at 2^53, so an integer near 2^63 spelled as int vs float produced different canons/ContentIds. Fixed by normalizing across the full `i128`-exact range (2^127). Also addressed: a golden-bytes format pin, strengthened (non-vacuous, cross-shape) proptests, the shared `write_canon_object` helper (equal-by-construction), and coverage for nested-secret rejection, Mode boundaries, empty containers, multi-byte varints, and `content_id` separation. Deferred (noted): `Eq`/`Hash` on `FieldValue` (clippy ripple — separate pass), the keyed-commitment feature, and the `ValidSchema` definition-canon.

## Verification

`cargo nextest run --workspace` — **5655 passed, 1 skipped, 0 failed**. `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings`, `cargo deny` (blake3 licenses/advisories ok), and the canon proptests + golden test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content addressing and deduplication support for field values.

* **Bug Fixes**
  * Fixed list field uniqueness validation to correctly treat numeric equivalents (e.g., `1` and `1.0`) as duplicates.

* **Tests**
  * Added comprehensive tests for canonicalization properties and numeric equivalence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->