### PR TITLE
feat(schema): opt-in keyed secret commitment (tag 0x0A) for content-addressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,6 +3928,7 @@ dependencies = [
  "nebula-validator",
  "pretty_assertions",
  "proptest",
+ "rand 0.10.1",
  "regex",
  "rstest",
  "schemars",

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -29,6 +29,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 indexmap = { workspace = true }
 blake3 = { workspace = true }
+rand = { workspace = true }
 smallvec = { workspace = true }
 regex = { workspace = true }
 schemars = { version = "1.0", optional = true }
@@ -70,6 +71,10 @@ path = "tests/proptest/serde_preserves.rs"
 [[test]]
 name = "proptest_canonical_bytes"
 path = "tests/proptest/canonical_bytes.rs"
+
+[[test]]
+name = "proptest_canonical_bytes_committing"
+path = "tests/proptest/canonical_bytes_committing.rs"
 
 [[test]]
 name = "evolution_wire_snapshot"

--- a/crates/schema/src/commitment.rs
+++ b/crates/schema/src/commitment.rs
@@ -30,6 +30,7 @@
 
 use std::fmt;
 
+use rand::Rng as _;
 use zeroize::Zeroizing;
 
 use crate::secret::SecretValue;
@@ -63,13 +64,24 @@ impl CommitmentKey {
     /// Mint a fresh process-scoped key from the thread CSPRNG. Use in production.
     #[must_use]
     pub fn ephemeral() -> Self {
-        Self(Zeroizing::new(rand::random::<[u8; 32]>()))
+        // Fill in place: minting the key as a by-value temporary would leave an
+        // un-zeroized copy in the return slot. Matches the repo's key-gen idiom.
+        let mut key = Zeroizing::new([0u8; 32]);
+        rand::rng().fill_bytes(key.as_mut());
+        Self(key)
     }
 
-    /// Construct a key from fixed bytes — **tests only**. The name is the
-    /// structural signal: a fixed/persisted key turns every commitment under it
-    /// back into a brute-forceable oracle, so there is deliberately no
-    /// `from_bytes` / `persistent` constructor for production use.
+    /// Construct a key from fixed bytes — **tests only**, and `#[doc(hidden)]` so
+    /// it is not part of the public API surface.
+    ///
+    /// A fixed (let alone hardcoded) key turns every commitment under it back into
+    /// a brute-forceable oracle — the exact failure the default `secret.not_hashable`
+    /// rejection prevents. Production code must use [`CommitmentKey::ephemeral`];
+    /// there is deliberately no `from_bytes` / `persistent` constructor. (A cargo
+    /// `test-util` feature is intentionally not used — it is banned in this
+    /// workspace — and `#[cfg(test)]` would hide this from integration tests that
+    /// legitimately need a deterministic key.)
+    #[doc(hidden)]
     #[must_use]
     pub fn for_testing(key: [u8; 32]) -> Self {
         Self(Zeroizing::new(key))

--- a/crates/schema/src/commitment.rs
+++ b/crates/schema/src/commitment.rs
@@ -1,0 +1,268 @@
+//! Opt-in **keyed commitment** of secret material for content-addressing.
+//!
+//! By default [`FieldValue::canonical_bytes`](crate::FieldValue::canonical_bytes)
+//! *rejects* a secret-bearing value (`secret.not_hashable`): a deterministic,
+//! unkeyed hash of a low-entropy secret is a brute-forceable confirmation oracle.
+//! When a caller genuinely needs a dedup / content key for a structure that
+//! contains a secret, the committing variants
+//! ([`FieldValue::canonical_bytes_committing`](crate::FieldValue::canonical_bytes_committing))
+//! emit a **keyed** commitment instead — `blake3::keyed_hash` under a
+//! [`CommitmentKey`] the attacker does not have, so the digest is a PRF output,
+//! not an invertible hash of the secret.
+//!
+//! # Security model (what this does and does NOT give you)
+//!
+//! - A [`CommitmentKey`] is **process-scoped and ephemeral** by design:
+//!   [`CommitmentKey::ephemeral`] mints a fresh 256-bit CSPRNG key held only in
+//!   memory (zeroized on drop, never serialized, cloned, or logged). Commitments
+//!   are therefore comparable **only within the lifetime of one key** — they are
+//!   meaningless across process restarts and are *not* a durable address (hence
+//!   [`CommitmentId`] is deliberately distinct from
+//!   [`ContentId`](crate::ContentId) and is not serializable).
+//! - Equality of two commitments under one key reveals only "these two secrets
+//!   are equal". That is the same fact [`SecretValue`]'s constant-time `PartialEq`
+//!   already answers; do **not** use a commitment as an equality oracle against
+//!   attacker-supplied candidates.
+//! - A single key gives intra-process equality across *all* commitments it
+//!   produces — it is **not** per-tenant. A caller that must keep tenants
+//!   mutually unlinkable has to derive a separate [`CommitmentKey`] per tenant
+//!   (key derivation belongs to `nebula-credential`, not here).
+
+use std::fmt;
+
+use zeroize::Zeroizing;
+
+use crate::secret::SecretValue;
+use crate::value::VALUE_CANON_VERSION;
+
+/// The reserved value-canon tag for an opt-in secret commitment (see the tag
+/// table in `crate::value`). A commitment frame is `TAG + kind(1) + digest(32)`.
+pub(crate) const TAG_SECRET_COMMITMENT: u8 = 0x0A;
+
+/// Domain separator folded *inside* the keyed hash (distinct from the value-canon
+/// domain so a commitment preimage can never alias an ordinary canon stream).
+const SECRET_COMMIT_DOMAIN: &[u8] = b"nbschema-secret-commit-v";
+
+/// Per-variant discriminator, folded into the keyed hash so a `String("abc")` and
+/// a `Bytes(b"abc")` — identical raw bytes — commit to different digests.
+const COMMIT_KIND_STRING: u8 = 0x01;
+const COMMIT_KIND_BYTES: u8 = 0x02;
+
+/// A process-scoped, ephemeral 256-bit key for [secret commitments](self).
+///
+/// The key is the entire security property: with it a commitment is just a hash
+/// of the secret, so it must never be persisted, serialized, cloned into another
+/// scope, or logged. The type enforces that structurally — it has no
+/// `Serialize`/`Deserialize`/`Clone`/`Display`, a redacted `Debug`, and is
+/// zeroized on drop. The only constructor that takes raw bytes is
+/// [`CommitmentKey::for_testing`], whose name announces that production code must
+/// use [`CommitmentKey::ephemeral`] instead.
+pub struct CommitmentKey(Zeroizing<[u8; 32]>);
+
+impl CommitmentKey {
+    /// Mint a fresh process-scoped key from the thread CSPRNG. Use in production.
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self(Zeroizing::new(rand::random::<[u8; 32]>()))
+    }
+
+    /// Construct a key from fixed bytes — **tests only**. The name is the
+    /// structural signal: a fixed/persisted key turns every commitment under it
+    /// back into a brute-forceable oracle, so there is deliberately no
+    /// `from_bytes` / `persistent` constructor for production use.
+    #[must_use]
+    pub fn for_testing(key: [u8; 32]) -> Self {
+        Self(Zeroizing::new(key))
+    }
+
+    /// Borrow the raw key for `blake3::keyed_hash` (crate-internal only).
+    pub(crate) fn raw(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CommitmentKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CommitmentKey(<ephemeral>)")
+    }
+}
+
+/// A 32-byte, **process-scoped** secret-commitment digest.
+///
+/// Distinct from [`ContentId`](crate::ContentId) by type so it can never be
+/// stored where a durable content address is expected: it is keyed by an
+/// ephemeral [`CommitmentKey`], so it is meaningless outside that key's lifetime
+/// and is intentionally **not** serializable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CommitmentId([u8; 32]);
+
+impl CommitmentId {
+    /// Construct from a raw digest (crate-internal: produced by the keyed hash).
+    pub(crate) fn from_digest(digest: [u8; 32]) -> Self {
+        Self(digest)
+    }
+
+    /// Borrow the raw 32-byte digest.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for CommitmentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Whether a secret-bearing value may enter a canonical encoding, and how.
+///
+/// Threaded through the single `write_canonical` traversal so the default
+/// (`Reject`) and committing (`Keyed`) paths share one code path. A future
+/// scheme (e.g. a tenant-domained variant) is an additive enum arm, not a new
+/// public method.
+pub(crate) enum SecretCommitmentPolicy<'k> {
+    /// Secrets have no canonical form — return `secret.not_hashable`.
+    Reject,
+    /// Commit each secret with `blake3::keyed_hash` under this key.
+    Keyed(&'k CommitmentKey),
+}
+
+/// Write a keyed secret-commitment frame (`TAG 0x0A + kind + digest(32)`) into
+/// `out`. The plaintext and its length live only inside a `Zeroizing` preimage
+/// that is wiped immediately after hashing — the visible footprint is a
+/// fixed-width 34-byte frame with no cleartext length.
+pub(crate) fn write_secret_commitment(
+    secret: &SecretValue,
+    key: &CommitmentKey,
+    out: &mut Vec<u8>,
+) {
+    let (kind, raw): (u8, &[u8]) = match secret {
+        SecretValue::String(s) => (COMMIT_KIND_STRING, s.expose().as_bytes()),
+        SecretValue::Bytes(b) => (COMMIT_KIND_BYTES, b.expose()),
+    };
+
+    // Preimage (invisible to observers; hashed under the key):
+    //   domain || VALUE_CANON_VERSION || kind || len(u64) || raw
+    // Fixed-width framing before `raw` keeps the encoding injective; the length
+    // is inside the hash, never emitted as cleartext.
+    let mut preimage: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::with_capacity(
+        SECRET_COMMIT_DOMAIN.len() + 11 + raw.len(),
+    ));
+    preimage.extend_from_slice(SECRET_COMMIT_DOMAIN);
+    preimage.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+    preimage.push(kind);
+    preimage.extend_from_slice(&(raw.len() as u64).to_be_bytes());
+    preimage.extend_from_slice(raw);
+
+    let digest = blake3::keyed_hash(key.raw(), &preimage);
+
+    out.push(TAG_SECRET_COMMITMENT);
+    out.push(kind);
+    out.extend_from_slice(digest.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FieldValue;
+
+    fn fixed_key() -> CommitmentKey {
+        CommitmentKey::for_testing([7u8; 32])
+    }
+
+    #[test]
+    fn ephemeral_keys_differ() {
+        // Two freshly minted keys must commit the same secret differently.
+        let secret = FieldValue::SecretLiteral(SecretValue::string("hunter2".to_owned()));
+        let a = secret
+            .canonical_bytes_committing(&CommitmentKey::ephemeral())
+            .expect("commit");
+        let b = secret
+            .canonical_bytes_committing(&CommitmentKey::ephemeral())
+            .expect("commit");
+        assert_ne!(a, b, "distinct keys must produce distinct commitments");
+    }
+
+    #[test]
+    fn key_debug_does_not_leak_bytes() {
+        let key = CommitmentKey::for_testing([0xABu8; 32]);
+        let rendered = format!("{key:?}");
+        assert_eq!(rendered, "CommitmentKey(<ephemeral>)");
+        assert!(!rendered.contains("ab"), "Debug must not print key bytes");
+    }
+
+    #[test]
+    fn string_and_bytes_with_same_raw_commit_differently() {
+        let key = fixed_key();
+        let as_string = FieldValue::SecretLiteral(SecretValue::string("abc".to_owned()))
+            .canonical_bytes_committing(&key)
+            .expect("commit");
+        let as_bytes = FieldValue::SecretLiteral(SecretValue::bytes(b"abc".to_vec()))
+            .canonical_bytes_committing(&key)
+            .expect("commit");
+        assert_ne!(
+            as_string, as_bytes,
+            "kind discriminator must domain-separate String from Bytes"
+        );
+    }
+
+    #[test]
+    fn same_key_same_secret_is_deterministic() {
+        let key = fixed_key();
+        let secret = FieldValue::SecretLiteral(SecretValue::string("s".to_owned()));
+        assert_eq!(
+            secret.canonical_bytes_committing(&key).expect("commit"),
+            secret.canonical_bytes_committing(&key).expect("commit"),
+        );
+    }
+
+    #[test]
+    fn commitment_frame_shape_and_golden_hash() {
+        // Freeze the exact frame so any preimage/format drift is caught.
+        let key = CommitmentKey::for_testing([0u8; 32]);
+        let bytes = FieldValue::SecretLiteral(SecretValue::string("x".to_owned()))
+            .canonical_bytes_committing(&key)
+            .expect("commit");
+        // outer canon: domain(16) + version(2) + TAG(1) + kind(1) + digest(32) = 52
+        assert_eq!(bytes.len(), 52, "frame size");
+        assert_eq!(&bytes[0..16], b"nbschema-value-v", "outer canon domain");
+        assert_eq!(&bytes[16..18], &[0x00, 0x01], "VALUE_CANON_VERSION = 1");
+        assert_eq!(bytes[18], TAG_SECRET_COMMITMENT, "tag 0x0A");
+        assert_eq!(bytes[19], COMMIT_KIND_STRING, "kind = string");
+
+        let mut preimage = SECRET_COMMIT_DOMAIN.to_vec();
+        preimage.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+        preimage.push(COMMIT_KIND_STRING);
+        preimage.extend_from_slice(&1u64.to_be_bytes());
+        preimage.push(b'x');
+        let expected = blake3::keyed_hash(&[0u8; 32], &preimage);
+        assert_eq!(&bytes[20..52], expected.as_bytes(), "commitment digest");
+    }
+
+    #[test]
+    fn plaintext_never_appears_in_commitment() {
+        let key = fixed_key();
+        let bytes = FieldValue::SecretLiteral(SecretValue::string("hunter2".to_owned()))
+            .canonical_bytes_committing(&key)
+            .expect("commit");
+        assert!(
+            bytes.windows(7).all(|w| w != b"hunter2"),
+            "the plaintext secret must never appear in the commitment"
+        );
+    }
+
+    #[test]
+    fn empty_secret_commits_to_full_width_frame() {
+        let key = fixed_key();
+        let bytes = FieldValue::SecretLiteral(SecretValue::string(String::new()))
+            .canonical_bytes_committing(&key)
+            .expect("commit");
+        // No special-case: an empty secret still yields a 52-byte frame (no
+        // length side-channel distinguishing empty from non-empty).
+        assert_eq!(bytes.len(), 52);
+    }
+}

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -139,6 +139,8 @@ extern crate self as nebula_schema;
 
 /// Typed-closure builder DSL (leaf aliases + Object/List/Group composite builders).
 pub mod builder;
+/// Opt-in keyed commitment of secret material for content-addressing.
+pub mod commitment;
 /// Schema-compatibility check: structural width-subtyping (TypeDAG T1).
 pub mod compat;
 /// Builds the validator predicate context (visibility/required) from schema fields + values.
@@ -193,6 +195,7 @@ pub use builder::{
     BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
     ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,
 };
+pub use commitment::{CommitmentId, CommitmentKey};
 pub use compat::{
     Assignability, SchemaIncompat, UnknownReason, explain_assignable, is_assignable_schema,
 };

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::{
+    commitment::{CommitmentId, CommitmentKey, SecretCommitmentPolicy, write_secret_commitment},
     expression::Expression,
     key::FieldKey,
     path::{FieldPath, PathSegment},
@@ -271,7 +272,36 @@ impl FieldValue {
         let mut out = Vec::new();
         out.extend_from_slice(CANON_DOMAIN);
         out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
-        self.write_canonical(&mut out, 0)?;
+        self.write_canonical(&mut out, 0, &SecretCommitmentPolicy::Reject)?;
+        Ok(out)
+    }
+
+    /// Canonical bytes with an opt-in **keyed commitment** for secrets.
+    ///
+    /// Identical to [`canonical_bytes`](Self::canonical_bytes) except a
+    /// [`SecretLiteral`](Self::SecretLiteral) is encoded as a `blake3::keyed_hash`
+    /// commitment under `key` (see [`crate::commitment`]) instead of returning
+    /// `secret.not_hashable`. The result is **process-scoped**: it is comparable
+    /// only against other commitments made with the *same* `key`, and is not a
+    /// durable address (see [`content_id_committing`](Self::content_id_committing)).
+    ///
+    /// # Errors
+    ///
+    /// `value.non_canonical_float` for a non-finite float, or `recursion_limit`
+    /// for an over-deep value — but **never** `secret.not_hashable`.
+    #[must_use = "the committing bytes are computed for a dedup/content key; discarding wastes the work"]
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn canonical_bytes_committing(
+        &self,
+        key: &CommitmentKey,
+    ) -> Result<Vec<u8>, crate::error::ValidationError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(CANON_DOMAIN);
+        out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+        self.write_canonical(&mut out, 0, &SecretCommitmentPolicy::Keyed(key))?;
         Ok(out)
     }
 
@@ -293,6 +323,32 @@ impl FieldValue {
         Ok(ContentId(blake3::hash(&self.canonical_bytes()?).into()))
     }
 
+    /// Process-scoped [`CommitmentId`] for a secret-bearing value — the keyed
+    /// analogue of [`content_id`](Self::content_id).
+    ///
+    /// The outer digest is also `blake3::keyed_hash` under `key`, so the id is
+    /// opaque and meaningful only within the key's lifetime. It is a distinct
+    /// type from [`ContentId`] precisely so it cannot be stored where a durable
+    /// content address is expected.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`canonical_bytes_committing`](Self::canonical_bytes_committing).
+    #[must_use = "the commitment id is computed for a dedup key; discarding wastes the work"]
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn content_id_committing(
+        &self,
+        key: &CommitmentKey,
+    ) -> Result<CommitmentId, crate::error::ValidationError> {
+        let bytes = self.canonical_bytes_committing(key)?;
+        Ok(CommitmentId::from_digest(
+            blake3::keyed_hash(key.raw(), &bytes).into(),
+        ))
+    }
+
     /// Recursive canonical writer for a [`FieldValue`].
     ///
     /// `depth` bounds the recursion at [`MAX_VALUE_DEPTH`] (shared with
@@ -309,6 +365,7 @@ impl FieldValue {
         &self,
         out: &mut Vec<u8>,
         depth: u8,
+        policy: &SecretCommitmentPolicy<'_>,
     ) -> Result<(), crate::error::ValidationError> {
         if depth > MAX_VALUE_DEPTH {
             return Err(canon_recursion_limit());
@@ -316,18 +373,19 @@ impl FieldValue {
         match self {
             // A `Literal` carries a raw JSON value (including `Array`/`Object`
             // when keys were not valid `FieldKey`s — `from_json` preserves them),
-            // canonicalized by the JSON writer below.
+            // canonicalized by the JSON writer below. Raw JSON cannot hold a
+            // secret, so the commitment policy does not reach it.
             Self::Literal(value) => write_canon_json(value, out, depth)?,
             Self::Expression(expr) => {
                 out.push(TAG_EXPRESSION);
                 write_lp(out, expr.source().as_bytes());
             },
-            Self::Object(map) => write_canon_object(map, out, depth)?,
+            Self::Object(map) => write_canon_object(map, out, depth, policy)?,
             Self::List(items) => {
                 out.push(TAG_LIST);
                 write_varint(out, items.len() as u64);
                 for item in items {
-                    item.write_canonical(out, depth.saturating_add(1))?;
+                    item.write_canonical(out, depth.saturating_add(1), policy)?;
                 }
             },
             Self::Mode { mode, value } => {
@@ -336,13 +394,18 @@ impl FieldValue {
                 match value {
                     Some(inner) => {
                         out.push(1);
-                        inner.write_canonical(out, depth.saturating_add(1))?;
+                        inner.write_canonical(out, depth.saturating_add(1), policy)?;
                     },
                     None => out.push(0),
                 }
             },
-            // Secrets never enter a content hash (see `canonical_bytes` docs).
-            Self::SecretLiteral(_) => return Err(secret_not_hashable()),
+            // A secret has no plaintext canonical form. By default it is rejected
+            // (`secret.not_hashable`); the opt-in `Keyed` policy commits it with a
+            // keyed hash instead (see `crate::commitment`).
+            Self::SecretLiteral(secret) => match policy {
+                SecretCommitmentPolicy::Reject => return Err(secret_not_hashable()),
+                SecretCommitmentPolicy::Keyed(key) => write_secret_commitment(secret, key, out),
+            },
         }
         Ok(())
     }
@@ -376,11 +439,11 @@ const TAG_LIST: u8 = 0x06;
 const TAG_OBJECT: u8 = 0x07;
 const TAG_EXPRESSION: u8 = 0x08;
 const TAG_MODE: u8 = 0x09;
-// 0x0A is reserved for an opt-in secret commitment, deferred. When implemented
-// it MUST use a keyed / domain-separated hash (e.g. `blake3::keyed_hash` with an
-// ephemeral per-process key), never the unkeyed `blake3::hash` used for content
-// ids — an unkeyed hash of a low-entropy secret is a brute-forceable oracle,
-// the exact property `secret.not_hashable` exists to prevent.
+// 0x0A is the opt-in secret commitment (`crate::commitment::TAG_SECRET_COMMITMENT`).
+// It uses `blake3::keyed_hash` under an ephemeral per-process `CommitmentKey`,
+// NEVER the unkeyed `blake3::hash` used for content ids — an unkeyed hash of a
+// low-entropy secret is a brute-forceable oracle, the exact property
+// `secret.not_hashable` exists to prevent.
 const TAG_JSON_ARRAY: u8 = 0x0B;
 const TAG_JSON_OBJECT: u8 = 0x0C;
 
@@ -461,6 +524,7 @@ fn write_canon_object(
     map: &IndexMap<FieldKey, FieldValue>,
     out: &mut Vec<u8>,
     depth: u8,
+    policy: &SecretCommitmentPolicy<'_>,
 ) -> Result<(), crate::error::ValidationError> {
     out.push(TAG_OBJECT);
     let mut entries: Vec<(&FieldKey, &FieldValue)> = map.iter().collect();
@@ -468,7 +532,7 @@ fn write_canon_object(
     write_varint(out, entries.len() as u64);
     for (key, value) in entries {
         write_lp(out, key.as_str().as_bytes());
-        value.write_canonical(out, depth.saturating_add(1))?;
+        value.write_canonical(out, depth.saturating_add(1), policy)?;
     }
     Ok(())
 }
@@ -889,7 +953,30 @@ impl FieldValues {
         let mut out = Vec::new();
         out.extend_from_slice(CANON_DOMAIN);
         out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
-        write_canon_object(&self.0, &mut out, 0)?;
+        write_canon_object(&self.0, &mut out, 0, &SecretCommitmentPolicy::Reject)?;
+        Ok(out)
+    }
+
+    /// Canonical bytes with an opt-in keyed commitment for secrets — the store
+    /// analogue of [`FieldValue::canonical_bytes_committing`]. Process-scoped to
+    /// `key`; see [`crate::commitment`] for the security model.
+    ///
+    /// # Errors
+    ///
+    /// `value.non_canonical_float` or `recursion_limit` — never `secret.not_hashable`.
+    #[must_use = "the committing bytes are computed for a dedup/content key; discarding wastes the work"]
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn canonical_bytes_committing(
+        &self,
+        key: &CommitmentKey,
+    ) -> Result<Vec<u8>, crate::error::ValidationError> {
+        let mut out = Vec::new();
+        out.extend_from_slice(CANON_DOMAIN);
+        out.extend_from_slice(&VALUE_CANON_VERSION.to_be_bytes());
+        write_canon_object(&self.0, &mut out, 0, &SecretCommitmentPolicy::Keyed(key))?;
         Ok(out)
     }
 
@@ -904,6 +991,27 @@ impl FieldValues {
     )]
     pub fn content_id(&self) -> Result<ContentId, crate::error::ValidationError> {
         Ok(ContentId(blake3::hash(&self.canonical_bytes()?).into()))
+    }
+
+    /// Process-scoped [`CommitmentId`] — the keyed analogue of
+    /// [`content_id`](Self::content_id). See [`crate::commitment`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`canonical_bytes_committing`](Self::canonical_bytes_committing).
+    #[must_use = "the commitment id is computed for a dedup key; discarding wastes the work"]
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn content_id_committing(
+        &self,
+        key: &CommitmentKey,
+    ) -> Result<CommitmentId, crate::error::ValidationError> {
+        let bytes = self.canonical_bytes_committing(key)?;
+        Ok(CommitmentId::from_digest(
+            blake3::keyed_hash(key.raw(), &bytes).into(),
+        ))
     }
 }
 

--- a/crates/schema/tests/proptest/canonical_bytes_committing.rs
+++ b/crates/schema/tests/proptest/canonical_bytes_committing.rs
@@ -1,0 +1,80 @@
+//! Proptest: algebraic laws of the opt-in keyed secret commitment
+//! (`FieldValue::canonical_bytes_committing`).
+//!
+//! The committing path must (1) be byte-identical to the default canon on any
+//! secret-free value — the key path is only entered for a `SecretLiteral` — and
+//! (2) be a deterministic, injective PRF over secrets under a fixed key.
+
+use nebula_schema::{CommitmentKey, FieldKey, FieldValue, FieldValues, SecretValue};
+use proptest::prelude::*;
+use serde_json::{Value, json};
+
+/// Bounded secret-free JSON (same domain as `FieldValue::from_json`).
+fn json_strategy() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(|n| json!(n)),
+        "[a-z]{0,6}".prop_map(Value::String),
+    ];
+    leaf.prop_recursive(3, 16, 4, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..4).prop_map(Value::Array),
+            prop::collection::hash_map("[a-z]{1,4}", inner, 0..4)
+                .prop_map(|m| Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+fn key() -> CommitmentKey {
+    CommitmentKey::for_testing([42u8; 32])
+}
+
+proptest! {
+    /// On any secret-free value the committing path is byte-identical to the
+    /// default canon: the key is only consulted for a `SecretLiteral`.
+    #[test]
+    fn committing_equals_default_when_secret_free(v in json_strategy()) {
+        let fv = FieldValue::from_json(v);
+        let default = fv.canonical_bytes().expect("secret-free, finite");
+        let committed = fv.canonical_bytes_committing(&key()).expect("secret-free, finite");
+        prop_assert_eq!(default, committed);
+    }
+
+    /// A committed secret is deterministic under a fixed key.
+    #[test]
+    fn secret_commit_is_deterministic(s in "[a-zA-Z0-9]{0,32}") {
+        let fv = FieldValue::SecretLiteral(SecretValue::string(s));
+        let k = key();
+        prop_assert_eq!(
+            fv.canonical_bytes_committing(&k).expect("commit"),
+            fv.canonical_bytes_committing(&k).expect("commit"),
+        );
+    }
+
+    /// Distinct secrets commit to distinct bytes under one key (PRF injectivity;
+    /// a collision here is a 2^-256 event and treated as failure).
+    #[test]
+    fn distinct_secrets_commit_differently(a in "[a-z]{1,16}", b in "[a-z]{1,16}") {
+        prop_assume!(a != b);
+        let k = key();
+        let ca = FieldValue::SecretLiteral(SecretValue::string(a))
+            .canonical_bytes_committing(&k).expect("commit");
+        let cb = FieldValue::SecretLiteral(SecretValue::string(b))
+            .canonical_bytes_committing(&k).expect("commit");
+        prop_assert_ne!(ca, cb);
+    }
+
+    /// The default (rejecting) path is unaffected by the new policy threading: a
+    /// secret-bearing store still has no canon.
+    #[test]
+    fn default_still_rejects_secret_in_store(s in "[a-z]{0,16}") {
+        let mut values = FieldValues::new();
+        values.set(
+            FieldKey::new("k").expect("valid key"),
+            FieldValue::SecretLiteral(SecretValue::string(s)),
+        );
+        prop_assert!(values.canonical_bytes().is_err(), "secret store has no default canon");
+        prop_assert!(values.canonical_bytes_committing(&key()).is_ok(), "but commits under a key");
+    }
+}


### PR DESCRIPTION
## What & why

Step 6 of the nebula-schema fix-plan. `FieldValue::canonical_bytes()` **rejects** a secret-bearing value by default (`secret.not_hashable`) — an unkeyed hash of a low-entropy secret is a brute-forceable confirmation oracle. But a caller sometimes genuinely needs a dedup / content key for a structure that *contains* a secret. This adds an **opt-in keyed commitment** that fills the reserved tag `0x0A`:

```rust
let key = CommitmentKey::ephemeral();                  // 256-bit, process-scoped
let id  = values.content_id_committing(&key)?;          // CommitmentId, not ContentId
```

Each `SecretLiteral` is committed with `blake3::keyed_hash` under `key` — a PRF output, not an invertible hash of the secret.

## Design (panel + adversarial abuse-case analysis)

- **`CommitmentKey`** — `Zeroizing<[u8;32]>`, `ephemeral()` (CSPRNG, filled in place) / `for_testing()` (`#[doc(hidden)]`). No `Clone`/`Serialize`/`Deserialize`/`Display`; redacted `Debug`; zeroized on drop. There is deliberately **no production constructor that takes raw key bytes** — a fixed/persisted key re-creates the oracle.
- **`CommitmentId`** — a distinct type from the durable [`ContentId`] and **not serializable**, so a process-scoped commitment can never be stored where a durable content address is expected.
- **Encoding** — frame `TAG 0x0A | kind | keyed_hash(32)`; the keyed-hash preimage is `domain | VALUE_CANON_VERSION | kind | len(u64) | raw`, all folded *inside* the hash. Fixed-width 34-byte frame: no cleartext length, `String("abc")` ≠ `Bytes(b"abc")` (kind byte), empty secrets indistinguishable in width, version bump re-keys.
- **One traversal** — a `SecretCommitmentPolicy { Reject, Keyed }` threads through the existing `write_canonical` recursion; the default path passes `Reject` (byte-identical behavior), committing passes `Keyed`. A future tenant-domained scheme is an additive enum arm.

### Security scope (documented in the module)

A `CommitmentKey` gives equality only **within its lifetime** — commitments are meaningless across process restarts and are not a durable address. A single key is **not per-tenant**: a caller needing tenant isolation derives a per-tenant key (key derivation belongs to `nebula-credential`). This is a documented hazard; the policy enum keeps a tenant-domained variant additive.

## Tests & gates

- Unit (key Debug redaction, kind disambiguation, determinism, golden-frame hash freeze, plaintext-never-appears, empty-secret width) + 4 property laws (secret-free committing == default, determinism, injectivity, default-still-rejects).
- Green: `nextest` 527/527, `clippy --all-targets --all-features -D warnings`, `fmt`, `rustdoc -D warnings`, `cargo-deny` (new `rand` dep clean), `cargo check --workspace --all-features`.

## Review

A design panel (3 API designs + adversarial security analyst) produced the spec; an adversarial implementation review (crypto-correctness / key-&-secret-leak / abuse-case-coverage / policy-soundness, each finding independently verified) found **0 crypto defects** and 2 hardening items — both fixed in the second commit (in-place key zeroization; `#[doc(hidden)]` on `for_testing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in keyed secret commitment scheme enabling content-addressing with secrets via secure keyed hashing and domain separation.

* **Tests**
  * Added property-based tests validating commitment functionality, including determinism, injectivity, and correct handling of empty secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->