### PR TITLE
refactor(schema)!: collapse StringWidget to {Plain, Multiline} — semantic hint lives in InputHint

### DIFF
--- a/crates/schema/src/widget.rs
+++ b/crates/schema/src/widget.rs
@@ -1,6 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-/// Widget hints for `StringField`.
+/// Rendering **mode** for a `StringField` (single- vs multi-line).
+///
+/// The *semantic* kind of a string input (email, URL, date, color, …) lives in
+/// [`InputHint`](crate::InputHint), the single source of that hint — `StringWidget`
+/// carries only the line-mode (symmetric with [`SecretWidget`]). A field's
+/// semantic type and its line-mode are orthogonal: a multi-line markdown editor is
+/// `widget = Multiline` + `hint = InputHint::Markdown`.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -10,22 +16,6 @@ pub enum StringWidget {
     Plain,
     /// Multi-line text input.
     Multiline,
-    /// Email-oriented input.
-    Email,
-    /// URL-oriented input.
-    Url,
-    /// Masked UI input (not a secret store).
-    Password,
-    /// Phone number-oriented input.
-    Phone,
-    /// IP address-oriented input.
-    Ip,
-    /// Regex editor input.
-    Regex,
-    /// Markdown editor input.
-    Markdown,
-    /// Cron expression input.
-    Cron,
 }
 
 /// Widget hints for `SecretField`.

--- a/crates/schema/tests/compile_fail/secret_widget_mismatch.rs
+++ b/crates/schema/tests/compile_fail/secret_widget_mismatch.rs
@@ -1,3 +1,6 @@
 fn main() {
-    let _ = nebula_schema::Field::secret(nebula_schema::field_key!("token")).widget(nebula_schema::StringWidget::Email);
+    // A secret field's `.widget()` takes a `SecretWidget`, so passing a
+    // `StringWidget` is a type mismatch (the widgets are not interchangeable).
+    let _ = nebula_schema::Field::secret(nebula_schema::field_key!("token"))
+        .widget(nebula_schema::StringWidget::Plain);
 }

--- a/crates/schema/tests/compile_fail/secret_widget_mismatch.stderr
+++ b/crates/schema/tests/compile_fail/secret_widget_mismatch.stderr
@@ -1,10 +1,10 @@
 error[E0308]: mismatched types
- --> tests/compile_fail/secret_widget_mismatch.rs:2:85
+ --> tests/compile_fail/secret_widget_mismatch.rs:5:17
   |
-2 |     let _ = nebula_schema::Field::secret(nebula_schema::field_key!("token")).widget(nebula_schema::StringWidget::Email);
-  |                                                                              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `SecretWidget`, found `StringWidget`
-  |                                                                              |
-  |                                                                              arguments to this method are incorrect
+5 |         .widget(nebula_schema::StringWidget::Plain);
+  |          ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `SecretWidget`, found `StringWidget`
+  |          |
+  |          arguments to this method are incorrect
   |
 note: method defined here
  --> src/field.rs


### PR DESCRIPTION
## What & why

Step 11 of the nebula-schema fix-plan ("InputHint merge"). A `StringField` carried **two overlapping** string-rendering hints:

- **`InputHint`** — the full semantic hint: `Text / Email / Url / Password / Phone / Ip / Regex / Markdown / Cron / Date / DateTime / Time / Color / Duration / Uuid`.
- **`StringWidget`** — `Plain / Multiline` **plus** semantic variants `Email / Url / Password / Phone / Ip / Regex / Markdown / Cron` that **duplicated** InputHint's.

The duplication let a field contradict itself (`widget = Email` + `hint = Url`), and in practice only `StringWidget::{Plain, Multiline}` was ever used — the semantic variants were dead duplicates (verified: zero workspace usages except a compile-fail test; the macro only emits `Multiline`; JSON-Schema `format` comes from validation rules, not the widget).

## Change

Reduce `StringWidget` to `{Plain, Multiline}` — the line-**mode** only, symmetric with `SecretWidget`. The semantic **kind** of a string input now lives solely in `InputHint`. The two axes are orthogonal: a multi-line markdown editor is `widget = Multiline` + `hint = InputHint::Markdown`.

Breaking: removes 8 unused `StringWidget` variants. A document or code using one no longer compiles/deserializes that variant — but none existed. The `secret_widget_mismatch` compile-fail test (which used `StringWidget::Email` to prove the secret/string widget-type mismatch) now uses `::Plain`.

## Gates

`nextest` 541/541, `clippy --all-targets --all-features -D warnings`, `fmt`, `rustdoc -D warnings`, `cargo check --workspace --all-features` — all green; no cross-crate fallout. (cargo-semver-checks will flag the variant removal — intended, pre-1.0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)