### PR TITLE
feat(schema): #[schema(reserved("key"))] forbids reusing a removed field's key

### DIFF
--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -592,8 +592,10 @@ fn lower_first(value: &str) -> String {
     }
 }
 
-/// The subset of `#[serde(...)]` attributes that affect the schema key, read from
-/// a container (`rename_all`) or a field / variant (`rename`, `skip`, `flatten`).
+/// The subset of `#[serde(...)]` attributes the schema derive reads: the ones
+/// that affect the schema key (`rename_all`, `rename`, `skip`, `flatten`) plus
+/// `alias`, which does not change the key but is an alternative wire key serde
+/// still deserializes into the field — so a reserved key must also reject it.
 #[derive(Default)]
 pub(crate) struct SerdeAttrs {
     pub rename_all: Option<RenameRule>,
@@ -602,6 +604,9 @@ pub(crate) struct SerdeAttrs {
     /// `Some(span)` when `#[serde(flatten)]` is present — used to anchor the
     /// "flatten not yet supported" compile error at the attribute.
     pub flatten_span: Option<Span>,
+    /// `#[serde(alias = "..")]` keys (deserialize-only alternative wire keys).
+    /// Empty unless the field carries one or more aliases.
+    pub aliases: Vec<String>,
 }
 
 impl SerdeAttrs {
@@ -620,6 +625,9 @@ impl SerdeAttrs {
                     },
                     Meta::NameValue(nv) if nv.path.is_ident("rename") => {
                         out.rename = Some(expr_str(&nv.value, "rename")?);
+                    },
+                    Meta::NameValue(nv) if nv.path.is_ident("alias") => {
+                        out.aliases.push(expr_str(&nv.value, "alias")?);
                     },
                     Meta::Path(p) if p.is_ident("skip") || p.is_ident("skip_deserializing") => {
                         out.skip = true;

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -457,6 +457,13 @@ impl Parse for SchemaEntry {
         let value: LitStr = input.parse()?;
         match name.to_string().as_str() {
             "custom" => Ok(Self::Custom { value }),
+            // `reserved` is a valid option used with the wrong (assignment) form —
+            // point at the list syntax instead of claiming the option is unknown.
+            "reserved" => Err(syn::Error::new(
+                name.span(),
+                "#[schema(reserved)] requires list syntax: write `reserved(\"key\")`, \
+                 not `reserved = \"key\"`",
+            )),
             other => Err(syn::Error::new(
                 name.span(),
                 format!("unknown #[schema(..)] option `{other}`"),

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -384,6 +384,11 @@ fn lit_to_i64(expr: &Expr) -> syn::Result<i64> {
 pub(crate) struct SchemaStructAttrs {
     /// Wire-level `Rule::Deferred(DeferredRule::Custom(..))` expression strings.
     pub custom: Vec<LitStr>,
+    /// Field keys reserved against reuse (`#[schema(reserved("old_key"))]`). A
+    /// reserved key may not be used by any field of this struct — the derive
+    /// rejects a collision at expansion. Kept as `LitStr` so the span points at
+    /// the offending literal in diagnostics.
+    pub reserved: Vec<LitStr>,
 }
 
 impl SchemaStructAttrs {
@@ -402,6 +407,7 @@ impl SchemaStructAttrs {
 
 enum SchemaEntry {
     Custom { value: LitStr },
+    Reserved { keys: Vec<LitStr> },
 }
 
 impl SchemaEntry {
@@ -411,6 +417,10 @@ impl SchemaEntry {
                 out.custom.push(value);
                 Ok(())
             },
+            Self::Reserved { keys } => {
+                out.reserved.extend(keys);
+                Ok(())
+            },
         }
     }
 }
@@ -418,10 +428,29 @@ impl SchemaEntry {
 impl Parse for SchemaEntry {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let name: syn::Ident = input.parse()?;
+
+        // List-form options: `reserved("a", "b")`.
+        if input.peek(syn::token::Paren) {
+            let content;
+            syn::parenthesized!(content in input);
+            let keys: Punctuated<LitStr, Token![,]> =
+                content.parse_terminated(<LitStr as Parse>::parse, Token![,])?;
+            return match name.to_string().as_str() {
+                "reserved" => Ok(Self::Reserved {
+                    keys: keys.into_iter().collect(),
+                }),
+                other => Err(syn::Error::new(
+                    name.span(),
+                    format!("unknown list-form #[schema(..)] option `{other}`"),
+                )),
+            };
+        }
+
+        // Assignment-form options: `custom = "..."`.
         if !input.peek(Token![=]) {
             return Err(syn::Error::new(
                 name.span(),
-                "expected `#[schema(custom = \"...\")]` — flag-style schema options are not supported",
+                "expected `#[schema(custom = \"...\")]` or `#[schema(reserved(\"...\"))]`",
             ));
         }
         input.parse::<Token![=]>()?;

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -184,6 +184,7 @@ fn enforce_reserved_keys(
     reserved: &[syn::LitStr],
     field_keys: &[(String, Span)],
 ) -> syn::Result<()> {
+    let mut seen = std::collections::HashSet::with_capacity(reserved.len());
     for lit in reserved {
         let reserved_key = lit.value();
         // A reserved key that is not a valid `FieldKey` can never match a real
@@ -194,6 +195,13 @@ fn enforce_reserved_keys(
                 format!("reserved key `{reserved_key}` is not a valid schema field key ({reason})"),
             )
         })?;
+        // The same key reserved twice is a typo: the duplicate is a dead entry.
+        if !seen.insert(reserved_key.clone()) {
+            return Err(syn::Error::new(
+                lit.span(),
+                format!("key `{reserved_key}` is reserved more than once"),
+            ));
+        }
         if let Some((_, field_span)) = field_keys.iter().find(|(key, _)| *key == reserved_key) {
             return Err(syn::Error::new(
                 *field_span,

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -51,6 +51,10 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
 
     let mut field_exprs = Vec::with_capacity(fields.len());
     let mut field_keys: Vec<(String, Span)> = Vec::with_capacity(fields.len());
+    // Serde aliases are alternative wire keys serde still deserializes into the
+    // field, so a reserved key must reject them too — collected separately so the
+    // collision diagnostic can name the alias as the culprit.
+    let mut field_aliases: Vec<(String, Span)> = Vec::new();
     for f in fields {
         let field_name = f
             .ident
@@ -73,6 +77,9 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         let kind = classify(&f.ty);
         let key_str = resolve_field_key(field_name, &serde, container_serde.rename_all)?;
         field_keys.push((key_str.clone(), field_name.span()));
+        for alias in &serde.aliases {
+            field_aliases.push((alias.clone(), field_name.span()));
+        }
         let expr = build_field_expr(
             field_name,
             &key_str,
@@ -84,7 +91,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         field_exprs.push(expr);
     }
 
-    enforce_reserved_keys(&schema_attrs.reserved, &field_keys)?;
+    enforce_reserved_keys(&schema_attrs.reserved, &field_keys, &field_aliases)?;
 
     let ty_name_str = ty_name.to_string();
     Ok(quote! {
@@ -172,17 +179,21 @@ fn check_field_key(key: &str, span: Span) -> syn::Result<()> {
     })
 }
 
-/// Reject any field whose resolved schema key collides with a key listed in
+/// Reject any field whose resolved schema key — or a `#[serde(alias = "..")]`
+/// serde still deserializes into it — collides with a key listed in
 /// `#[schema(reserved(..))]`, and validate each reserved literal is itself a
 /// well-formed `FieldKey`.
 ///
 /// Reserving a key prevents a removed field's key from being silently reused for
 /// a *different* field — a document written before the removal still carries the
 /// old key, so reusing it would misread that data (Protobuf-style reservation).
-/// The check runs at expansion, so a collision is a spanned compile error.
+/// An alias is checked too: it is exactly such an alternative wire key, so an
+/// alias onto a reserved key reintroduces the very misread the reservation guards
+/// against. The check runs at expansion, so a collision is a spanned compile error.
 fn enforce_reserved_keys(
     reserved: &[syn::LitStr],
     field_keys: &[(String, Span)],
+    field_aliases: &[(String, Span)],
 ) -> syn::Result<()> {
     let mut seen = std::collections::HashSet::with_capacity(reserved.len());
     for lit in reserved {
@@ -208,6 +219,19 @@ fn enforce_reserved_keys(
                 format!(
                     "field key `{reserved_key}` is reserved by `#[schema(reserved(..))]` and \
                      cannot be used — reserving a key prevents reusing it for a different field"
+                ),
+            ));
+        }
+        if let Some((_, field_span)) = field_aliases
+            .iter()
+            .find(|(alias, _)| *alias == reserved_key)
+        {
+            return Err(syn::Error::new(
+                *field_span,
+                format!(
+                    "key `{reserved_key}` is reserved by `#[schema(reserved(..))]` but a \
+                     `#[serde(alias = \"{reserved_key}\")]` still deserializes it into this field \
+                     — remove the alias or the reservation"
                 ),
             ));
         }

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -50,6 +50,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         .collect();
 
     let mut field_exprs = Vec::with_capacity(fields.len());
+    let mut field_keys: Vec<(String, Span)> = Vec::with_capacity(fields.len());
     for f in fields {
         let field_name = f
             .ident
@@ -71,6 +72,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         let validate = ValidateAttrs::from_attrs(&f.attrs)?;
         let kind = classify(&f.ty);
         let key_str = resolve_field_key(field_name, &serde, container_serde.rename_all)?;
+        field_keys.push((key_str.clone(), field_name.span()));
         let expr = build_field_expr(
             field_name,
             &key_str,
@@ -81,6 +83,8 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         )?;
         field_exprs.push(expr);
     }
+
+    enforce_reserved_keys(&schema_attrs.reserved, &field_keys)?;
 
     let ty_name_str = ty_name.to_string();
     Ok(quote! {
@@ -166,6 +170,41 @@ fn check_field_key(key: &str, span: Span) -> syn::Result<()> {
             ),
         )
     })
+}
+
+/// Reject any field whose resolved schema key collides with a key listed in
+/// `#[schema(reserved(..))]`, and validate each reserved literal is itself a
+/// well-formed `FieldKey`.
+///
+/// Reserving a key prevents a removed field's key from being silently reused for
+/// a *different* field — a document written before the removal still carries the
+/// old key, so reusing it would misread that data (Protobuf-style reservation).
+/// The check runs at expansion, so a collision is a spanned compile error.
+fn enforce_reserved_keys(
+    reserved: &[syn::LitStr],
+    field_keys: &[(String, Span)],
+) -> syn::Result<()> {
+    for lit in reserved {
+        let reserved_key = lit.value();
+        // A reserved key that is not a valid `FieldKey` can never match a real
+        // key, so the reservation would be silently inert — reject the typo.
+        crate::validate_field_key(&reserved_key).map_err(|reason| {
+            syn::Error::new(
+                lit.span(),
+                format!("reserved key `{reserved_key}` is not a valid schema field key ({reason})"),
+            )
+        })?;
+        if let Some((_, field_span)) = field_keys.iter().find(|(key, _)| *key == reserved_key) {
+            return Err(syn::Error::new(
+                *field_span,
+                format!(
+                    "field key `{reserved_key}` is reserved by `#[schema(reserved(..))]` and \
+                     cannot be used — reserving a key prevents reusing it for a different field"
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Build the token-stream expression that produces a `Field` for one struct field.

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -68,7 +68,8 @@ pub fn field_key(input: TokenStream) -> TokenStream {
 /// - `#[schema(...)]` — struct-level options: `custom = "..."` → the validator's
 ///   `Rule::custom` on the built schema (deferred wire hook); `reserved("a", "b")`
 ///   → keys that may not be used by any field (reusing a removed field's key would
-///   misread older documents), rejected at expansion if a field collides.
+///   misread older documents), rejected at expansion if a field's resolved key or
+///   a `#[serde(alias = ..)]` collides.
 /// - `#[serde(...)]` — read for key alignment so the schema key equals the wire
 ///   key: `rename` / `rename_all` rename the field, `skip` / `skip_deserializing`
 ///   drop it. `#[serde(flatten)]` is rejected (splicing is a follow-up).

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -65,8 +65,10 @@ pub fn field_key(input: TokenStream) -> TokenStream {
 /// - `#[field(...)]` — label/description/placeholder/default/hint/secret/
 ///   multiline/no_expression/expression_required/enum_select/skip/group.
 /// - `#[validate(...)]` — required/length(min,max)/range(min..=max)/ pattern/url/email.
-/// - `#[schema(...)]` — struct-level options; today: `custom = "..."` → the validator's
-///   `Rule::custom` on the built schema (deferred wire hook).
+/// - `#[schema(...)]` — struct-level options: `custom = "..."` → the validator's
+///   `Rule::custom` on the built schema (deferred wire hook); `reserved("a", "b")`
+///   → keys that may not be used by any field (reusing a removed field's key would
+///   misread older documents), rejected at expansion if a field collides.
 /// - `#[serde(...)]` — read for key alignment so the schema key equals the wire
 ///   key: `rename` / `rename_all` rename the field, `skip` / `skip_deserializing`
 ///   drop it. `#[serde(flatten)]` is rejected (splicing is a follow-up).

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -106,6 +106,20 @@
 //! let values = FieldValues::from_json(json!({"name": "n"})).unwrap();
 //! assert!(schema.validate(&values).is_ok());
 //! ```
+//!
+//! `#[schema(reserved("old_key"))]` forbids any field from using a key — reusing
+//! a removed field's key would misread documents written before the removal
+//! (Protobuf-style reservation). A collision is a compile error:
+//!
+//! ```compile_fail
+//! use nebula_schema::Schema;
+//!
+//! #[derive(Schema)]
+//! #[schema(reserved("name"))]
+//! struct Bad {
+//!     name: String, // error: field key `name` is reserved
+//! }
+//! ```
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -109,7 +109,9 @@
 //!
 //! `#[schema(reserved("old_key"))]` forbids any field from using a key — reusing
 //! a removed field's key would misread documents written before the removal
-//! (Protobuf-style reservation). A collision is a compile error:
+//! (Protobuf-style reservation). It is enforced at compile time on this struct's
+//! definition (it is not recorded in the built schema). A collision is a compile
+//! error:
 //!
 //! ```compile_fail
 //! use nebula_schema::Schema;

--- a/crates/schema/tests/compile_fail/derive_reserved_duplicate.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_duplicate.rs
@@ -1,0 +1,14 @@
+use nebula_schema::Schema;
+
+// Reserving the same key twice is a typo — the duplicate is a dead entry, so the
+// derive rejects it rather than silently accepting a no-op reservation.
+#[derive(Schema)]
+#[schema(reserved("old_key", "old_key"))]
+#[allow(dead_code)]
+struct Bad {
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_duplicate.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_duplicate.stderr
@@ -1,0 +1,18 @@
+error: key `old_key` is reserved more than once
+ --> tests/compile_fail/derive_reserved_duplicate.rs:6:30
+  |
+6 | #[schema(reserved("old_key", "old_key"))]
+  |                              ^^^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_duplicate.rs:13:18
+   |
+ 8 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+13 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_key_collision.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_collision.rs
@@ -1,0 +1,14 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[schema(reserved("name"))]
+#[allow(dead_code)]
+struct Bad {
+    // `name` is reserved, so a field resolving to that key must be rejected —
+    // reserving a key forbids reusing it for a different field.
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_key_collision.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_collision.stderr
@@ -1,0 +1,18 @@
+error: field key `name` is reserved by `#[schema(reserved(..))]` and cannot be used — reserving a key prevents reusing it for a different field
+ --> tests/compile_fail/derive_reserved_key_collision.rs:9:5
+  |
+9 |     name: String,
+  |     ^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_key_collision.rs:13:18
+   |
+ 6 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+13 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_key_invalid.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_invalid.rs
@@ -1,0 +1,14 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+// A reserved key that is not a valid `FieldKey` can never match a real key, so
+// the reservation would be silently inert — the derive must reject the typo.
+#[schema(reserved("not a valid key"))]
+#[allow(dead_code)]
+struct Bad {
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_key_invalid.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_invalid.stderr
@@ -1,0 +1,18 @@
+error: reserved key `not a valid key` is not a valid schema field key (key must be ASCII alphanumeric or underscore)
+ --> tests/compile_fail/derive_reserved_key_invalid.rs:6:19
+  |
+6 | #[schema(reserved("not a valid key"))]
+  |                   ^^^^^^^^^^^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_key_invalid.rs:13:18
+   |
+ 8 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+13 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_key_rename_all_collision.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_rename_all_collision.rs
@@ -1,0 +1,16 @@
+use nebula_schema::Schema;
+
+// The reservation is checked against the *resolved* wire key, so a container
+// `#[serde(rename_all = ..)]` that maps a field onto a reserved key still
+// collides (the resolved key `myField`, not the raw ident `my_field`).
+#[derive(Schema, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[schema(reserved("myField"))]
+#[allow(dead_code)]
+struct Bad {
+    my_field: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_key_rename_all_collision.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_rename_all_collision.stderr
@@ -1,0 +1,18 @@
+error: field key `myField` is reserved by `#[schema(reserved(..))]` and cannot be used — reserving a key prevents reusing it for a different field
+  --> tests/compile_fail/derive_reserved_key_rename_all_collision.rs:11:5
+   |
+11 |     my_field: String,
+   |     ^^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_key_rename_all_collision.rs:15:18
+   |
+10 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+15 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_key_serde_alias.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_serde_alias.rs
@@ -1,0 +1,16 @@
+use nebula_schema::Schema;
+
+// A `#[serde(alias = "old")]` is an alternative wire key serde still deserializes
+// into the field, so reserving that key while a field aliases it would reintroduce
+// the misread the reservation guards against — the derive must reject it.
+#[derive(Schema, serde::Deserialize)]
+#[schema(reserved("old"))]
+#[allow(dead_code)]
+struct Bad {
+    #[serde(alias = "old")]
+    current: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_key_serde_alias.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_serde_alias.stderr
@@ -1,0 +1,18 @@
+error: key `old` is reserved by `#[schema(reserved(..))]` but a `#[serde(alias = "old")]` still deserializes it into this field — remove the alias or the reservation
+  --> tests/compile_fail/derive_reserved_key_serde_alias.rs:11:5
+   |
+11 |     current: String,
+   |     ^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_key_serde_alias.rs:15:18
+   |
+ 9 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+15 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_key_serde_rename.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_serde_rename.rs
@@ -1,0 +1,15 @@
+use nebula_schema::Schema;
+
+// The reservation is checked against the *resolved* wire key, not the raw field
+// ident: a field serde-renamed onto a reserved key still collides.
+#[derive(Schema, serde::Serialize)]
+#[schema(reserved("legacy"))]
+#[allow(dead_code)]
+struct Bad {
+    #[serde(rename = "legacy")]
+    current: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_key_serde_rename.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_key_serde_rename.stderr
@@ -1,0 +1,18 @@
+error: field key `legacy` is reserved by `#[schema(reserved(..))]` and cannot be used — reserving a key prevents reusing it for a different field
+  --> tests/compile_fail/derive_reserved_key_serde_rename.rs:10:5
+   |
+10 |     current: String,
+   |     ^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_key_serde_rename.rs:14:18
+   |
+ 8 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+14 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_reserved_wrong_form.rs
+++ b/crates/schema/tests/compile_fail/derive_reserved_wrong_form.rs
@@ -1,0 +1,14 @@
+use nebula_schema::Schema;
+
+// `reserved` is a list-form option; the assignment form is a usage error, and the
+// derive must say so (point at the list syntax, not claim the option is unknown).
+#[derive(Schema)]
+#[schema(reserved = "old_key")]
+#[allow(dead_code)]
+struct Bad {
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_reserved_wrong_form.stderr
+++ b/crates/schema/tests/compile_fail/derive_reserved_wrong_form.stderr
@@ -1,0 +1,18 @@
+error: #[schema(reserved)] requires list syntax: write `reserved("key")`, not `reserved = "key"`
+ --> tests/compile_fail/derive_reserved_wrong_form.rs:6:10
+  |
+6 | #[schema(reserved = "old_key")]
+  |          ^^^^^^^^
+
+error[E0599]: no associated function or constant named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_reserved_wrong_form.rs:13:18
+   |
+ 8 | struct Bad {
+   | ---------- associated function or constant `schema` not found for this struct
+...
+13 |     let _ = Bad::schema();
+   |                  ^^^^^^ associated function or constant not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -190,6 +190,28 @@ fn derive_reserved_keys_do_not_materialize_or_block_other_fields() {
     assert!(!keys.contains(&"v1_secret"));
 }
 
+#[derive(Schema)]
+#[schema(reserved("dropped"))]
+#[allow(dead_code)]
+struct ReservedMatchesSkippedField {
+    keep: String,
+    // A skipped field has no wire key, so reserving its name is not a collision —
+    // this pins the skip-before-key-collection ordering in the derive.
+    #[field(skip)]
+    dropped: u64,
+}
+
+#[test]
+fn derive_reserved_key_matching_a_skipped_field_is_allowed() {
+    let s = ReservedMatchesSkippedField::schema();
+    let keys: Vec<&str> = s.fields().iter().map(|f| f.key().as_str()).collect();
+    assert_eq!(
+        keys,
+        ["keep"],
+        "the skipped `dropped` field never reaches the schema"
+    );
+}
+
 // ── #[derive(EnumSelect)] ──────────────────────────────────────────────────
 
 #[derive(EnumSelect, Clone, Copy)]

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -171,6 +171,25 @@ fn derive_respects_skip() {
     assert_eq!(s.fields()[0].key().as_str(), "keep");
 }
 
+#[derive(Schema)]
+#[schema(reserved("legacy_token", "v1_secret"))]
+#[allow(dead_code)]
+struct WithReservedKeys {
+    name: String,
+    enabled: bool,
+}
+
+#[test]
+fn derive_reserved_keys_do_not_materialize_or_block_other_fields() {
+    let s = WithReservedKeys::schema();
+    let keys: Vec<&str> = s.fields().iter().map(|f| f.key().as_str()).collect();
+    // The real fields build normally — reserving unrelated keys is a no-op for them.
+    assert_eq!(keys, ["name", "enabled"]);
+    // The reserved keys are guard rails only: they are not materialized as fields.
+    assert!(!keys.contains(&"legacy_token"));
+    assert!(!keys.contains(&"v1_secret"));
+}
+
 // ── #[derive(EnumSelect)] ──────────────────────────────────────────────────
 
 #[derive(EnumSelect, Clone, Copy)]

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -212,6 +212,23 @@ fn derive_reserved_key_matching_a_skipped_field_is_allowed() {
     );
 }
 
+#[derive(Schema, serde::Deserialize)]
+#[schema(reserved("removed"))]
+#[allow(dead_code)]
+struct AliasDoesNotCollide {
+    // An alias that does NOT match a reserved key is allowed — only a collision
+    // is rejected, aliases are not blanket-forbidden on reserved-key structs.
+    #[serde(alias = "name_old")]
+    name: String,
+}
+
+#[test]
+fn derive_reserved_allows_a_non_colliding_serde_alias() {
+    let s = AliasDoesNotCollide::schema();
+    let keys: Vec<&str> = s.fields().iter().map(|f| f.key().as_str()).collect();
+    assert_eq!(keys, ["name"]);
+}
+
 // ── #[derive(EnumSelect)] ──────────────────────────────────────────────────
 
 #[derive(EnumSelect, Clone, Copy)]


### PR DESCRIPTION
## What & why

Step 7 part 3 of the nebula-schema evolution work (C13). Adds a Protobuf-style key reservation to `#[derive(Schema)]`:

```rust
#[derive(Schema)]
#[schema(reserved("old_token", "v1_key"))]
struct Config { name: String } // a field resolving to a reserved key → compile_error!
```

Reusing a **removed** field's key for a *different* field would misread documents written before the removal (the old data still carries that key). Reserving the key forbids any field from using it, caught at macro expansion.

## Design

- **Resolved-key check.** The reservation is compared against the *resolved wire key*, so a `#[serde(rename = "..")]` or container `#[serde(rename_all = ..)]` that maps a field onto a reserved key still collides — not the raw ident.
- **`#[field(skip)]` / `#[serde(skip)]` fields are exempt** — they have no wire key, so reserving their name is not a collision.
- **Validation at expansion.** A reserved literal that is not a valid `FieldKey` is rejected (a typo'd reservation would be silently inert); the same key reserved twice is rejected; the wrong `reserved = "x"` form gets a targeted "use list syntax" error rather than "unknown option".
- **Compile-time only.** The reservation is a guard rail on this struct's definition; it is not recorded in the built schema (documented).

## Tests & gates

- 4 trybuild compile-fail cases: direct collision, invalid reserved literal, container `rename_all` collision (proves resolved-key checking), duplicate reservation, wrong-form usage.
- 2 positive tests: reserving unrelated keys is a no-op; a skipped field may share a reserved key.
- crate + derive-macro docs (incl. a `compile_fail` doctest).
- Green: `nextest` 515/515, `clippy --all-targets --all-features -D warnings`, `fmt --check`, `rustdoc -D warnings`, doctests 15/0, `cargo check --workspace --all-features`.

## Review

Adversarial multi-agent review (macro-soundness / design / tests, each finding independently verified). 4 confirmed findings — all fixed in the second commit (wrong-form error, duplicate detection, the rename_all + skipped-field test coverage, the compile-time-scope doc note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `#[schema(reserved(...))]` attribute to declare field keys that cannot be used by struct fields; compile-time validation detects collisions including with renamed fields.

* **Documentation**
  * Updated documentation with reserved field key usage and compile-fail examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->