### PR TITLE
feat(schema): field aliases — read_aliases ingest folding + write_alias projection

### DIFF
--- a/crates/schema/src/alias.rs
+++ b/crates/schema/src/alias.rs
@@ -1,0 +1,171 @@
+//! Field alias container — extra accepted input keys (read-aliases) and
+//! optional output key remapping (write-alias).
+//!
+//! This is a pure storage type; canonicalization is enforced at ingest in
+//! `validated.rs` and collision checks run at lint time in `lint.rs`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{error::ValidationError, key::FieldKey, path::FieldPath};
+
+/// Ordered set of read-alias keys for a single field.
+///
+/// # Serde
+///
+/// Serializes/deserializes transparently as a JSON array of strings.
+/// An empty set serializes as `[]` and is skipped in field wire output via
+/// `#[serde(skip_serializing_if = "FieldAliases::is_empty")]`.
+///
+/// # Ordering invariant
+///
+/// Iteration order equals insertion order (aliases are pushed sequentially).
+/// The resolver tries aliases in that order; the first one present in a
+/// submitted value map wins.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FieldAliases(Vec<FieldKey>);
+
+impl FieldAliases {
+    /// An empty alias set. Equivalent to `Default::default()`.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Build a validated alias set from an iterable of string-like values.
+    ///
+    /// Each item is validated as a [`FieldKey`] (code `alias.invalid_key`).
+    /// Intra-set duplicates are rejected with code `alias.duplicate`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `alias.invalid_key` if any item is not a valid field key, or
+    /// `alias.duplicate` if the same key appears more than once in the input.
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn new(
+        aliases: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<Self, ValidationError> {
+        let mut out = Vec::new();
+        let mut seen_strs: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for raw in aliases {
+            let raw = raw.as_ref();
+            let key = FieldKey::new(raw).map_err(|_| {
+                ValidationError::builder("alias.invalid_key")
+                    .at(FieldPath::root())
+                    .param("key", raw.to_owned())
+                    .message(format!(
+                        "alias `{raw}` is not a valid field key (must be ASCII alphanumeric/underscore, start with letter or underscore, max 64 chars)"
+                    ))
+                    .build()
+            })?;
+            if !seen_strs.insert(raw.to_owned()) {
+                return Err(ValidationError::builder("alias.duplicate")
+                    .at(FieldPath::root())
+                    .param("key", raw.to_owned())
+                    .message(format!(
+                        "alias `{raw}` appears more than once in the alias list"
+                    ))
+                    .build());
+            }
+            out.push(key);
+        }
+        Ok(Self(out))
+    }
+
+    /// Returns `true` when the alias list is empty.
+    #[must_use]
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Number of aliases.
+    #[must_use]
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Borrow the underlying alias slice.
+    #[must_use]
+    #[inline]
+    pub fn as_slice(&self) -> &[FieldKey] {
+        &self.0
+    }
+
+    /// Append a pre-validated key without re-checking.
+    ///
+    /// For use by schema builders and macro-generated code that has already
+    /// validated the key. Callers must ensure uniqueness themselves.
+    #[inline]
+    pub(crate) fn push_unchecked(&mut self, key: FieldKey) {
+        self.0.push(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_default_equivalence() {
+        assert_eq!(FieldAliases::empty(), FieldAliases::default());
+        assert!(FieldAliases::empty().is_empty());
+        assert_eq!(FieldAliases::empty().len(), 0);
+    }
+
+    #[test]
+    fn new_validates_keys() {
+        let err = FieldAliases::new(["has-dash"]).unwrap_err();
+        assert_eq!(err.code, "alias.invalid_key");
+        assert_eq!(
+            err.params
+                .iter()
+                .find(|(k, _)| k.as_ref() == "key")
+                .map(|(_, v)| v.as_str().unwrap()),
+            Some("has-dash")
+        );
+    }
+
+    #[test]
+    fn new_rejects_intra_set_duplicate() {
+        let err = FieldAliases::new(["foo", "foo"]).unwrap_err();
+        assert_eq!(err.code, "alias.duplicate");
+    }
+
+    #[test]
+    fn new_preserves_order() {
+        let aliases = FieldAliases::new(["b", "a", "c"]).unwrap();
+        let keys: Vec<&str> = aliases.as_slice().iter().map(FieldKey::as_str).collect();
+        assert_eq!(keys, ["b", "a", "c"]);
+    }
+
+    #[test]
+    fn serde_transparent_round_trip() {
+        let aliases = FieldAliases::new(["alpha", "beta"]).unwrap();
+        let wire = serde_json::to_value(&aliases).unwrap();
+        assert_eq!(wire, serde_json::json!(["alpha", "beta"]));
+        let back: FieldAliases = serde_json::from_value(wire).unwrap();
+        assert_eq!(back, aliases);
+    }
+
+    #[test]
+    fn serde_empty_round_trip() {
+        let aliases = FieldAliases::empty();
+        let wire = serde_json::to_value(&aliases).unwrap();
+        assert_eq!(wire, serde_json::json!([]));
+        let back: FieldAliases = serde_json::from_value(wire).unwrap();
+        assert_eq!(back, aliases);
+    }
+
+    #[test]
+    fn push_unchecked_appends() {
+        let mut aliases = FieldAliases::empty();
+        let key = FieldKey::new("foo").unwrap();
+        aliases.push_unchecked(key.clone());
+        assert_eq!(aliases.as_slice(), [key]);
+    }
+}

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -317,6 +317,15 @@ impl std::error::Error for ValidationReport {}
 /// A test in the schema crate guarantees every entry here is emittable from
 /// an integration test (see `tests/flow/all_error_codes.rs`).
 pub const STANDARD_CODES: &[&str] = &[
+    // alias subsystem
+    "alias.duplicate",
+    "alias.invalid_key",
+    "alias.scope_collision",
+    "alias.scope_duplicate",
+    "alias.self_collision",
+    "alias.write_collision",
+    "alias.write_on_secret",
+    "alias.write_scope_duplicate",
     // value validation — schema-owned structural code
     "required",
     "type_mismatch",

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -320,6 +320,7 @@ pub const STANDARD_CODES: &[&str] = &[
     // alias subsystem
     "alias.duplicate",
     "alias.invalid_key",
+    "alias.read_write_collision",
     "alias.scope_collision",
     "alias.scope_duplicate",
     "alias.self_collision",

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -57,6 +57,12 @@ macro_rules! define_field {
             /// Optional grouping name.
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub group: Option<String>,
+            /// Extra keys accepted on ingest in addition to `key` (additive, like `#[serde(alias)]`).
+            #[serde(default, skip_serializing_if = "crate::alias::FieldAliases::is_empty")]
+            pub read_aliases: crate::alias::FieldAliases,
+            /// Optional alternative key emitted on projection output (write-alias).
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub write_alias: Option<FieldKey>,
             /// Validation rules.
             #[serde(default, skip_serializing_if = "Vec::is_empty")]
             pub rules: Vec<Rule>,
@@ -80,6 +86,8 @@ macro_rules! define_field {
                     required: RequiredMode::default(),
                     expression: $expr_dflt,
                     group: None,
+                    read_aliases: crate::alias::FieldAliases::empty(),
+                    write_alias: None,
                     rules: Vec::new(),
                     transformers: Vec::new(),
                     $($extra: $dflt,)*
@@ -238,6 +246,99 @@ macro_rules! define_field {
             #[must_use]
             pub fn with_transformer(mut self, transformer: Transformer) -> Self {
                 self.transformers.push(transformer);
+                self
+            }
+
+            /// Append a single validated read-alias key.
+            ///
+            /// Validates the supplied string as a [`FieldKey`] and appends it to
+            /// [`read_aliases`](Self::read_aliases). Returns `Err` with code
+            /// `alias.invalid_key` when the key fails validation.
+            ///
+            /// # Errors
+            ///
+            /// Returns `alias.invalid_key` when `alias` is not a valid field key.
+            #[must_use = "builder: discard only if the error is intentionally ignored"]
+            #[expect(
+                clippy::result_large_err,
+                reason = "ValidationError is intentionally large; callers are on the validation path"
+            )]
+            pub fn read_alias(
+                mut self,
+                alias: impl AsRef<str>,
+            ) -> Result<Self, crate::error::ValidationError> {
+                let alias_str = alias.as_ref();
+                let key = FieldKey::new(alias_str).map_err(|_| {
+                    crate::error::ValidationError::builder("alias.invalid_key")
+                        .at(crate::path::FieldPath::root())
+                        .param("key", alias_str.to_owned())
+                        .message(format!(
+                            "alias `{alias_str}` is not a valid field key"
+                        ))
+                        .build()
+                })?;
+                self.read_aliases.push_unchecked(key);
+                Ok(self)
+            }
+
+            /// Replace the read-alias set wholesale with `aliases`.
+            #[must_use]
+            pub fn read_aliases(mut self, aliases: crate::alias::FieldAliases) -> Self {
+                self.read_aliases = aliases;
+                self
+            }
+
+            /// Set the write-alias key (the key emitted on projection output).
+            ///
+            /// Validates the supplied string as a [`FieldKey`] and stores it as
+            /// [`write_alias`](Self::write_alias). Returns `Err` with code
+            /// `alias.invalid_key` when the key fails validation.
+            ///
+            /// # Errors
+            ///
+            /// Returns `alias.invalid_key` when `alias` is not a valid field key.
+            #[must_use = "builder: discard only if the error is intentionally ignored"]
+            #[expect(
+                clippy::result_large_err,
+                reason = "ValidationError is intentionally large; callers are on the validation path"
+            )]
+            pub fn write_alias(
+                mut self,
+                alias: impl AsRef<str>,
+            ) -> Result<Self, crate::error::ValidationError> {
+                let alias_str = alias.as_ref();
+                let key = FieldKey::new(alias_str).map_err(|_| {
+                    crate::error::ValidationError::builder("alias.invalid_key")
+                        .at(crate::path::FieldPath::root())
+                        .param("key", alias_str.to_owned())
+                        .message(format!(
+                            "write alias `{alias_str}` is not a valid field key"
+                        ))
+                        .build()
+                })?;
+                self.write_alias = Some(key);
+                Ok(self)
+            }
+
+            /// Append a pre-validated read-alias key without re-checking.
+            ///
+            /// For use by builders and derive-macro code that has already validated
+            /// the key. Callers must ensure uniqueness themselves.
+            #[must_use]
+            #[allow(dead_code)] // used by derive-macro code (not yet generated)
+            pub(crate) fn read_alias_unchecked(mut self, key: FieldKey) -> Self {
+                self.read_aliases.push_unchecked(key);
+                self
+            }
+
+            /// Set a pre-validated write-alias key without re-checking.
+            ///
+            /// For use by builders and derive-macro code that has already validated
+            /// the key.
+            #[must_use]
+            #[allow(dead_code)] // used by derive-macro code (not yet generated)
+            pub(crate) fn write_alias_unchecked(mut self, key: FieldKey) -> Self {
+                self.write_alias = Some(key);
                 self
             }
 
@@ -1442,6 +1543,55 @@ impl Field {
             Self::Computed(f) => f.default.as_ref(),
             Self::Dynamic(f) => f.default.as_ref(),
             Self::Notice(f) => f.default.as_ref(),
+            Self::Unknown(_) => None,
+        }
+    }
+
+    /// Shared read-aliases accessor — extra keys accepted on ingest.
+    ///
+    /// Returns `&[]` for [`Field::Unknown`] (this version cannot enumerate aliases
+    /// of a future field kind).
+    #[inline]
+    #[must_use]
+    pub fn read_aliases(&self) -> &[FieldKey] {
+        match self {
+            Self::String(f) => f.read_aliases.as_slice(),
+            Self::Secret(f) => f.read_aliases.as_slice(),
+            Self::Number(f) => f.read_aliases.as_slice(),
+            Self::Boolean(f) => f.read_aliases.as_slice(),
+            Self::Select(f) => f.read_aliases.as_slice(),
+            Self::Object(f) => f.read_aliases.as_slice(),
+            Self::List(f) => f.read_aliases.as_slice(),
+            Self::Mode(f) => f.read_aliases.as_slice(),
+            Self::Code(f) => f.read_aliases.as_slice(),
+            Self::File(f) => f.read_aliases.as_slice(),
+            Self::Computed(f) => f.read_aliases.as_slice(),
+            Self::Dynamic(f) => f.read_aliases.as_slice(),
+            Self::Notice(f) => f.read_aliases.as_slice(),
+            Self::Unknown(_) => &[],
+        }
+    }
+
+    /// Shared write-alias accessor — alternative key emitted on projection output.
+    ///
+    /// Returns `None` for [`Field::Unknown`].
+    #[inline]
+    #[must_use]
+    pub fn write_alias(&self) -> Option<&FieldKey> {
+        match self {
+            Self::String(f) => f.write_alias.as_ref(),
+            Self::Secret(f) => f.write_alias.as_ref(),
+            Self::Number(f) => f.write_alias.as_ref(),
+            Self::Boolean(f) => f.write_alias.as_ref(),
+            Self::Select(f) => f.write_alias.as_ref(),
+            Self::Object(f) => f.write_alias.as_ref(),
+            Self::List(f) => f.write_alias.as_ref(),
+            Self::Mode(f) => f.write_alias.as_ref(),
+            Self::Code(f) => f.write_alias.as_ref(),
+            Self::File(f) => f.write_alias.as_ref(),
+            Self::Computed(f) => f.write_alias.as_ref(),
+            Self::Dynamic(f) => f.write_alias.as_ref(),
+            Self::Notice(f) => f.write_alias.as_ref(),
             Self::Unknown(_) => None,
         }
     }

--- a/crates/schema/src/json_schema.rs
+++ b/crates/schema/src/json_schema.rs
@@ -98,13 +98,7 @@ fn schema_for_fields(
         Value::Object(properties_for_fields(fields)),
     );
 
-    let required = required_for_fields(fields);
-    if !required.is_empty() {
-        root.insert(
-            "required".to_owned(),
-            Value::Array(required.into_iter().map(Value::String).collect()),
-        );
-    }
+    apply_required_constraints(fields, &mut root);
     if !root_rules.is_empty() {
         let mut serialized = Vec::with_capacity(root_rules.len());
         for (index, rule) in root_rules.iter().enumerate() {
@@ -122,17 +116,71 @@ fn schema_for_fields(
 fn properties_for_fields(fields: &[Field]) -> Map<String, Value> {
     let mut out = Map::with_capacity(fields.len());
     for field in fields {
-        out.insert(field.key().as_str().to_owned(), field_schema_value(field));
+        let value = field_schema_value(field);
+        // Read-aliases are accepted input keys (folded to the canonical key at
+        // ingest), so expose each as a property too — otherwise the sibling
+        // `additionalProperties: false` would reject a valid alias-keyed
+        // submission that `validate` accepts. Aliases are lint-guaranteed
+        // disjoint from canonical keys and from each other, so this never
+        // collides. The value schema is shared (the alias carries the same
+        // contract as the canonical key).
+        for alias in field.read_aliases() {
+            out.insert(alias.as_str().to_owned(), value.clone());
+        }
+        out.insert(field.key().as_str().to_owned(), value);
     }
     out
 }
 
-fn required_for_fields(fields: &[Field]) -> Vec<String> {
-    fields
-        .iter()
-        .filter(|field| matches!(field.required(), RequiredMode::Always))
-        .map(|field| field.key().as_str().to_owned())
-        .collect()
+/// Emit `required` (and, for required fields with read-aliases, an `allOf` of
+/// `anyOf`-required clauses) into `target`.
+///
+/// A required field with no aliases is a flat `required` entry. A required field
+/// satisfiable via a read-alias instead becomes
+/// `anyOf: [{required:[canonical]}, {required:[alias]}, …]`, because a flat
+/// `required: [canonical]` would reject an alias-only submission that `validate`
+/// accepts (it canonicalizes the alias before the required check). The exported
+/// schema must never reject input `validate` would accept.
+fn apply_required_constraints(fields: &[Field], target: &mut Map<String, Value>) {
+    let mut flat_required: Vec<Value> = Vec::new();
+    let mut any_of_clauses: Vec<Value> = Vec::new();
+
+    for field in fields {
+        if !matches!(field.required(), RequiredMode::Always) {
+            continue;
+        }
+        let aliases = field.read_aliases();
+        if aliases.is_empty() {
+            flat_required.push(Value::String(field.key().as_str().to_owned()));
+            continue;
+        }
+        let mut clauses = Vec::with_capacity(aliases.len() + 1);
+        clauses.push(Value::Object(required_clause(field.key().as_str())));
+        clauses.extend(
+            aliases
+                .iter()
+                .map(|a| Value::Object(required_clause(a.as_str()))),
+        );
+        let mut any_of = Map::new();
+        any_of.insert("anyOf".to_owned(), Value::Array(clauses));
+        any_of_clauses.push(Value::Object(any_of));
+    }
+
+    if !flat_required.is_empty() {
+        target.insert("required".to_owned(), Value::Array(flat_required));
+    }
+    if !any_of_clauses.is_empty() {
+        target.insert("allOf".to_owned(), Value::Array(any_of_clauses));
+    }
+}
+
+fn required_clause(key: &str) -> Map<String, Value> {
+    let mut clause = Map::new();
+    clause.insert(
+        "required".to_owned(),
+        Value::Array(vec![Value::String(key.to_owned())]),
+    );
+    clause
 }
 
 fn field_schema_value(field: &Field) -> Value {
@@ -185,7 +233,39 @@ fn field_schema_value(field: &Field) -> Value {
     let mut schema = apply_expression_mode(core_schema, *field.expression());
     apply_common_keywords(field, &mut schema);
     apply_contract_keywords(field, &mut schema);
+    apply_alias_keywords(field, &mut schema);
     Value::Object(schema)
+}
+
+/// Emit alias metadata for a field.
+///
+/// - `x-nebula-read-aliases`: extra input keys accepted at ingest (folded onto
+///   the canonical key). They are ALSO surfaced as accepted properties by
+///   [`properties_for_fields`] so `additionalProperties: false` does not reject a
+///   valid alias-keyed submission.
+/// - `x-nebula-write-alias`: the key this field is emitted under by `project` /
+///   `to_wire_json`. The exported document is an INPUT schema keyed on canonical
+///   names, so the write-alias is metadata only — an output validator reads this
+///   to learn the projected key without the input contract misrepresenting it.
+fn apply_alias_keywords(field: &Field, schema: &mut Map<String, Value>) {
+    let read_aliases = field.read_aliases();
+    if !read_aliases.is_empty() {
+        schema.insert(
+            "x-nebula-read-aliases".to_owned(),
+            Value::Array(
+                read_aliases
+                    .iter()
+                    .map(|alias| Value::String(alias.as_str().to_owned()))
+                    .collect(),
+            ),
+        );
+    }
+    if let Some(write_alias) = field.write_alias() {
+        schema.insert(
+            "x-nebula-write-alias".to_owned(),
+            Value::String(write_alias.as_str().to_owned()),
+        );
+    }
 }
 
 fn apply_common_keywords(field: &Field, schema: &mut Map<String, Value>) {
@@ -283,13 +363,7 @@ fn object_schema(field: &ObjectField) -> Map<String, Value> {
         "properties".to_owned(),
         Value::Object(properties_for_fields(&field.fields)),
     );
-    let required = required_for_fields(&field.fields);
-    if !required.is_empty() {
-        out.insert(
-            "required".to_owned(),
-            Value::Array(required.into_iter().map(Value::String).collect()),
-        );
-    }
+    apply_required_constraints(&field.fields, &mut out);
     out.insert("additionalProperties".to_owned(), Value::Bool(false));
     out
 }
@@ -734,5 +808,98 @@ mod tests {
             json!("boolean"),
             "Forbidden-mode fields must still expose x-nebula-resolved-value-schema"
         );
+    }
+
+    #[test]
+    fn read_alias_is_an_accepted_property_with_metadata() {
+        let schema = Schema::builder()
+            .add(
+                Field::string(FieldKey::new("internal_id").expect("static key"))
+                    .read_alias("externalId")
+                    .expect("valid alias"),
+            )
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        // Canonical property present, and the read-alias is ALSO an accepted
+        // property so `additionalProperties: false` does not reject a valid
+        // alias-keyed submission.
+        assert!(json["properties"]["internal_id"].is_object());
+        assert!(
+            json["properties"]["externalId"].is_object(),
+            "read-alias must be an accepted input property"
+        );
+        assert_eq!(
+            json["properties"]["internal_id"]["x-nebula-read-aliases"],
+            json!(["externalId"])
+        );
+        assert_eq!(json["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn write_alias_is_metadata_only_input_property_stays_canonical() {
+        let schema = Schema::builder()
+            .add(
+                Field::string(FieldKey::new("internal_id").expect("static key"))
+                    .write_alias("externalId")
+                    .expect("valid alias"),
+            )
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        // The input property stays canonical — write-alias is output-only.
+        assert!(json["properties"]["internal_id"].is_object());
+        assert!(
+            json["properties"].get("externalId").is_none(),
+            "write-alias must not become an input property"
+        );
+        // The projected output key is exposed as metadata for output validators.
+        assert_eq!(
+            json["properties"]["internal_id"]["x-nebula-write-alias"],
+            json!("externalId")
+        );
+    }
+
+    #[test]
+    fn required_field_with_read_alias_uses_any_of_not_flat_required() {
+        let schema = Schema::builder()
+            .add(
+                Field::string(FieldKey::new("email").expect("static key"))
+                    .required()
+                    .read_alias("emailAddress")
+                    .expect("valid alias"),
+            )
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        // A flat `required: [email]` would reject an alias-only submission that
+        // `validate` accepts, so the constraint is an anyOf of required clauses.
+        assert!(
+            json.get("required").is_none(),
+            "an alias-bearing required field must not be a flat required entry"
+        );
+        let all_of = json["allOf"].as_array().expect("allOf array");
+        let any_of = all_of[0]["anyOf"].as_array().expect("anyOf array");
+        let required_keys: Vec<&str> = any_of
+            .iter()
+            .map(|clause| clause["required"][0].as_str().expect("required key string"))
+            .collect();
+        assert!(required_keys.contains(&"email"));
+        assert!(required_keys.contains(&"emailAddress"));
+    }
+
+    #[test]
+    fn required_field_without_alias_stays_flat_required() {
+        let schema = Schema::builder()
+            .add(Field::string(FieldKey::new("name").expect("static key")).required())
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        assert_eq!(json["required"], json!(["name"]));
+        assert!(json.get("allOf").is_none());
     }
 }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -138,6 +138,8 @@
 // works from external crates, integration tests, doctests, and lib tests.
 extern crate self as nebula_schema;
 
+/// Field alias container — extra accepted input keys (read-aliases) and optional output key remapping (write-alias).
+pub mod alias;
 /// Typed-closure builder DSL (leaf aliases + Object/List/Group composite builders).
 pub mod builder;
 /// Opt-in keyed commitment of secret material for content-addressing.
@@ -192,6 +194,7 @@ pub mod value;
 /// Typed widget hints by field family.
 pub mod widget;
 
+pub use alias::FieldAliases;
 pub use builder::{
     BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
     ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -113,6 +113,7 @@ fn lint_fields_new(
     report: &mut ValidationReport,
 ) {
     lint_duplicate_keys_in_scope(fields, prefix, report);
+    lint_alias_collisions_in_scope(fields, prefix, report);
     let local_keys: HashSet<&str> = fields.iter().map(|f| f.key().as_str()).collect();
     for field in fields {
         let path = prefix.clone().join(field.key().clone());
@@ -288,6 +289,146 @@ fn lint_duplicate_keys_in_scope(
                 .message(format!("duplicate field key `{key}`"))
                 .build(),
         );
+    }
+}
+
+/// Emit `alias.write_on_secret` if a `Field::Secret` carries a write-alias.
+///
+/// A secret's projected output is always omitted, so a write-alias on it is
+/// always a mistake. This is a per-field (unary) check, so it is enforced
+/// wherever a `Field` appears — a scope member, a bare list item, or a
+/// mode-variant payload — not only at the top scope level. A no-op for any
+/// non-secret field.
+fn lint_secret_write_alias(field: &Field, path: &FieldPath, report: &mut ValidationReport) {
+    if matches!(field, Field::Secret(_)) && field.write_alias().is_some() {
+        report.push(
+            ValidationError::builder("alias.write_on_secret")
+                .at(path.clone())
+                .message(format!(
+                    "secret field `{}` must not have a write_alias; secret output is always redacted",
+                    field.key().as_str()
+                ))
+                .build(),
+        );
+    }
+}
+
+/// Validate alias constraints within a single field-scope level.
+///
+/// Five scope-relative collision kinds plus the unary write-on-secret check:
+/// - `alias.self_collision`: a read-alias equals the field's own canonical key.
+/// - `alias.scope_collision`: a read-alias collides with another field's canonical key in scope
+///   (confused-deputy guard — prevents aliasing another field's identity).
+/// - `alias.scope_duplicate`: two fields share the same read-alias.
+/// - `alias.write_collision`: a write-alias equals any field's canonical key in scope.
+/// - `alias.write_scope_duplicate`: two fields share the same write-alias.
+/// - `alias.write_on_secret`: a `Field::Secret` has a write-alias set (forbidden) —
+///   via `lint_secret_write_alias`, also enforced on bare list items / mode payloads.
+///
+/// Checks a single field-scope only; `lint_fields_new` drives the descent into
+/// every nested Object / List item / Mode-variant scope (calling this once per
+/// scope), exactly as it does for `lint_duplicate_keys_in_scope`. The traversal
+/// must reach every scope `canonicalize_aliases` folds, or a collision at depth
+/// would silently mis-route a value at ingest with no build-time guard.
+fn lint_alias_collisions_in_scope(
+    fields: &[Field],
+    prefix: &FieldPath,
+    report: &mut ValidationReport,
+) {
+    // Collect all canonical keys in this scope for collision checks.
+    let canonical_keys: HashSet<&str> = fields.iter().map(|f| f.key().as_str()).collect();
+
+    // Track which read-aliases and write-aliases have been seen across this scope.
+    let mut seen_read_aliases: HashMap<&str, &str> = HashMap::new();
+    let mut seen_write_aliases: HashMap<&str, &str> = HashMap::new();
+
+    for field in fields {
+        let field_key_str = field.key().as_str();
+        let field_path = prefix.clone().join(field.key().clone());
+
+        // alias.write_on_secret: Field::Secret must not carry a write-alias.
+        lint_secret_write_alias(field, &field_path, report);
+
+        // Read-alias collision checks.
+        for alias_key in field.read_aliases() {
+            let alias_str = alias_key.as_str();
+
+            // alias.self_collision: alias equals the field's own canonical key.
+            if alias_str == field_key_str {
+                report.push(
+                    ValidationError::builder("alias.self_collision")
+                        .at(field_path.clone())
+                        .param("alias", alias_str.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has read-alias `{alias_str}` that equals its own canonical key"
+                        ))
+                        .build(),
+                );
+                continue;
+            }
+
+            // alias.scope_collision: alias collides with another field's canonical key.
+            if canonical_keys.contains(alias_str) {
+                report.push(
+                    ValidationError::builder("alias.scope_collision")
+                        .at(field_path.clone())
+                        .param("alias", alias_str.to_owned())
+                        .param("collides_with", alias_str.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has read-alias `{alias_str}` that collides with another field's canonical key in this scope"
+                        ))
+                        .build(),
+                );
+                continue;
+            }
+
+            // alias.scope_duplicate: two fields share a read-alias.
+            if let Some(prior_field_key) = seen_read_aliases.insert(alias_str, field_key_str) {
+                report.push(
+                    ValidationError::builder("alias.scope_duplicate")
+                        .at(field_path.clone())
+                        .param("alias", alias_str.to_owned())
+                        .param("also_on_field", prior_field_key.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has read-alias `{alias_str}` already used by field `{prior_field_key}` in this scope"
+                        ))
+                        .build(),
+                );
+            }
+        }
+
+        // Write-alias collision checks.
+        if let Some(write_alias_key) = field.write_alias() {
+            let write_alias_str = write_alias_key.as_str();
+
+            // alias.write_collision: write-alias equals any canonical key in scope.
+            if canonical_keys.contains(write_alias_str) {
+                report.push(
+                    ValidationError::builder("alias.write_collision")
+                        .at(field_path.clone())
+                        .param("write_alias", write_alias_str.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has write_alias `{write_alias_str}` that collides with a canonical field key in this scope"
+                        ))
+                        .build(),
+                );
+            }
+
+            // alias.write_scope_duplicate: two fields share a write-alias.
+            if let Some(prior_field_key) = seen_write_aliases.insert(write_alias_str, field_key_str)
+            {
+                report.push(
+                    ValidationError::builder("alias.write_scope_duplicate")
+                        .at(field_path.clone())
+                        .param("write_alias", write_alias_str.to_owned())
+                        .param("also_on_field", prior_field_key.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has write_alias `{write_alias_str}` already used by field `{prior_field_key}` in this scope"
+                        ))
+                        .build(),
+                );
+            }
+        }
     }
 }
 
@@ -491,8 +632,20 @@ fn lint_list_new(
         );
         return;
     }
-    if let Some(Field::Object(obj)) = list.item.as_deref() {
-        lint_fields_new(&obj.fields, path, root_keys, report);
+    // Descend into the item schema for ANY item kind, not only a direct Object,
+    // so nested scopes (list-of-list, list-of-mode, …) are linted to the same
+    // depth `canonicalize_aliases` folds. From-json keys a list under its own
+    // path, so nested scopes share `path`.
+    if let Some(item_field) = list.item.as_deref() {
+        // A bare secret list item is not a member of any scope, so the scope
+        // collision pass never sees it — check write_on_secret on it directly.
+        lint_secret_write_alias(item_field, path, report);
+    }
+    match list.item.as_deref() {
+        Some(Field::Object(obj)) => lint_fields_new(&obj.fields, path, root_keys, report),
+        Some(Field::List(inner)) => lint_list_new(inner, path, root_keys, report),
+        Some(Field::Mode(inner)) => lint_mode_new(inner, path, root_keys, report),
+        _ => {},
     }
 }
 
@@ -554,12 +707,20 @@ fn lint_mode_new(
                 );
             }
         }
-        // Recurse into variant payload.
-        if let Field::Object(obj) = variant.field.as_ref()
-            && let Some(vk) = variant_key
-        {
+        // Recurse into the variant payload for ANY payload kind, not only a
+        // direct Object, so nested scopes (mode-of-list, mode-of-mode, …) are
+        // linted to the same depth `canonicalize_aliases` folds.
+        if let Some(vk) = variant_key {
             let vpath = path.clone().join(vk);
-            lint_fields_new(&obj.fields, &vpath, root_keys, report);
+            // A bare secret variant payload is not a scope member, so check
+            // write_on_secret on it directly (no-op for non-secret payloads).
+            lint_secret_write_alias(variant.field.as_ref(), &vpath, report);
+            match variant.field.as_ref() {
+                Field::Object(obj) => lint_fields_new(&obj.fields, &vpath, root_keys, report),
+                Field::List(inner) => lint_list_new(inner, &vpath, root_keys, report),
+                Field::Mode(inner) => lint_mode_new(inner, &vpath, root_keys, report),
+                _ => {},
+            }
         }
     }
 }

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -315,13 +315,15 @@ fn lint_secret_write_alias(field: &Field, path: &FieldPath, report: &mut Validat
 
 /// Validate alias constraints within a single field-scope level.
 ///
-/// Five scope-relative collision kinds plus the unary write-on-secret check:
+/// Six scope-relative collision kinds plus the unary write-on-secret check:
 /// - `alias.self_collision`: a read-alias equals the field's own canonical key.
 /// - `alias.scope_collision`: a read-alias collides with another field's canonical key in scope
 ///   (confused-deputy guard — prevents aliasing another field's identity).
 /// - `alias.scope_duplicate`: two fields share the same read-alias.
 /// - `alias.write_collision`: a write-alias equals any field's canonical key in scope.
 /// - `alias.write_scope_duplicate`: two fields share the same write-alias.
+/// - `alias.read_write_collision`: one field's read-alias equals another field's write-alias —
+///   a wire round-trip would move data between the two fields (same-field reuse is allowed).
 /// - `alias.write_on_secret`: a `Field::Secret` has a write-alias set (forbidden) —
 ///   via `lint_secret_write_alias`, also enforced on bare list items / mode payloads.
 ///
@@ -382,6 +384,26 @@ fn lint_alias_collisions_in_scope(
                 continue;
             }
 
+            // alias.read_write_collision: this field's read-alias collides with
+            // a write-alias already declared on ANOTHER field in scope. `project`
+            // would emit that other field under the key, and a later `validate`
+            // would fold the key into THIS field — round-trip data movement
+            // between fields. Same-field read+write reuse is stable and allowed.
+            if let Some(&write_owner) = seen_write_aliases.get(alias_str)
+                && write_owner != field_key_str
+            {
+                report.push(
+                    ValidationError::builder("alias.read_write_collision")
+                        .at(field_path.clone())
+                        .param("alias", alias_str.to_owned())
+                        .param("write_alias_on_field", write_owner.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has read-alias `{alias_str}` that collides with a write_alias on field `{write_owner}` in this scope"
+                        ))
+                        .build(),
+                );
+            }
+
             // alias.scope_duplicate: two fields share a read-alias.
             if let Some(prior_field_key) = seen_read_aliases.insert(alias_str, field_key_str) {
                 report.push(
@@ -409,6 +431,25 @@ fn lint_alias_collisions_in_scope(
                         .param("write_alias", write_alias_str.to_owned())
                         .message(format!(
                             "field `{field_key_str}` has write_alias `{write_alias_str}` that collides with a canonical field key in this scope"
+                        ))
+                        .build(),
+                );
+            }
+
+            // alias.read_write_collision: this field's write-alias collides with
+            // a read-alias already declared on ANOTHER field in scope (the
+            // mirror of the read-loop check, catching the reverse declaration
+            // order). Same-field read+write reuse is allowed.
+            if let Some(&read_owner) = seen_read_aliases.get(write_alias_str)
+                && read_owner != field_key_str
+            {
+                report.push(
+                    ValidationError::builder("alias.read_write_collision")
+                        .at(field_path.clone())
+                        .param("write_alias", write_alias_str.to_owned())
+                        .param("read_alias_on_field", read_owner.to_owned())
+                        .message(format!(
+                            "field `{field_key_str}` has write_alias `{write_alias_str}` that collides with a read-alias on field `{read_owner}` in this scope"
                         ))
                         .build(),
                 );

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -14,7 +14,7 @@ use smallvec::SmallVec;
 use crate::{
     error::{Severity, ValidationError, ValidationReport},
     expression::ExpressionContext,
-    field::{Field, ListField, NumberField, ObjectField},
+    field::{Field, ListField, ModeField, NumberField, ObjectField},
     key::FieldKey,
     loader::{LoaderContext, LoaderRegistry, LoaderResult},
     mode::ExpressionMode,
@@ -422,11 +422,18 @@ impl ValidSchema {
 
         let mut report = ValidationReport::new();
 
+        // SECURITY: canonicalize alias-keyed entries before ANY validation,
+        // secret-strip, or predicate-context build.  A value submitted under a
+        // read-alias key must live under the canonical FieldKey before those
+        // passes run — otherwise an alias-keyed secret bypasses the secret-strip
+        // in context.rs and the loader redaction in loader.rs.
+        let canonicalized: FieldValues = canonicalize_aliases(values, &self.0.fields);
+
         // One whole-tree predicate context. Built once and shared across all
         // nesting levels: a nested field's `When` may reference a sibling at
         // any depth via an absolute RFC-6901 pointer, so per-level rebuilds
         // would make cross-level predicates fail open.
-        let ctx = predicate_context_for(&self.0.fields, values);
+        let ctx = predicate_context_for(&self.0.fields, &canonicalized);
 
         // Top-level fields are the first field-set level. Visibility/required
         // for every level (this one and each nested object/list/mode level)
@@ -440,7 +447,7 @@ impl ValidSchema {
                 let validator_path = validator_path_from_schema_path(&schema_path);
                 LevelEntry {
                     field,
-                    raw: values.get(field.key()),
+                    raw: resolve_field_value(field, &canonicalized),
                     schema_path,
                     validator_path,
                 }
@@ -448,13 +455,14 @@ impl ValidSchema {
             .collect();
         gate_and_validate_level(&entries, &ctx, &mut report);
 
-        // Schema-level rules run against the full submission
-        // (`values.to_json()`), but the predicate context is the
-        // secret-scrubbed `root_predicate_context_for`: a value-comparing root
-        // predicate can never read a `Field::Secret` plaintext, while legal
-        // non-secret nested predicates still resolve (no fail-open).
+        // Schema-level rules run against the canonicalized submission
+        // (`canonicalized.to_json()` — alias keys already folded onto their
+        // canonical field key), but the predicate context is the
+        // secret-scrubbed `root_predicate_context_from_json`: a value-comparing
+        // root predicate can never read a `Field::Secret` plaintext, while
+        // legal non-secret nested predicates still resolve (no fail-open).
         if !self.0.root_rules.is_empty() {
-            let json = values.to_json();
+            let json = canonicalized.to_json();
             let pred_ctx = crate::context::root_predicate_context_from_json(&self.0.fields, &json);
             if let Err(errs) = nebula_validator::validate_rules_with_ctx(
                 &json,
@@ -482,10 +490,332 @@ impl ValidSchema {
             .collect();
         Ok(ValidValues {
             schema: self.clone(),
-            values: values.clone(),
+            values: canonicalized,
             warnings,
         })
     }
+
+    /// Project `values` to a JSON object applying write-aliases.
+    ///
+    /// - Fields with a `write_alias` emit under that key instead of the canonical key.
+    /// - Fields without a `write_alias` emit under their canonical key (today's behaviour).
+    /// - `Field::Secret` subtrees are **never** emitted at any depth (defense-in-depth:
+    ///   secrets can only be accessed via `ResolvedValues::get_secret`). This holds for a
+    ///   secret nested in an object, a list item, or a mode-variant payload.
+    /// - Extra keys that do not match any field pass through under their own key, but a
+    ///   declared field always wins: an extra key cannot overwrite a field's projected
+    ///   value nor shadow a `write_alias` output key.
+    /// - Recurse into object children, list items, and the active mode-variant payload so
+    ///   nested write-aliases are applied and nested secrets are dropped.
+    ///
+    /// `values` is canonicalized first (read-alias keys folded onto their canonical
+    /// FieldKey), so a secret submitted under a read-alias is caught by the secret-skip
+    /// even when this is called on raw, never-validated values.
+    #[must_use]
+    pub fn project(&self, values: &FieldValues) -> serde_json::Value {
+        // Canonicalize first: fold any read-alias-keyed value (a secret submitted under
+        // its read-alias included) onto its canonical FieldKey so the secret-skip — keyed
+        // on the canonical `Field::Secret` — catches it. `to_wire_json` passes already
+        // canonical `raw()`, for which this is an idempotent no-op; a direct caller that
+        // passes raw values is made safe by construction rather than by precondition.
+        let canonical = canonicalize_aliases(values, &self.0.fields);
+        project_level(&self.0.fields, canonical.as_map())
+    }
+}
+
+/// Project one field-scope level: schema-declared fields (write-aliases applied,
+/// secrets dropped) plus extra pass-through keys that no declared field claims.
+fn project_level(
+    fields: &[Field],
+    value_map: &IndexMap<FieldKey, FieldValue>,
+) -> serde_json::Value {
+    use serde_json::Value;
+
+    let mut out = serde_json::Map::new();
+
+    // An input key equal to a declared field's canonical key is that field's
+    // value (consumed in the first loop), never a pass-through extra.
+    let canonical_key_strs: HashSet<&str> = fields.iter().map(|f| f.key().as_str()).collect();
+    // Every write-aliased field reserves its output name UNCONDITIONALLY — even
+    // when the field is absent this submission or its value is dropped (a secret
+    // or a shape-mismatched blob) — so a pass-through extra can never occupy a
+    // schema-owned output slot (integrity/spoofing guard). Write-alias output
+    // names are disjoint from canonical keys and unique among themselves
+    // (enforced by the alias.write_collision / alias.write_scope_duplicate lints),
+    // so reserving them cannot suppress a legitimate canonical key or pass-through.
+    let write_alias_strs: HashSet<&str> = fields
+        .iter()
+        .filter_map(|f| f.write_alias().map(FieldKey::as_str))
+        .collect();
+
+    // Emit schema-declared fields.
+    for field in fields {
+        let Some(value) = value_map.get(field.key()) else {
+            continue;
+        };
+
+        // Secrets (at any depth) and shape-mismatched secret-bearing blobs are dropped.
+        let Some(projected_value) = project_value(field, value) else {
+            continue;
+        };
+
+        // Output key: write-alias overrides the canonical key.
+        let output_key = field
+            .write_alias()
+            .map(FieldKey::as_str)
+            .unwrap_or_else(|| field.key().as_str())
+            .to_owned();
+
+        out.insert(output_key, projected_value);
+    }
+
+    // Pass extra (non-schema) keys through unchanged — but never into a reserved
+    // schema-owned output slot (a canonical key or a write-alias output name).
+    for (key, value) in value_map {
+        let k = key.as_str();
+        if !canonical_key_strs.contains(k) && !write_alias_strs.contains(k) {
+            out.insert(k.to_owned(), value.to_json());
+        }
+    }
+
+    Value::Object(out)
+}
+
+/// Project a single field's value, applying nested write-aliases and dropping
+/// `Field::Secret` subtrees.
+///
+/// Returns `None` when the whole value must be omitted: it *is* a secret, or it
+/// is a secret-bearing structured field whose value shape does not match (a blob
+/// that could smuggle a nested secret's plaintext via the unvalidated setter).
+/// Mirrors `context::strip_secret_value` on the projection side, so the wire
+/// output never carries secret material the way the predicate/loader paths never do.
+fn project_value(field: &Field, value: &FieldValue) -> Option<serde_json::Value> {
+    use serde_json::Value;
+
+    if matches!(field, Field::Secret(_)) {
+        return None;
+    }
+    match (field, value) {
+        (Field::Object(obj), FieldValue::Object(map)) => Some(project_level(&obj.fields, map)),
+        (Field::List(list), FieldValue::List(items)) => match list.item.as_deref() {
+            Some(item_field) => Some(Value::Array(
+                items
+                    .iter()
+                    .filter_map(|item| project_value(item_field, item))
+                    .collect(),
+            )),
+            None => Some(value.to_json()),
+        },
+        (Field::Mode(mode), FieldValue::Object(map)) => Some(project_mode_object(mode, map)),
+        (
+            Field::Mode(mode),
+            FieldValue::Mode {
+                mode: mode_key,
+                value: payload,
+            },
+        ) => Some(project_mode_typed(mode, mode_key, payload.as_deref())),
+        // A secret-bearing structured field whose value is the wrong shape (e.g. a
+        // `Literal` blob set via the unvalidated bypass): drop it.
+        _ if crate::context::field_subtree_has_secret(field) => None,
+        _ => Some(value.to_json()),
+    }
+}
+
+/// Project a `Field::Mode` whose value arrived as the wire `{mode,value}` object
+/// envelope (the shape `from_json` produces). The selector is kept verbatim; the
+/// payload is projected against the active variant (explicit `mode`, else default).
+fn project_mode_object(
+    mode: &ModeField,
+    map: &IndexMap<FieldKey, FieldValue>,
+) -> serde_json::Value {
+    use serde_json::Value;
+
+    let mut out = serde_json::Map::new();
+
+    // Keep the variant selector verbatim (a string, never secret material).
+    if let Some(selector) = map.get(&*MODE_SELECTOR_KEY) {
+        out.insert(MODE_SELECTOR_KEY.as_str().to_owned(), selector.to_json());
+    }
+
+    // Resolve the active variant the same way the rest of the crate does.
+    let selected: Option<&str> = match map.get(&*MODE_SELECTOR_KEY) {
+        Some(FieldValue::Literal(Value::String(mode_key))) => Some(mode_key.as_str()),
+        Some(_) => None,
+        None => mode.default_variant.as_deref(),
+    };
+    if let Some(payload) = map.get(&*MODE_PAYLOAD_KEY)
+        && let Some(key) = selected
+        && let Some(variant) = mode.variants.iter().find(|v| v.key.as_str() == key)
+        && let Some(projected) = project_value(variant.field.as_ref(), payload)
+    {
+        out.insert(MODE_PAYLOAD_KEY.as_str().to_owned(), projected);
+    }
+
+    Value::Object(out)
+}
+
+/// Project a `Field::Mode` whose value is the programmatic `FieldValue::Mode`
+/// shape (constructed directly, not via `from_json`).
+fn project_mode_typed(
+    mode: &ModeField,
+    mode_key: &FieldKey,
+    payload: Option<&FieldValue>,
+) -> serde_json::Value {
+    use serde_json::Value;
+
+    let mut out = serde_json::Map::new();
+    out.insert(
+        MODE_SELECTOR_KEY.as_str().to_owned(),
+        Value::String(mode_key.as_str().to_owned()),
+    );
+    if let Some(payload) = payload
+        && let Some(variant) = mode
+            .variants
+            .iter()
+            .find(|v| v.key.as_str() == mode_key.as_str())
+        && let Some(projected) = project_value(variant.field.as_ref(), payload)
+    {
+        out.insert(MODE_PAYLOAD_KEY.as_str().to_owned(), projected);
+    }
+
+    Value::Object(out)
+}
+
+/// Canonicalize alias-keyed values to their canonical field key.
+///
+/// For each field with read-aliases: if the canonical key is absent but an
+/// alias key is present, move the alias-keyed value to the canonical key.
+/// If both canonical and alias are present, canonical wins (silent — matches
+/// serde's own `#[serde(alias)]` semantics).
+///
+/// After this pass the canonical lookup `values.get(field.key())` is
+/// sufficient; alias-keyed entries have been moved or discarded.
+///
+/// Recurse into Object children, List items, and the active Mode variant
+/// payload so nested alias keys are canonicalized at every level before
+/// validation — the same container shape the secret-strip / loader / projection
+/// walks descend, so an alias-keyed secret can never escape the fold at depth.
+fn canonicalize_aliases(values: &FieldValues, fields: &[Field]) -> FieldValues {
+    // Clone once: we need an owned map to mutate.
+    let mut map: IndexMap<FieldKey, FieldValue> = values.as_map().clone();
+
+    for field in fields {
+        let aliases = field.read_aliases();
+        if aliases.is_empty() {
+            // Fast path: no aliases → descend into containers but no top-level move.
+            if let Some(value) = map.get_mut(field.key()) {
+                canonicalize_nested_value(field, value);
+            }
+            continue;
+        }
+
+        // Find the first alias-keyed value present (canonical is preferred).
+        let alias_value: Option<(FieldKey, FieldValue)> = if map.contains_key(field.key()) {
+            // Canonical already present — remove all alias keys, canonical wins.
+            for alias_key in aliases {
+                map.shift_remove(alias_key);
+            }
+            None
+        } else {
+            // Canonical absent — promote the first alias found (insertion-order priority).
+            let mut found: Option<(FieldKey, FieldValue)> = None;
+            for alias_key in aliases {
+                if let Some(v) = map.shift_remove(alias_key) {
+                    found = Some((alias_key.clone(), v));
+                    break;
+                }
+            }
+            // Remove any remaining alias keys that weren't promoted.
+            if found.is_some() {
+                for alias_key in aliases {
+                    map.shift_remove(alias_key);
+                }
+            }
+            found
+        };
+
+        if let Some((_alias_key_from, promoted_value)) = alias_value {
+            // Insert under canonical key.
+            map.insert(field.key().clone(), promoted_value);
+        }
+
+        // Recurse into the (now canonically-keyed) nested container.
+        if let Some(value) = map.get_mut(field.key()) {
+            canonicalize_nested_value(field, value);
+        }
+    }
+
+    FieldValues::from_map(map)
+}
+
+/// Recurse into nested containers to canonicalize aliases at deeper levels.
+fn canonicalize_nested_value(field: &Field, value: &mut FieldValue) {
+    match (field, &mut *value) {
+        (Field::Object(obj), FieldValue::Object(nested_map)) => {
+            // Build a scratch FieldValues to recursively canonicalize.
+            let scratch = FieldValues::from_map(nested_map.clone());
+            let canonicalized = canonicalize_aliases(&scratch, &obj.fields);
+            *nested_map = canonicalized.into_map();
+        },
+        (Field::List(list), FieldValue::List(items)) => {
+            if let Some(item_field) = list.item.as_deref() {
+                for item_value in items.iter_mut() {
+                    canonicalize_nested_value(item_field, item_value);
+                }
+            }
+        },
+        (
+            Field::Mode(mode_field),
+            FieldValue::Mode {
+                mode: mode_key,
+                value: Some(payload),
+            },
+        ) => {
+            if let Some(variant) = mode_field
+                .variants
+                .iter()
+                .find(|v| v.key == mode_key.as_str())
+            {
+                canonicalize_nested_value(&variant.field, payload.as_mut());
+            }
+        },
+        (Field::Mode(mode_field), FieldValue::Object(map)) => {
+            // SECURITY: wire ingest parses a `{"mode","value"}` envelope into a
+            // `FieldValue::Object`, NEVER a `FieldValue::Mode` (see
+            // `value::FieldValue::from_json_limited`), so the typed arm above is
+            // dead for `from_json` input. Resolve the active variant exactly as
+            // `promote_secrets_in_value` / loader / context do — an explicit
+            // string `mode`, else `default_variant` — and recurse into the
+            // payload so alias keys inside the variant fold onto their canonical
+            // FieldKey BEFORE secret-strip, loader redaction, and projection
+            // run. Without this arm an alias-keyed secret in a mode payload
+            // escapes canonicalization and leaks plaintext.
+            let resolved_key = match map.get(&*MODE_SELECTOR_KEY) {
+                Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => {
+                    Some(mode_key.clone())
+                },
+                Some(_) => None,
+                None => mode_field.default_variant.clone(),
+            };
+            if let Some(variant) = resolved_key
+                .as_deref()
+                .and_then(|mode_key| mode_field.variants.iter().find(|v| v.key == mode_key))
+                && let Some(payload) = map.get_mut(&*MODE_PAYLOAD_KEY)
+            {
+                canonicalize_nested_value(variant.field.as_ref(), payload);
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Resolve a field's value from canonicalized values.
+///
+/// After `canonicalize_aliases` runs, the canonical key lookup is always
+/// sufficient. This helper makes the intent explicit and provides a single
+/// point to extend with fallback logic if needed.
+fn resolve_field_value<'v>(field: &Field, values: &'v FieldValues) -> Option<&'v FieldValue> {
+    values.get(field.key())
 }
 
 /// Validated values — tied to a specific `ValidSchema`.
@@ -539,6 +869,15 @@ impl ValidValues {
     #[must_use]
     pub fn get_path(&self, path: &FieldPath) -> Option<&FieldValue> {
         self.values.get_path(path)
+    }
+
+    /// Project the validated values to a JSON object, applying write-aliases.
+    ///
+    /// Equivalent to `self.schema().project(self.raw())`. Fields with a
+    /// `write_alias` emit under the alias key. Secret fields are never emitted.
+    #[must_use]
+    pub fn to_wire_json(&self) -> serde_json::Value {
+        self.schema.project(self.raw())
     }
 
     /// Resolve all `FieldValue::Expression` entries by evaluating them through

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -791,6 +791,24 @@ impl FieldValues {
         &self.0
     }
 
+    /// Construct a `FieldValues` from a pre-built ordered map.
+    ///
+    /// Used by alias canonicalization in `validated.rs`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn from_map(map: IndexMap<FieldKey, FieldValue>) -> Self {
+        Self(map)
+    }
+
+    /// Consume into the underlying ordered map.
+    ///
+    /// Used by alias canonicalization to move nested maps back into place.
+    #[inline]
+    #[must_use]
+    pub(crate) fn into_map(self) -> IndexMap<FieldKey, FieldValue> {
+        self.0
+    }
+
     /// Mutably borrow a value by key.
     #[inline]
     pub fn get_mut(&mut self, key: &FieldKey) -> Option<&mut FieldValue> {

--- a/crates/schema/tests/alias.rs
+++ b/crates/schema/tests/alias.rs
@@ -1,0 +1,958 @@
+//! Integration tests for the field-alias subsystem.
+//!
+//! Covers:
+//! - Builder API (read_alias / write_alias / read_aliases methods)
+//! - Ingest canonicalization (alias-keyed → canonical-keyed before validation)
+//! - Security: alias-keyed secret is canonicalized, not leaked under the alias key
+//! - Projection via `ValidSchema::project` and `ValidValues::to_wire_json`
+//! - Lint: all alias.* error codes emitted at `SchemaBuilder::build` time
+//! - No-alias path: fields without aliases produce no extra wire keys
+
+use nebula_schema::{Field, FieldAliases, FieldKey, FieldValue, FieldValues, Schema};
+use serde_json::json;
+
+fn fk(s: &str) -> FieldKey {
+    FieldKey::new(s).unwrap()
+}
+
+fn has_error_code(r: &nebula_schema::ValidationReport, code: &str) -> bool {
+    r.errors().any(|e| e.code == code)
+}
+
+// ── Builder API ───────────────────────────────────────────────────────────────
+
+#[test]
+fn builder_read_alias_registers_on_field_enum() {
+    let field = Field::string(fk("name"))
+        .read_alias("display_name")
+        .unwrap()
+        .into_field();
+    // Accessor on the Field enum returns the alias slice.
+    assert_eq!(field.read_aliases().len(), 1);
+    assert_eq!(field.read_aliases()[0].as_str(), "display_name");
+}
+
+#[test]
+fn builder_read_alias_rejects_invalid_key() {
+    let err = Field::string(fk("name"))
+        .read_alias("has-dash")
+        .unwrap_err();
+    assert_eq!(err.code, "alias.invalid_key");
+}
+
+#[test]
+fn builder_read_aliases_bulk_replaces_set() {
+    let aliases = FieldAliases::new(["a", "b"]).unwrap();
+    let field = Field::string(fk("name")).read_aliases(aliases).into_field();
+    let keys: Vec<&str> = field.read_aliases().iter().map(FieldKey::as_str).collect();
+    assert_eq!(keys, ["a", "b"]);
+}
+
+#[test]
+fn builder_write_alias_registers_on_field_enum() {
+    let field = Field::string(fk("internal_name"))
+        .write_alias("displayName")
+        .unwrap()
+        .into_field();
+    assert_eq!(
+        field.write_alias().map(FieldKey::as_str),
+        Some("displayName")
+    );
+}
+
+#[test]
+fn builder_write_alias_rejects_invalid_key() {
+    let err = Field::string(fk("name"))
+        .write_alias("has-dash")
+        .unwrap_err();
+    assert_eq!(err.code, "alias.invalid_key");
+}
+
+#[test]
+fn field_enum_without_aliases_returns_empty_slice_and_none() {
+    let field = Field::string(fk("x")).into_field();
+    assert!(field.read_aliases().is_empty());
+    assert!(field.write_alias().is_none());
+}
+
+// ── Ingest canonicalization ───────────────────────────────────────────────────
+
+#[test]
+fn alias_key_accepted_and_stored_under_canonical_key() {
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("canonical_name"))
+                .read_alias("alias_name")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let submitted = FieldValues::from_json(json!({"alias_name": "hello"})).unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("alias_name must be accepted");
+
+    // After ingest the value lives under the canonical key only.
+    assert!(
+        valid.raw().get(&fk("canonical_name")).is_some(),
+        "value must be stored under the canonical key"
+    );
+    assert!(
+        valid.raw().get(&fk("alias_name")).is_none(),
+        "alias key must not remain in stored values"
+    );
+}
+
+#[test]
+fn canonical_key_wins_over_alias_when_both_submitted() {
+    let schema = Schema::builder()
+        .add(Field::string(fk("name")).read_alias("alt_name").unwrap())
+        .build()
+        .unwrap();
+
+    // Submit both canonical and alias — canonical must win (matches serde alias semantics).
+    let submitted =
+        FieldValues::from_json(json!({"name": "canonical_value", "alt_name": "alias_value"}))
+            .unwrap();
+    let valid = schema.validate(&submitted).expect("should accept");
+
+    let stored_string = valid.raw().get_string(&fk("name"));
+    assert_eq!(
+        stored_string,
+        Some("canonical_value"),
+        "canonical value must win when both submitted"
+    );
+    assert!(valid.raw().get(&fk("alt_name")).is_none());
+}
+
+#[test]
+fn multiple_aliases_first_present_wins() {
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("target"))
+                .read_alias("first_alias")
+                .unwrap()
+                .read_alias("second_alias")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    // Submit second alias only.
+    let submitted = FieldValues::from_json(json!({"second_alias": "from_second"})).unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("second_alias must be accepted");
+    assert!(
+        valid.raw().get(&fk("target")).is_some(),
+        "value must be stored under canonical key"
+    );
+    assert!(valid.raw().get(&fk("second_alias")).is_none());
+}
+
+#[test]
+fn required_field_satisfied_via_alias_key() {
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("email"))
+                .required()
+                .read_alias("email_address")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let submitted = FieldValues::from_json(json!({"email_address": "user@example.com"})).unwrap();
+    schema
+        .validate(&submitted)
+        .expect("required satisfied via alias must not emit 'required'");
+}
+
+#[test]
+fn field_validation_runs_on_alias_submitted_value() {
+    // min_length constraint must be enforced even when value is submitted via alias.
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("name"))
+                .min_length(5)
+                .read_alias("user_name")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let too_short = FieldValues::from_json(json!({"user_name": "ab"})).unwrap();
+    let report = schema.validate(&too_short).unwrap_err();
+    assert!(
+        report.errors().any(|e| e.code == "min_length"),
+        "min_length validation must run on alias-submitted value; got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn nested_object_alias_is_canonicalized() {
+    let schema = Schema::builder()
+        .add(
+            Field::object(fk("user"))
+                .add(Field::string(fk("username")).read_alias("login").unwrap()),
+        )
+        .build()
+        .unwrap();
+
+    let submitted = FieldValues::from_json(json!({"user": {"login": "admin"}})).unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("nested alias must be accepted");
+
+    // Inner value must be stored under canonical key.
+    let user_value = valid.raw().get(&fk("user"));
+    if let Some(FieldValue::Object(inner_map)) = user_value {
+        assert!(
+            inner_map.get(&fk("username")).is_some(),
+            "nested value must be under canonical key"
+        );
+        assert!(
+            inner_map.get(&fk("login")).is_none(),
+            "alias key must be removed"
+        );
+    } else {
+        panic!("expected Object value for 'user', got: {user_value:?}");
+    }
+}
+
+// ── Security: alias must not bypass secret-strip ──────────────────────────────
+
+#[test]
+fn secret_via_alias_is_canonicalized_not_stored_under_alias_key() {
+    // SECURITY: if alias canonicalization fails, a secret stored under the alias key
+    // would bypass the secret-strip in context.rs (which indexes by field.key()).
+    let schema = Schema::builder()
+        .add(Field::secret(fk("api_key")).read_alias("token").unwrap())
+        .build()
+        .unwrap();
+
+    let submitted = FieldValues::from_json(json!({"token": "s3cr3t"})).unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("secret via alias must be accepted");
+
+    // Alias key must be absent; canonical key present so secret-strip can find it.
+    assert!(
+        valid.raw().get(&fk("token")).is_none(),
+        "alias key must not remain after ingest — secret would bypass secret-strip"
+    );
+    assert!(
+        valid.raw().get(&fk("api_key")).is_some(),
+        "secret must be stored under canonical key so context.rs redaction runs"
+    );
+}
+
+// ── Projection: ValidSchema::project ─────────────────────────────────────────
+
+#[test]
+fn project_emits_write_alias_key_instead_of_canonical_key() {
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("internal_id"))
+                .write_alias("externalId")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"internal_id": "abc123"})).unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["externalId"], json!("abc123"));
+    assert!(
+        projected.get("internal_id").is_none(),
+        "canonical key must not appear in projected output when write_alias is set"
+    );
+}
+
+#[test]
+fn project_emits_canonical_key_when_no_write_alias() {
+    let schema = Schema::builder()
+        .add(Field::string(fk("name")))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"name": "alice"})).unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["name"], json!("alice"));
+}
+
+#[test]
+fn project_excludes_secret_fields() {
+    let schema = Schema::builder()
+        .add(Field::string(fk("name")))
+        .add(Field::secret(fk("password")))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"name": "alice", "password": "s3cr3t"})).unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["name"], json!("alice"));
+    assert!(
+        projected.get("password").is_none(),
+        "secrets must never appear in projected output"
+    );
+}
+
+#[test]
+fn project_passes_extra_non_schema_keys_through_unchanged() {
+    let schema = Schema::builder()
+        .add(Field::string(fk("x")))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"x": "hello", "extra_key": 99})).unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["x"], json!("hello"));
+    assert_eq!(projected["extra_key"], json!(99));
+}
+
+#[test]
+fn project_recurses_into_nested_object_write_aliases() {
+    let schema = Schema::builder()
+        .add(
+            Field::object(fk("contact")).add(
+                Field::string(fk("phone_number"))
+                    .write_alias("phoneNumber")
+                    .unwrap(),
+            ),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"contact": {"phone_number": "555-1234"}})).unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["contact"]["phoneNumber"], json!("555-1234"));
+    assert!(
+        projected["contact"].get("phone_number").is_none(),
+        "canonical nested key must not appear in projected output"
+    );
+}
+
+// ── ValidValues::to_wire_json ─────────────────────────────────────────────────
+
+#[test]
+fn to_wire_json_applies_write_alias_to_validated_output() {
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("internal_field"))
+                .write_alias("wireField")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"internal_field": "payload"})).unwrap();
+    let valid = schema.validate(&values).expect("validates");
+    let wire = valid.to_wire_json();
+
+    assert_eq!(wire["wireField"], json!("payload"));
+    assert!(wire.get("internal_field").is_none());
+}
+
+// ── Lint: alias.* error codes ─────────────────────────────────────────────────
+
+#[test]
+fn lint_write_on_secret_emits_error() {
+    // Field::Secret with a write_alias is forbidden (exposes secret key on wire).
+    let report = Schema::builder()
+        .add(Field::secret(fk("api_key")).write_alias("apiKey").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.write_on_secret"),
+        "expected alias.write_on_secret, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_read_alias_equal_to_own_key_emits_self_collision() {
+    let report = Schema::builder()
+        .add(Field::string(fk("name")).read_alias("name").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.self_collision"),
+        "expected alias.self_collision, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_read_alias_equal_to_sibling_canonical_key_emits_scope_collision() {
+    let report = Schema::builder()
+        .add(Field::string(fk("name")).read_alias("email").unwrap())
+        .add(Field::string(fk("email")))
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.scope_collision"),
+        "expected alias.scope_collision, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_shared_read_alias_across_sibling_fields_emits_scope_duplicate() {
+    let report = Schema::builder()
+        .add(Field::string(fk("a")).read_alias("alt").unwrap())
+        .add(Field::string(fk("b")).read_alias("alt").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.scope_duplicate"),
+        "expected alias.scope_duplicate, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_write_alias_equal_to_sibling_canonical_key_emits_write_collision() {
+    // write_alias "target" collides with the canonical key of the "target" field.
+    let report = Schema::builder()
+        .add(Field::string(fk("source")).write_alias("target").unwrap())
+        .add(Field::string(fk("target")))
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.write_collision"),
+        "expected alias.write_collision, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_shared_write_alias_across_sibling_fields_emits_write_scope_duplicate() {
+    let report = Schema::builder()
+        .add(Field::string(fk("a")).write_alias("shared_out").unwrap())
+        .add(Field::string(fk("b")).write_alias("shared_out").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.write_scope_duplicate"),
+        "expected alias.write_scope_duplicate, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+// ── No-alias path stays wire-identical ───────────────────────────────────────
+
+#[test]
+fn field_without_aliases_emits_no_extra_wire_keys() {
+    // `read_aliases` must be skipped (`skip_serializing_if = "is_empty"`);
+    // `write_alias` must be skipped (`skip_serializing_if = "Option::is_none"`).
+    let field = Field::string(fk("name"))
+        .label("Name")
+        .required()
+        .into_field();
+    let wire = serde_json::to_value(&field).unwrap();
+
+    assert!(
+        wire.get("read_aliases").is_none(),
+        "read_aliases must not appear in wire format when empty"
+    );
+    assert!(
+        wire.get("write_alias").is_none(),
+        "write_alias must not appear in wire format when None"
+    );
+}
+
+#[test]
+fn schema_without_aliases_round_trips_byte_identical() {
+    let schema = Schema::builder()
+        .add(Field::string(fk("x")).required())
+        .add(Field::number(fk("y")))
+        .build()
+        .unwrap();
+
+    let wire_first = serde_json::to_string(&schema).unwrap();
+    let schema_back: Schema = serde_json::from_str(&wire_first).unwrap();
+    let wire_second = serde_json::to_string(&schema_back).unwrap();
+
+    assert_eq!(
+        wire_first, wire_second,
+        "no-alias schema must round-trip byte-identical"
+    );
+}
+
+// ── Security: aliases & secrets nested in Mode / List payloads ─────────────────
+//
+// Regression guards for the canonicalize/project/lint recursion gaps found in
+// the Step-12a adversarial review: a wire `{"mode","value"}` envelope parses to
+// a `FieldValue::Object` (never `FieldValue::Mode`), so canonicalization and
+// projection must handle the Object shape at every container depth, and the
+// build-time collision lint must reach the same depth the canonicalizer folds.
+
+/// Serialize a validated value tree to its wire string, for leak assertions.
+fn wire_string(valid: &nebula_schema::ValidValues) -> String {
+    serde_json::to_string(&valid.to_wire_json()).expect("wire json serializes")
+}
+
+#[test]
+fn mode_payload_secret_alias_canonicalized_not_leaked() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant(
+                    "apikey",
+                    "API Key",
+                    Field::object(fk("payload")).add(
+                        Field::secret(fk("api_key"))
+                            .read_alias("token_alias")
+                            .unwrap(),
+                    ),
+                )
+                .default_variant("apikey"),
+        )
+        .build()
+        .unwrap();
+
+    let submitted = FieldValues::from_json(json!({
+        "auth": {"mode": "apikey", "value": {"token_alias": "PLAINTEXT_SECRET"}}
+    }))
+    .unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("mode-payload alias must be accepted");
+
+    // The alias key must have folded onto the canonical secret key at depth.
+    let raw = valid.raw().to_json();
+    assert_eq!(
+        raw["auth"]["value"]["api_key"],
+        json!("PLAINTEXT_SECRET"),
+        "mode-payload alias must fold onto the canonical secret key"
+    );
+    assert!(
+        raw["auth"]["value"].get("token_alias").is_none(),
+        "alias key must not survive inside the mode payload"
+    );
+    // And the secret must never reach the wire — neither key nor plaintext.
+    assert!(
+        !wire_string(&valid).contains("PLAINTEXT_SECRET"),
+        "secret plaintext leaked into wire projection"
+    );
+}
+
+#[test]
+fn mode_payload_alias_canonicalized_via_default_variant() {
+    // `mode` omitted → the active variant comes from `default_variant`; a nested
+    // alias must still fold (regression for the default-variant ingest path).
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant(
+                    "token",
+                    "Token",
+                    Field::object(fk("payload")).add(
+                        Field::string(fk("client_id"))
+                            .read_alias("clientId")
+                            .unwrap(),
+                    ),
+                )
+                .default_variant("token"),
+        )
+        .build()
+        .unwrap();
+
+    let submitted =
+        FieldValues::from_json(json!({"auth": {"value": {"clientId": "abc"}}})).unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("default-variant nested alias must be accepted");
+
+    let raw = valid.raw().to_json();
+    assert_eq!(
+        raw["auth"]["value"]["client_id"],
+        json!("abc"),
+        "default-variant nested alias must fold onto the canonical key"
+    );
+    assert!(raw["auth"]["value"].get("clientId").is_none());
+}
+
+#[test]
+fn list_item_mode_payload_secret_alias_not_leaked() {
+    // The leak must also be closed through array-of-record bulk-ingest shapes.
+    let schema = Schema::builder()
+        .add(
+            Field::list(fk("rows")).item(
+                Field::object(fk("row")).add(
+                    Field::mode(fk("auth"))
+                        .variant(
+                            "apikey",
+                            "API Key",
+                            Field::object(fk("cfg"))
+                                .add(Field::secret(fk("api_key")).read_alias("token").unwrap()),
+                        )
+                        .default_variant("apikey"),
+                ),
+            ),
+        )
+        .build()
+        .unwrap();
+
+    // A mode variant's object payload maps its child fields directly under
+    // `value` — the variant field's own key is not a wire wrapper.
+    let submitted = FieldValues::from_json(json!({
+        "rows": [{"auth": {"mode": "apikey", "value": {"token": "PLAINTEXT_SECRET"}}}]
+    }))
+    .unwrap();
+    let valid = schema
+        .validate(&submitted)
+        .expect("list-item mode alias accepted");
+
+    let raw = valid.raw().to_json();
+    assert_eq!(
+        raw["rows"][0]["auth"]["value"]["api_key"],
+        json!("PLAINTEXT_SECRET"),
+        "alias inside a list-item mode payload must fold onto the canonical key"
+    );
+    assert!(raw["rows"][0]["auth"]["value"].get("token").is_none());
+    assert!(
+        !wire_string(&valid).contains("PLAINTEXT_SECRET"),
+        "secret plaintext leaked into wire projection from a list-item mode payload"
+    );
+}
+
+#[test]
+fn project_drops_secret_nested_in_list() {
+    // A secret nested in a list item must never appear in projection; its
+    // non-secret sibling must.
+    let schema = Schema::builder()
+        .add(
+            Field::list(fk("creds")).item(
+                Field::object(fk("cred"))
+                    .add(Field::string(fk("user")))
+                    .add(Field::secret(fk("password"))),
+            ),
+        )
+        .build()
+        .unwrap();
+
+    let values =
+        FieldValues::from_json(json!({"creds": [{"user": "alice", "password": "PLAINTEXT_LEAK"}]}))
+            .unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["creds"][0]["user"], json!("alice"));
+    assert!(
+        projected["creds"][0].get("password").is_none(),
+        "secret in a list item must be dropped from projection"
+    );
+    assert!(
+        !serde_json::to_string(&projected)
+            .unwrap()
+            .contains("PLAINTEXT_LEAK")
+    );
+}
+
+#[test]
+fn project_drops_secret_nested_in_mode_payload() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant(
+                    "basic",
+                    "Basic",
+                    Field::object(fk("payload"))
+                        .add(Field::string(fk("user")))
+                        .add(Field::secret(fk("password"))),
+                )
+                .default_variant("basic"),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "auth": {"mode": "basic", "value": {"user": "bob", "password": "MODE_SECRET"}}
+    }))
+    .unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["auth"]["value"]["user"], json!("bob"));
+    assert!(
+        projected["auth"]["value"].get("password").is_none(),
+        "secret in a mode payload must be dropped from projection"
+    );
+    assert!(
+        !serde_json::to_string(&projected)
+            .unwrap()
+            .contains("MODE_SECRET")
+    );
+}
+
+#[test]
+fn project_applies_write_alias_inside_list_items() {
+    let schema = Schema::builder()
+        .add(
+            Field::list(fk("rows")).item(
+                Field::object(fk("row")).add(
+                    Field::string(fk("internal_id"))
+                        .write_alias("externalId")
+                        .unwrap(),
+                ),
+            ),
+        )
+        .build()
+        .unwrap();
+
+    let values =
+        FieldValues::from_json(json!({"rows": [{"internal_id": "x1"}, {"internal_id": "x2"}]}))
+            .unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["rows"][0]["externalId"], json!("x1"));
+    assert_eq!(projected["rows"][1]["externalId"], json!("x2"));
+    assert!(
+        projected["rows"][0].get("internal_id").is_none(),
+        "canonical key must be remapped to the write_alias inside list items"
+    );
+}
+
+#[test]
+fn project_applies_write_alias_inside_mode_payload() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant(
+                    "token",
+                    "Token",
+                    Field::object(fk("payload")).add(
+                        Field::string(fk("client_id"))
+                            .write_alias("clientId")
+                            .unwrap(),
+                    ),
+                )
+                .default_variant("token"),
+        )
+        .build()
+        .unwrap();
+
+    let values =
+        FieldValues::from_json(json!({"auth": {"mode": "token", "value": {"client_id": "abc"}}}))
+            .unwrap();
+    let projected = schema.project(&values);
+
+    assert_eq!(projected["auth"]["value"]["clientId"], json!("abc"));
+    assert!(projected["auth"]["value"].get("client_id").is_none());
+}
+
+#[test]
+fn project_extra_key_cannot_clobber_write_alias_output() {
+    // INTEGRITY: an attacker-supplied extra key equal to a field's write_alias
+    // output name must not overwrite the field's real projected value.
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("internal_id"))
+                .write_alias("externalId")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let values =
+        FieldValues::from_json(json!({"internal_id": "REAL", "externalId": "ATTACKER"})).unwrap();
+
+    let projected = schema.project(&values);
+    assert_eq!(
+        projected["externalId"],
+        json!("REAL"),
+        "declared field must win over a colliding extra pass-through key"
+    );
+    // The validated path stores the extra key, so the guard must hold there too.
+    let valid = schema.validate(&values).expect("validates");
+    assert_eq!(valid.to_wire_json()["externalId"], json!("REAL"));
+}
+
+#[test]
+fn project_extra_key_cannot_occupy_absent_write_alias_output_slot() {
+    // INTEGRITY: a write-aliased field reserves its output slot even when the
+    // field is ABSENT this submission — an attacker-supplied extra key equal to
+    // that output name must not occupy the schema-owned slot.
+    let schema = Schema::builder()
+        .add(
+            Field::string(fk("internal_id"))
+                .write_alias("externalId")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    // `internal_id` is optional and omitted; only the spoof key is present.
+    let values = FieldValues::from_json(json!({"externalId": "ATTACKER"})).unwrap();
+
+    let projected = schema.project(&values);
+    assert!(
+        projected.get("externalId").is_none(),
+        "extra key must not occupy an absent write-aliased field's output slot, got: {projected}"
+    );
+    // Same on the validated wire path (validate stores the extra key).
+    let valid = schema.validate(&values).expect("validates");
+    assert!(valid.to_wire_json().get("externalId").is_none());
+}
+
+#[test]
+fn project_extra_key_cannot_occupy_dropped_secret_field_output_slot() {
+    // INTEGRITY: a secret-bearing structured field with a write_alias whose value
+    // is dropped (wrong-shape blob → over-redacted to nothing) still reserves its
+    // output slot; an extra key must not slip into it.
+    let schema = Schema::builder()
+        .add(
+            Field::object(fk("creds"))
+                .add(Field::secret(fk("password")))
+                .write_alias("credsOut")
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    // `creds` is a wrong-shape literal blob (dropped by the over-redact guard),
+    // plus an attacker payload under the reserved `credsOut` output name.
+    let values = FieldValues::from_json(json!({
+        "creds": "wrong-shape-blob",
+        "credsOut": {"injected": "ATTACKER"}
+    }))
+    .unwrap();
+
+    let projected = schema.project(&values);
+    assert!(
+        projected.get("credsOut").is_none(),
+        "extra key must not occupy a dropped write-aliased field's output slot, got: {projected}"
+    );
+    assert!(
+        !serde_json::to_string(&projected)
+            .unwrap()
+            .contains("ATTACKER"),
+        "attacker payload must not appear in projection"
+    );
+}
+
+#[test]
+fn project_on_raw_read_aliased_secret_does_not_leak() {
+    // `project` canonicalizes first, so a secret submitted under its read-alias
+    // is folded onto the canonical secret key and dropped — even when called
+    // directly on raw, never-validated values.
+    let schema = Schema::builder()
+        .add(Field::secret(fk("api_key")).read_alias("token").unwrap())
+        .build()
+        .unwrap();
+
+    let raw = FieldValues::from_json(json!({"token": "s3cr3t"})).unwrap();
+    let projected = schema.project(&raw);
+
+    assert!(
+        projected.get("token").is_none(),
+        "a secret submitted under its read-alias must not pass through projection"
+    );
+    assert!(
+        projected.get("api_key").is_none(),
+        "secret must be dropped, never emitted"
+    );
+    assert!(
+        !serde_json::to_string(&projected)
+            .unwrap()
+            .contains("s3cr3t")
+    );
+}
+
+#[test]
+fn lint_catches_alias_scope_collision_at_list_of_list_depth() {
+    // The collision lint must reach the same depth `canonicalize_aliases` folds.
+    // A read-alias stealing a sibling secret's canonical key two containers deep
+    // must still be rejected at build time.
+    let report = Schema::builder()
+        .add(
+            Field::list(fk("outer")).item(
+                Field::list(fk("inner")).item(
+                    Field::object(fk("row"))
+                        .add(Field::string(fk("public")).read_alias("api_key").unwrap())
+                        .add(Field::secret(fk("api_key"))),
+                ),
+            ),
+        )
+        .build()
+        .unwrap_err();
+
+    assert!(
+        has_error_code(&report, "alias.scope_collision"),
+        "expected alias.scope_collision at list-of-list depth, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_catches_alias_self_collision_at_mode_of_list_depth() {
+    let report = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant(
+                    "v",
+                    "V",
+                    Field::list(fk("items")).item(
+                        Field::object(fk("row"))
+                            .add(Field::string(fk("name")).read_alias("name").unwrap()),
+                    ),
+                )
+                .default_variant("v"),
+        )
+        .build()
+        .unwrap_err();
+
+    assert!(
+        has_error_code(&report, "alias.self_collision"),
+        "expected alias.self_collision at mode-of-list depth, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_catches_write_on_secret_for_bare_list_item() {
+    // A bare secret list item is not a scope member, so write_on_secret must be
+    // checked on it directly.
+    let report = Schema::builder()
+        .add(
+            Field::list(fk("tokens")).item(
+                Field::secret(fk("tok"))
+                    .write_alias("exposedToken")
+                    .unwrap(),
+            ),
+        )
+        .build()
+        .unwrap_err();
+
+    assert!(
+        has_error_code(&report, "alias.write_on_secret"),
+        "expected alias.write_on_secret for a bare secret list item, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_nested_self_collision_reported_exactly_once() {
+    // A single recursion owner: a collision inside a nested object is reported
+    // exactly once, not duplicated by a second recursion pass.
+    let report = Schema::builder()
+        .add(Field::object(fk("user")).add(Field::string(fk("name")).read_alias("name").unwrap()))
+        .build()
+        .unwrap_err();
+
+    let collision_count = report
+        .errors()
+        .filter(|e| e.code == "alias.self_collision")
+        .count();
+    assert_eq!(
+        collision_count, 1,
+        "nested self_collision must be reported exactly once, got {collision_count}"
+    );
+}

--- a/crates/schema/tests/alias.rs
+++ b/crates/schema/tests/alias.rs
@@ -447,6 +447,59 @@ fn lint_shared_write_alias_across_sibling_fields_emits_write_scope_duplicate() {
     );
 }
 
+#[test]
+fn lint_read_alias_colliding_with_sibling_write_alias_emits_read_write_collision() {
+    // `b.read_alias("wire")` collides with `a.write_alias("wire")`: project emits
+    // `a` under "wire", and a later validate folds "wire" into `b` — a wire
+    // round-trip silently moves data between the two fields.
+    let report = Schema::builder()
+        .add(Field::string(fk("a")).write_alias("wire").unwrap())
+        .add(Field::string(fk("b")).read_alias("wire").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.read_write_collision"),
+        "expected alias.read_write_collision, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_read_write_collision_caught_regardless_of_declaration_order() {
+    // Reverse declaration order: the read-alias field comes before the write one.
+    let report = Schema::builder()
+        .add(Field::string(fk("b")).read_alias("wire").unwrap())
+        .add(Field::string(fk("a")).write_alias("wire").unwrap())
+        .build()
+        .unwrap_err();
+    assert!(
+        has_error_code(&report, "alias.read_write_collision"),
+        "expected alias.read_write_collision regardless of order, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn lint_same_field_read_and_write_alias_reuse_is_allowed() {
+    // A field may read AND write under the same key — round-trip stable, allowed.
+    let result = Schema::builder()
+        .add(
+            Field::string(fk("internal"))
+                .read_alias("wire")
+                .unwrap()
+                .write_alias("wire")
+                .unwrap(),
+        )
+        .build();
+    assert!(
+        result.is_ok(),
+        "same-field read+write alias reuse must build, got: {:?}",
+        result
+            .err()
+            .map(|r| r.errors().map(|e| e.code.clone()).collect::<Vec<_>>())
+    );
+}
+
 // ── No-alias path stays wire-identical ───────────────────────────────────────
 
 #[test]

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -517,3 +517,43 @@ async fn resolve_promotes_mode_object_envelope_secrets_via_default_variant() {
         Some(&json!("<redacted>"))
     );
 }
+
+#[tokio::test]
+async fn resolved_expression_structured_value_with_noncanonical_keys_is_rejected() {
+    // Defense-by-construction for the alias subsystem: a resolved expression is
+    // stored as `FieldValue::Literal` (never a structured `Object/List/Mode`
+    // tree), and `resolve` introduces no new map keys. So an alias-keyed secret
+    // can never appear in a resolved structured tree for secret-promotion to
+    // miss — a structured field whose expression resolves to a literal-wrapped
+    // shape is rejected at the post-resolve revalidate as a type mismatch.
+    let schema = Schema::builder()
+        .add(
+            Field::object(field_key!("creds"))
+                .expression_mode(ExpressionMode::Allowed)
+                .add(
+                    Field::secret(field_key!("api_key"))
+                        .read_alias("token_alias")
+                        .unwrap(),
+                ),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"creds": {"$expr": "{{ $resolve }}"}})).unwrap();
+    let valid = schema.validate(&values).unwrap();
+
+    // The expression "resolves" to an object keyed by the read-alias — but it is
+    // stored as a Literal, so the object field rejects it instead of letting an
+    // alias-keyed secret slip past secret promotion.
+    let report = valid
+        .resolve(&ConstCtx(json!({"token_alias": "PLAINTEXT_SECRET"})))
+        .await
+        .unwrap_err();
+    assert!(
+        report
+            .errors()
+            .any(|e| e.code == "expression.type_mismatch"),
+        "structured field with a literal-resolved expression must be rejected, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## What

Adds a Pydantic-style **field-alias subsystem** to `nebula-schema` (fix-plan Step 12a, runtime core):

- **`read_aliases`** — extra accepted input keys, folded onto the canonical `FieldKey` at ingest (canonicalize-at-ingest), exactly like `#[serde(alias)]`. Canonical wins when both submitted.
- **`write_alias`** — optional output-key remapping applied during projection (`project` / `to_wire_json`).
- **`FieldAliases`** newtype (validated, intra-list dedup-checked, `serde(transparent)`); builder methods (`read_alias` / `read_aliases` / `write_alias`) + `Field`-enum accessors; **8 `alias.*` lint codes** enforced at `SchemaBuilder::build`.
- No-alias schemas stay **wire byte-identical** (`skip_serializing_if`), so this is additive on the wire.

## Security invariant

An alias-keyed value is folded onto its canonical `FieldKey` **before** secret-strip / predicate-context / loader redaction / projection run — so an alias-keyed **secret can never bypass redaction**. Canonicalization, projection, and the collision lint all descend the **same container shape** (object children, list items, the active mode-variant payload) as the existing secret-strip / loader walks.

## Adversarial review

Two multi-agent adversarial security reviews drove this PR (a design+impl review, then a fix-verification review). Confirmed and fixed:

| Defect | Severity | Fix |
|---|---|---|
| Alias-keyed secret in a **mode payload** escaped canonicalization (wire `{mode,value}` parses to `FieldValue::Object`, never `::Mode`) → plaintext leak | critical | Added the `(Field::Mode, FieldValue::Object)` canonicalize arm; variant resolved via selector / `default_variant`, recursing at every depth |
| `project`/`to_wire_json` leaked **plaintext secrets nested in List / Mode** (ran pre-resolve, only recursed `Object`) | critical | Rewrote projection to recurse list items + mode payloads, drop `Field::Secret` at every depth, apply nested write-aliases, over-redact shape-mismatched blobs |
| Collision lint under-recursed vs the canonicalizer (missed list-of-list / mode-of-list) + double-emitted diagnostics | high | Single recursion owner; driver descends List/Mode of any kind; unary `write_on_secret` on bare list-item / mode-variant secrets |
| Pass-through extra key could **spoof a declared field's output slot** (canonical-via-alias leak; write-alias clobber on present **and** absent/dropped fields) | high | `project` canonicalizes at entry; every field's output slot (canonical + write-alias) reserved **unconditionally** against pass-through extras |

No secret plaintext leaks remain; the fix-verification review's only confirmed findings were one integrity gap (absent/dropped write-aliased output slot), now closed.

## Tests / gates

- **39 alias integration tests** (`crates/schema/tests/alias.rs`): canonicalization (incl. nested object / list / mode / default-variant), secret-safety, projection, all collision lint codes, integrity/spoofing, no-alias byte-identity.
- `cargo nextest -p nebula-schema --all-features`: **590 passed**.
- `clippy -D warnings`, `fmt --check`, `rustdoc -D warnings` clean; full `cargo check --workspace` builds.

## Follow-up (separate PR)

Step 12b — `#[derive(Schema)]` macro support for aliases (`#[serde(alias)]` → `read_alias`, `#[field(write_alias=…)]` with compile-fail on secrets, alias-generator). Not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fields can now have read aliases—alternate names for submitting data
  * Fields can have write aliases—alternate names for data output
  * Automatic validation prevents alias conflicts and ensures data integrity
  * Security safeguards prevent sensitive information from leaking through aliases
  * Data submitted under aliases is properly reconciled with canonical field names

* **Tests**
  * Comprehensive test coverage for alias functionality, validation, and security scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->