### PR TITLE
test(schema): schema-evolution gate — golden wire-format snapshots (C13)

### DIFF
--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -72,6 +72,10 @@ name = "proptest_canonical_bytes"
 path = "tests/proptest/canonical_bytes.rs"
 
 [[test]]
+name = "evolution_wire_snapshot"
+path = "tests/evolution_wire_snapshot.rs"
+
+[[test]]
 name = "json_schema_smoke"
 path = "tests/json_schema_smoke.rs"
 required-features = ["schemars"]

--- a/crates/schema/tests/evolution_wire_snapshot.rs
+++ b/crates/schema/tests/evolution_wire_snapshot.rs
@@ -14,7 +14,9 @@
 //!   `skip_serializing_if`, so a document written by an older version still
 //!   deserializes and a document written by a newer version still round-trips.
 
-use nebula_schema::{Field, FieldValues, Schema, field_key};
+use nebula_schema::{
+    Field, FieldValue, FieldValues, Predicate, Rule, Schema, VisibilityMode, field_key,
+};
 use serde_json::json;
 
 /// Every `Field` variant's wire shape (the `type` tag + each struct's
@@ -22,7 +24,19 @@ use serde_json::json;
 #[test]
 fn field_variants_wire_format() {
     let variants: Vec<Field> = vec![
-        Field::string(field_key!("s")).required().into(),
+        // A fully-decorated field freezes the SHARED serde keys that are skipped
+        // when default (`label`/`description`/`placeholder`/`default`/`group`/
+        // `visible`/`rules`), so renaming any of them also diffs this snapshot.
+        Field::string(field_key!("s"))
+            .label("Display Name")
+            .description("A fully-described field")
+            .placeholder("type here")
+            .group("contact")
+            .default(json!("default-value"))
+            .visible(VisibilityMode::Never)
+            .with_rule(Rule::predicate(Predicate::eq("s", json!("x")).unwrap()))
+            .required()
+            .into(),
         Field::secret(field_key!("sec")).into(),
         Field::number(field_key!("n")).integer().into(),
         Field::boolean(field_key!("b")).into(),
@@ -77,4 +91,16 @@ fn field_values_wire_format() {
     }))
     .unwrap();
     insta::assert_json_snapshot!(values);
+}
+
+/// The typed `FieldValue::Mode` serialization branch. `from_json` parses a
+/// `{"mode": …, "value": …}` object as an ordinary `Object`, so the `Mode`
+/// variant's wire output is only reachable by constructing it directly.
+#[test]
+fn field_value_mode_wire_format() {
+    let mode = FieldValue::Mode {
+        mode: field_key!("oauth2"),
+        value: Some(Box::new(FieldValue::from_json(json!({"scope": "read"})))),
+    };
+    insta::assert_json_snapshot!(mode);
 }

