### PR TITLE
refactor(schema)!: remove ComputedField.expression_source (write-only orphan)

### DIFF
--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -703,7 +703,6 @@ impl FileField {
 }
 
 define_field!(ComputedField {
-    expression_source: String = String::new(),
     returns: ComputedReturn = ComputedReturn::String,
 } expr: ExpressionMode::Required);
 
@@ -721,13 +720,6 @@ pub enum ComputedReturn {
 }
 
 impl ComputedField {
-    /// Set the expression source code.
-    #[must_use]
-    pub fn expression_source(mut self, src: impl Into<String>) -> Self {
-        self.expression_source = src.into();
-        self
-    }
-
     /// Set the return type hint.
     #[must_use]
     pub const fn returns(mut self, r: ComputedReturn) -> Self {

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__field_variants_wire_format.snap
@@ -126,7 +126,6 @@ expression: variants
     "type": "computed",
     "key": "comp",
     "expression": "required",
-    "expression_source": "",
     "returns": "string"
   },
   {

--- a/crates/schema/tests/validate_schema.rs
+++ b/crates/schema/tests/validate_schema.rs
@@ -258,7 +258,6 @@ fn computed_and_notice_expression_modes_are_normalized_after_deserialize() {
             {
                 "type": "computed",
                 "key": "calc",
-                "expression_source": "1 + 1",
                 "returns": "number",
                 "expression": "forbidden"
             },
@@ -274,6 +273,24 @@ fn computed_and_notice_expression_modes_are_normalized_after_deserialize() {
 
     assert_eq!(schema.fields()[0].expression(), &ExpressionMode::Required);
     assert_eq!(schema.fields()[1].expression(), &ExpressionMode::Forbidden);
+}
+
+#[test]
+fn computed_field_ignores_removed_expression_source_key() {
+    // `expression_source` was removed from `ComputedField` (it was a write-only
+    // orphan never read or evaluated). A document written before the removal must
+    // still deserialize — the stale key is ignored, not rejected.
+    let schema: Schema = serde_json::from_value(json!({
+        "fields": [{
+            "type": "computed",
+            "key": "calc",
+            "expression_source": "1 + 1",
+            "returns": "number"
+        }]
+    }))
+    .expect("a legacy computed field carrying expression_source still parses");
+    assert_eq!(schema.fields()[0].key().as_str(), "calc");
+    assert_eq!(schema.fields()[0].expression(), &ExpressionMode::Required);
 }
 
 // ── Type mismatch ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Step 8 (part 2) of the nebula-schema fix-plan (audit item **C8**). `ComputedField.expression_source` was a **write-only orphan**: a builder method set it, but nothing ever read or evaluated it.

A computed field's value comes entirely from the user-supplied `FieldValue::Expression` (`{"$expr": "..."}`), which is validated as expression-required and evaluated by the resolve pipeline. `expression_source` was a vestige of an abandoned "built-in expression" design — confirmed by an explore pass: **zero `.expression_source(` callers, zero reads** anywhere in the workspace, no engine evaluation.

This removes the dead field and its builder method. `ComputedField` keeps `returns` (the declared return type) and the `ExpressionMode::Required` invariant — i.e. "a field whose value must be a user-authored expression, evaluated at runtime, returning `returns`".

## Breaking change

The `expression_source` wire key is gone from `Field::Computed`. A document written before this **still deserializes** — serde ignores the now-unknown key (test `computed_field_ignores_removed_expression_source_key`). The `evolution_wire_snapshot` golden is updated to the new shape (`{type, key, expression, returns}`).

## Gates

`nextest` 538/538, `clippy --all-targets --all-features -D warnings`, `fmt`, `rustdoc -D warnings`, `cargo check --workspace --all-features` — all green; no cross-crate ripple (nothing constructed `ComputedField` with `expression_source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `expression_source` configuration option from the computed field builder API. The `returns()` method continues to support return-type hints on computed fields.

* **Tests**
  * Added backward-compatibility test confirming that schemas with the legacy `expression_source` field still deserialize correctly and maintain proper expression normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->