--- a/crates/schema/tests/evolution_wire_snapshot.rs
+++ b/crates/schema/tests/evolution_wire_snapshot.rs
@@ -1,0 +1,80 @@
+//! Schema-evolution gate (C13): golden snapshots that **freeze the serde wire
+//! representation** of the schema-definition types.
+//!
+//! `Field` is `#[serde(tag = "type")]` and is re-exported as a real external
+//! contract (`nebula-api`'s public-schema projection consumes it), so a renamed
+//! variant, a renamed field, or a changed type is a **silent** wire break that
+//! no compiler catches. Any such change diffs a snapshot below and fails CI
+//! until a maintainer consciously accepts it (`cargo insta review`).
+//!
+//! Backward/forward-compatibility rule this gate enforces by review:
+//! - new `Field` variants are only safe because the enum is `#[non_exhaustive]`
+//!   (an old reader must not be required to match them exhaustively);
+//! - new struct fields must be `Option` / `#[serde(default)]` with
+//!   `skip_serializing_if`, so a document written by an older version still
+//!   deserializes and a document written by a newer version still round-trips.
+
+use nebula_schema::{Field, FieldValues, Schema, field_key};
+use serde_json::json;
+
+/// Every `Field` variant's wire shape (the `type` tag + each struct's
+/// non-skipped fields). A renamed variant / field / type tag diffs here.
+#[test]
+fn field_variants_wire_format() {
+    let variants: Vec<Field> = vec![
+        Field::string(field_key!("s")).required().into(),
+        Field::secret(field_key!("sec")).into(),
+        Field::number(field_key!("n")).integer().into(),
+        Field::boolean(field_key!("b")).into(),
+        Field::select(field_key!("sel")).option("a", "A").into(),
+        Field::object(field_key!("o"))
+            .add(Field::string(field_key!("inner")))
+            .into(),
+        Field::list(field_key!("l"))
+            .item(Field::string(field_key!("it")))
+            .into(),
+        Field::mode(field_key!("m"))
+            .variant("v", "V", Field::string(field_key!("x")))
+            .into(),
+        Field::code(field_key!("c")).into(),
+        Field::file(field_key!("f")).multiple().into(),
+        Field::computed(field_key!("comp")).into(),
+        Field::dynamic(field_key!("d")).into(),
+        Field::notice(field_key!("not")).into(),
+    ];
+    insta::assert_json_snapshot!(variants);
+}
+
+/// A built `ValidSchema`'s wire shape (the `{"fields": [...]}` envelope plus a
+/// representative field set).
+#[test]
+fn valid_schema_wire_format() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("name")).required())
+        .add(Field::number(field_key!("age")))
+        .add(
+            Field::object(field_key!("address"))
+                .add(Field::string(field_key!("city")))
+                .add(Field::string(field_key!("zip")).required()),
+        )
+        .build()
+        .unwrap();
+    insta::assert_json_snapshot!(schema);
+}
+
+/// A `FieldValues` store covering every runtime-value shape (literal, nested
+/// object, list, expression wrapper, mode envelope).
+#[test]
+fn field_values_wire_format() {
+    let values = FieldValues::from_json(json!({
+        "scalar": 1,
+        "text": "hello",
+        "flag": true,
+        "nested": {"k": "v"},
+        "list": [1, 2, 3],
+        "expr": {"$expr": "{{ $x.y }}"},
+        "mode": {"mode": "oauth2", "value": {"scope": "read"}}
+    }))
+    .unwrap();
+    insta::assert_json_snapshot!(values);
+}

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__field_value_mode_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__field_value_mode_wire_format.snap
@@ -1,0 +1,10 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: mode
+---
+{
+  "mode": "oauth2",
+  "value": {
+    "scope": "read"
+  }
+}

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__field_values_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__field_values_wire_format.snap
@@ -1,0 +1,26 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: values
+---
+{
+  "expr": {
+    "$expr": "{{ $x.y }}"
+  },
+  "flag": true,
+  "list": [
+    1,
+    2,
+    3
+  ],
+  "mode": {
+    "mode": "oauth2",
+    "value": {
+      "scope": "read"
+    }
+  },
+  "nested": {
+    "k": "v"
+  },
+  "scalar": 1,
+  "text": "hello"
+}

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
@@ -6,9 +6,25 @@ expression: variants
   {
     "type": "string",
     "key": "s",
+    "label": "Display Name",
+    "description": "A fully-described field",
+    "placeholder": "type here",
+    "default": "default-value",
+    "visible": {
+      "kind": "never"
+    },
     "required": {
       "kind": "always"
     },
+    "group": "contact",
+    "rules": [
+      {
+        "eq": [
+          "/s",
+          "x"
+        ]
+      }
+    ],
     "hint": "text",
     "widget": "plain"
   },

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
@@ -1,0 +1,128 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: variants
+---
+[
+  {
+    "type": "string",
+    "key": "s",
+    "required": {
+      "kind": "always"
+    },
+    "hint": "text",
+    "widget": "plain"
+  },
+  {
+    "type": "secret",
+    "key": "sec",
+    "widget": "plain",
+    "reveal_last": null
+  },
+  {
+    "type": "number",
+    "key": "n",
+    "integer": true,
+    "widget": "plain",
+    "step": null
+  },
+  {
+    "type": "boolean",
+    "key": "b",
+    "expression": "forbidden",
+    "widget": "toggle"
+  },
+  {
+    "type": "select",
+    "key": "sel",
+    "expression": "forbidden",
+    "options": [
+      {
+        "value": "a",
+        "label": "A"
+      }
+    ],
+    "dynamic": false,
+    "loader": null,
+    "depends_on": [],
+    "multiple": false,
+    "allow_custom": false,
+    "searchable": false,
+    "widget": "dropdown"
+  },
+  {
+    "type": "object",
+    "key": "o",
+    "fields": [
+      {
+        "type": "string",
+        "key": "inner",
+        "hint": "text",
+        "widget": "plain"
+      }
+    ],
+    "widget": "inline"
+  },
+  {
+    "type": "list",
+    "key": "l",
+    "item": {
+      "type": "string",
+      "key": "it",
+      "hint": "text",
+      "widget": "plain"
+    },
+    "min_items": null,
+    "max_items": null,
+    "unique": false,
+    "widget": "plain"
+  },
+  {
+    "type": "mode",
+    "key": "m",
+    "variants": [
+      {
+        "key": "v",
+        "label": "V",
+        "field": {
+          "type": "string",
+          "key": "x",
+          "hint": "text",
+          "widget": "plain"
+        }
+      }
+    ],
+    "default_variant": null
+  },
+  {
+    "type": "code",
+    "key": "c",
+    "language": "plaintext",
+    "widget": "monaco"
+  },
+  {
+    "type": "file",
+    "key": "f",
+    "accept": null,
+    "max_size": null,
+    "multiple": true
+  },
+  {
+    "type": "computed",
+    "key": "comp",
+    "expression": "required",
+    "expression_source": "",
+    "returns": "string"
+  },
+  {
+    "type": "dynamic",
+    "key": "d",
+    "depends_on": [],
+    "loader": null
+  },
+  {
+    "type": "notice",
+    "key": "not",
+    "expression": "forbidden",
+    "severity": "info"
+  }
+]

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__valid_schema_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__valid_schema_wire_format.snap
@@ -1,0 +1,46 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: schema
+---
+{
+  "fields": [
+    {
+      "type": "string",
+      "key": "name",
+      "required": {
+        "kind": "always"
+      },
+      "hint": "text",
+      "widget": "plain"
+    },
+    {
+      "type": "number",
+      "key": "age",
+      "integer": false,
+      "widget": "plain",
+      "step": null
+    },
+    {
+      "type": "object",
+      "key": "address",
+      "fields": [
+        {
+          "type": "string",
+          "key": "city",
+          "hint": "text",
+          "widget": "plain"
+        },
+        {
+          "type": "string",
+          "key": "zip",
+          "required": {
+            "kind": "always"
+          },
+          "hint": "text",
+          "widget": "plain"
+        }
+      ],
+      "widget": "inline"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Step 7 (C13 evolution) — the **detection gate**. `Field` is `#[serde(tag = "type")]` and re-exported as a real external contract (`nebula-api`'s public-schema projection), so a renamed variant / field / type tag is a **silent** wire break no compiler catches. This freezes the serde representation with `insta` golden snapshots:

- every `Field` variant (all 13 — the `type` tag + each struct's non-skipped fields + defaults);
- a representative `ValidSchema` (the `{"fields": […]}` envelope);
- a `FieldValues` covering each runtime shape (literal, nested object, list, `$expr` wrapper, mode envelope).

Any change diffs a snapshot and **fails CI** until a maintainer consciously accepts it (`cargo insta review`) — the Avro-style backward/forward-compat gate, without a registry service.

The evolution rule the gate enforces by review (documented in the test): new `Field` variants ride the existing `#[non_exhaustive]`; new struct fields must be `Option` / `#[serde(default)]` + `skip_serializing_if` so old and new documents round-trip.

## Scope

This is the foundational **detection** mechanism of C13. The remaining evolution pieces are scoped follow-ups (each its own pass, noted in the commit): `Field::Unknown { type, raw }` forward-compat preservation (custom serde for the tagged enum), the `#[schema(reserved(..))]` attribute + lint, and wiring `default` into the backward-compat resolution in `compat.rs`.

## Verification

`cargo nextest run -p nebula-schema` — **490 passed, 0 failed** (incl. the 3 new snapshot tests, stable on re-run). `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings` green. Pure test infrastructure — no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)