### PR TITLE
feat(schema)!: sum-type SchemaKind::Union keystone + Mode variance + correctness fixes

### DIFF
--- a/crates/engine/src/resolver.rs
+++ b/crates/engine/src/resolver.rs
@@ -129,12 +129,27 @@ impl ParamResolver {
 
 /// Navigate a JSON value by a dot-separated path.
 ///
-/// Supports object key access and array index access:
+/// Supports object key access and array index access, with an optional JSONPath
+/// root prefix:
 /// - `"data.items"` → `value["data"]["items"]`
+/// - `"$.data.items"` → same (the `$.` root is stripped)
 /// - `"items.0.name"` → `value["items"][0]["name"]`
+/// - `"$"` → the whole value (root)
+///
+/// The public [`ParamValue::reference`](nebula_workflow::ParamValue::reference)
+/// constructor documents `output_path` as JSONPath (`$.data.items`), while this
+/// navigator splits on `.`. Stripping an optional leading `$.` (or a bare `$`)
+/// reconciles the two grammars so both forms resolve to the same location;
+/// without it a `$.`-prefixed path looked up a literal `"$"` key and silently
+/// resolved to `Null`. (A JSON object key literally named `$…` is not
+/// addressable — `$` is reserved for the JSONPath root, as in the standard.)
 ///
 /// Returns `Value::Null` for missing keys or out-of-bounds indices.
 fn navigate_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
+    let path = match path.strip_prefix("$.") {
+        Some(rest) => rest,
+        None => path.strip_prefix('$').unwrap_or(path),
+    };
     if path.is_empty() {
         return value.clone();
     }
@@ -211,6 +226,31 @@ mod tests {
     fn navigate_path_array_with_non_numeric_returns_null() {
         let val = json!([1, 2, 3]);
         assert_eq!(navigate_path(&val, "name"), json!(null));
+    }
+
+    /// The documented JSONPath grammar (`$.data.items`) must resolve to the same
+    /// place as the bare-dotted form. Before the root-prefix reconciliation a
+    /// `$.`-prefixed path looked up a literal `"$"` key and returned `Null`.
+    #[test]
+    fn navigate_path_strips_jsonpath_root_prefix() {
+        let val = json!({"data": {"items": [1, 2, 3]}});
+        assert_eq!(
+            navigate_path(&val, "$.data.items.0"),
+            json!(1),
+            "`$.`-prefixed JSONPath must resolve like the bare-dotted form"
+        );
+        // Both grammars agree.
+        assert_eq!(
+            navigate_path(&val, "$.data.items"),
+            navigate_path(&val, "data.items"),
+        );
+    }
+
+    /// A bare `$` is the JSONPath root — the whole value.
+    #[test]
+    fn navigate_path_bare_root_returns_whole_value() {
+        let val = json!({"a": 1});
+        assert_eq!(navigate_path(&val, "$"), val);
     }
 
     // -- resolve tests --

--- a/crates/execution/src/idempotency.rs
+++ b/crates/execution/src/idempotency.rs
@@ -14,34 +14,70 @@ use serde::{Deserialize, Serialize};
 /// A deterministic key used to ensure exactly-once execution of a node attempt.
 ///
 /// Two composition modes:
-/// - **Stateless / one-shot:** `{execution_id}:{node_key}:{attempt}` — see
-///   [`for_attempt`](Self::for_attempt).
-/// - **Stateful per-iteration:** `{execution_id}:{node_key}:{iteration}:{attempt}` — see
-///   [`for_iteration`](Self::for_iteration). Spec 28 §9.0 makes the iteration counter load-bearing
-///   so a resumed stateful action reuses the same key for the same iteration boundary on retry.
-/// - **Business dedup:** callers may append a `StatefulAction::idempotency_key(state)` via
-///   [`with_business_key`](Self::with_business_key) — e.g. to key payments by invoice ID instead of
-///   attempt number.
+/// - **Stateless / one-shot:** an attempt-tagged frame of `execution_id`,
+///   `node_key`, `attempt` — see [`for_attempt`](Self::for_attempt).
+/// - **Stateful per-iteration:** an iteration-tagged frame additionally carrying
+///   the iteration counter — see [`for_iteration`](Self::for_iteration). Spec 28
+///   §9.0 makes the iteration counter load-bearing so a resumed stateful action
+///   reuses the same key for the same iteration boundary on retry.
+/// - **Business dedup:** callers may append a `StatefulAction::idempotency_key(state)`
+///   via [`with_business_key`](Self::with_business_key) — e.g. to key payments by
+///   invoice ID instead of attempt number.
+///
+/// # Injective encoding
+///
+/// The components are **length-prefixed** (`{byte_len}:{bytes}` per part, plus a
+/// leading kind tag distinguishing attempt- from iteration-frames), not joined by
+/// a bare `:`. A naive `format!("{execution_id}:{node_key}:{attempt}")` is
+/// non-injective the moment a *variable-length* component can contain the
+/// separator: an author business key of `"0:extra"` appended to a stateless
+/// attempt-0 key would collide with a stateful iteration-0 attempt-0 key keyed by
+/// `"extra"` — a false dedup (the classic missed-payment / double-execution bug).
+/// Framing each part by its length makes the key injective regardless of what any
+/// component contains, so callers never have to guarantee a component is
+/// separator-free. (The string is an opaque dedup token; this format is not a
+/// stable wire contract.)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IdempotencyKey(String);
 
+/// Append one length-prefixed component (`{byte_len}:{part}`) to `buf`.
+///
+/// The decimal length is itself separator-free, so the `:` after it unambiguously
+/// ends the length, and the length states exactly how many following bytes belong
+/// to `part`. Concatenating parts this way is injective even when a part contains
+/// `:` — the property a bare colon-join lacks.
+fn push_part(buf: &mut String, part: &str) {
+    use std::fmt::Write as _;
+    // Writing to a String is infallible; the Result is discarded deliberately.
+    let _ = write!(buf, "{}:{}", part.len(), part);
+}
+
 impl IdempotencyKey {
-    /// Generate a stateless key — `{execution_id}:{node_key}:{attempt}`.
+    /// Generate a stateless key tagged `"a"` (attempt) over `execution_id`,
+    /// `node_key`, `attempt`.
     ///
     /// Used for `StatelessAction`, `ResourceAction`, and control-flow nodes
     /// that do not iterate. The `attempt` counter advances on retry; a single
     /// attempt dispatches exactly once.
     #[must_use]
     pub fn for_attempt(execution_id: ExecutionId, node_key: NodeKey, attempt: u32) -> Self {
-        Self(format!("{execution_id}:{node_key}:{attempt}"))
+        let mut key = String::new();
+        push_part(&mut key, "a");
+        push_part(&mut key, &execution_id.to_string());
+        push_part(&mut key, node_key.as_str());
+        push_part(&mut key, &attempt.to_string());
+        Self(key)
     }
 
-    /// Generate a stateful per-iteration key — `{execution_id}:{node_key}:{iteration}:{attempt}`.
+    /// Generate a stateful per-iteration key tagged `"i"` (iteration) over
+    /// `execution_id`, `node_key`, `iteration`, `attempt`.
     ///
     /// Called by the runtime before each `StatefulAction::execute` dispatch.
     /// The iteration counter is the same one the runtime uses to enforce
     /// `MAX_ITERATIONS` and for `StatefulCheckpoint::iteration`, so resuming
-    /// after a crash reuses the exact key that was in flight.
+    /// after a crash reuses the exact key that was in flight. The distinct kind
+    /// tag keeps the attempt- and iteration-frames in separate namespaces, so a
+    /// stateless key can never collide with a stateful one.
     #[must_use]
     pub fn for_iteration(
         execution_id: ExecutionId,
@@ -49,21 +85,28 @@ impl IdempotencyKey {
         iteration: u32,
         attempt: u32,
     ) -> Self {
-        Self(format!("{execution_id}:{node_key}:{iteration}:{attempt}"))
+        let mut key = String::new();
+        push_part(&mut key, "i");
+        push_part(&mut key, &execution_id.to_string());
+        push_part(&mut key, node_key.as_str());
+        push_part(&mut key, &iteration.to_string());
+        push_part(&mut key, &attempt.to_string());
+        Self(key)
     }
 
     /// Append an author-supplied business dedup suffix — the value returned by
-    /// `StatefulAction::idempotency_key(&state)`. Format: `{base}:{business}`.
+    /// `StatefulAction::idempotency_key(&state)` — as one length-prefixed part.
     ///
     /// Callers that want external systems (payment gateways, ticketing APIs)
     /// to dedup on their own notion of identity (invoice ID, job ID, ...) pass
-    /// the business key through here. An empty business key leaves the base
+    /// the business key through here. The length-prefixed framing means a
+    /// business key containing `:` (or chaining two business keys) is injective —
+    /// it cannot forge a different key. An empty business key leaves the base
     /// key unchanged.
     #[must_use]
     pub fn with_business_key(mut self, business: &str) -> Self {
         if !business.is_empty() {
-            self.0.push(':');
-            self.0.push_str(business);
+            push_part(&mut self.0, business);
         }
         self
     }
@@ -162,5 +205,34 @@ mod tests {
         let json = serde_json::to_string(&key).expect("serialize");
         let back: IdempotencyKey = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(key, back);
+    }
+
+    /// A single business key `"a:b"` must not equal chaining `"a"` then `"b"`: the
+    /// separator inside one part cannot be confused with a part boundary. Under the
+    /// old bare colon-join both produced `{base}:a:b` — a collision.
+    #[test]
+    fn business_key_with_separator_is_injective() {
+        let exec = ExecutionId::new();
+        let node = node_key!("pay");
+        let one = IdempotencyKey::for_attempt(exec, node.clone(), 0).with_business_key("a:b");
+        let two = IdempotencyKey::for_attempt(exec, node, 0)
+            .with_business_key("a")
+            .with_business_key("b");
+        assert_ne!(one, two, "framing must keep `a:b` distinct from `a`+`b`");
+    }
+
+    /// The attempt- and iteration-frames stay in separate namespaces even when the
+    /// trailing components coincide: a stateless attempt-0 keyed by the business
+    /// string `"5"` must not equal a stateful iteration-0 attempt-5 key. Under the
+    /// old colon-join both flattened to `{exec}:{node}:0:5` — a false dedup across
+    /// two distinct executions (the missed-payment bug).
+    #[test]
+    fn attempt_frame_never_collides_with_iteration_frame() {
+        let exec = ExecutionId::new();
+        let node = node_key!("n");
+        let attempt_framed =
+            IdempotencyKey::for_attempt(exec, node.clone(), 0).with_business_key("5");
+        let iteration_framed = IdempotencyKey::for_iteration(exec, node, 0, 5);
+        assert_ne!(attempt_framed, iteration_framed);
     }
 }

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -612,6 +612,19 @@ pub(crate) struct SerdeAttrs {
     /// `#[serde(alias = "..")]` keys (deserialize-only alternative wire keys).
     /// Empty unless the field carries one or more aliases.
     pub aliases: Vec<String>,
+    /// `#[serde(tag = "..")]` — the discriminant key. On an enum container this
+    /// selects internally- (no `content`) or adjacently- (`with content`) tagged
+    /// representation; the union derive reads it to record [`SerdeTagging`].
+    pub tag: Option<String>,
+    /// `#[serde(content = "..")]` — the payload key for adjacent tagging.
+    pub content: Option<String>,
+    /// `#[serde(untagged)]` — present on the enum container.
+    pub untagged: bool,
+    /// `Some(span)` when `#[serde(rename_all_fields = ..)]` is present on an enum
+    /// container. The union derive does not yet honor it (it would rename every
+    /// struct-variant field), so it is rejected rather than silently ignored —
+    /// ignoring it would desync the schema key from the wire key (a C1 break).
+    pub rename_all_fields_span: Option<Span>,
 }
 
 impl SerdeAttrs {
@@ -633,6 +646,18 @@ impl SerdeAttrs {
                     },
                     Meta::NameValue(nv) if nv.path.is_ident("alias") => {
                         out.aliases.push(expr_str(&nv.value, "alias")?);
+                    },
+                    Meta::NameValue(nv) if nv.path.is_ident("tag") => {
+                        out.tag = Some(expr_str(&nv.value, "tag")?);
+                    },
+                    Meta::NameValue(nv) if nv.path.is_ident("content") => {
+                        out.content = Some(expr_str(&nv.value, "content")?);
+                    },
+                    Meta::Path(p) if p.is_ident("untagged") => {
+                        out.untagged = true;
+                    },
+                    Meta::NameValue(nv) if nv.path.is_ident("rename_all_fields") => {
+                        out.rename_all_fields_span = Some(nv.span());
                     },
                     Meta::Path(p) if p.is_ident("skip") || p.is_ident("skip_deserializing") => {
                         out.skip = true;

--- a/crates/schema/macros/src/derive_enum_union.rs
+++ b/crates/schema/macros/src/derive_enum_union.rs
@@ -155,12 +155,22 @@ pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     ::std::sync::OnceLock::new();
                 __CACHE
                     .get_or_init(|| {
-                        let __mode = #crate_path::Field::mode(
-                            #crate_path::FieldKey::new(#UNION_ROOT_KEY)
-                                .expect("union root key is a valid FieldKey"),
-                        )
-                        #( #variant_calls )*;
-                        match #crate_path::ValidSchema::union(__mode, #tagging) {
+                        // Build inside a `Result`-returning closure so a non-record
+                        // newtype payload (`union_newtype_payload`) propagates via
+                        // `?` into the single error/log path below — the failure
+                        // surfaces here, not as a panic from library code.
+                        let __build = || -> ::core::result::Result<
+                            #crate_path::ValidSchema,
+                            #crate_path::error::ValidationReport,
+                        > {
+                            let mut __mode = #crate_path::Field::mode(
+                                #crate_path::FieldKey::new(#UNION_ROOT_KEY)
+                                    .expect("union root key is a valid FieldKey"),
+                            );
+                            #( __mode = __mode #variant_calls; )*
+                            #crate_path::ValidSchema::union(__mode, #tagging)
+                        };
+                        match __build() {
                             ::core::result::Result::Ok(s) => s,
                             ::core::result::Result::Err(report) => {
                                 #crate_path::__private::tracing::error!(
@@ -273,7 +283,7 @@ fn build_variant_call(
                             <#payload_ty as #crate_path::HasSchema>::schema(),
                             #enum_name,
                             #wire_key,
-                        )
+                        )?
                     };
                     Ok(quote! { .variant(#wire_key, #label, #payload) })
                 },

--- a/crates/schema/macros/src/derive_enum_union.rs
+++ b/crates/schema/macros/src/derive_enum_union.rs
@@ -1,0 +1,343 @@
+//! Implementation of `#[derive(Schema)]` for payload-carrying enums.
+//!
+//! A Rust enum becomes a tagged-union schema ([`SchemaKind::Union`]): one
+//! variant per enum variant, stored as the schema's sole root `Field::Mode`
+//! (the marker design — see `nebula_schema::SchemaKind::Union`). The variant wire
+//! keys and the recorded [`SerdeTagging`] reproduce serde's exact wire shape so
+//! the schema variant key always equals the wire key (the C1 invariant the whole
+//! serde-aware derive exists to protect).
+//!
+//! # Supported shapes
+//!
+//! - **Tagging:** external (serde default) and adjacent
+//!   (`#[serde(tag = "..", content = "..")]`). Internally-tagged
+//!   (`#[serde(tag = "..")]` alone) and untagged (`#[serde(untagged)]`) are
+//!   **rejected** — the former inlines the tag into the payload's field namespace,
+//!   the latter has no discriminant key, so neither can satisfy C1.
+//! - **Variants:** unit (→ no payload), newtype `V(T)` where `T` derives
+//!   [`HasSchema`] as a struct, and struct `V { .. }`. **Rejected:** tuple
+//!   variants with more than one field, a newtype over a non-struct payload
+//!   (primitive / `Vec` / `Option`), and `#[serde(flatten)]` on a variant field.
+//! - **Renaming:** a variant's wire key follows serde — `#[serde(rename = "..")]`
+//!   wins, else the container's `#[serde(rename_all = "..")]` applied to the
+//!   variant, else the variant ident verbatim (serde's real default, *not*
+//!   snake_case). A struct variant's field keys follow the **variant's** own
+//!   `#[serde(rename_all)]` (serde does not cascade the container rule to
+//!   struct-variant fields); the container `#[serde(rename_all_fields = ..)]` is
+//!   rejected rather than silently ignored.
+
+use std::collections::HashMap;
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Data, DataEnum, DeriveInput, Fields, Ident, Variant, ext::IdentExt};
+
+use crate::{
+    attrs::{FieldAttrs, RenameRule, SerdeAttrs, ValidateAttrs},
+    derive_schema::{build_field_expr, resolve_field_key},
+    type_infer::{FieldKind, classify},
+};
+
+/// Root key of the union's sole `Field::Mode`. Internal — *not* a wire key (the
+/// wire discriminants are the variant keys); it only exists because every field
+/// needs a `FieldKey`. A leading underscore is a valid key and signals "synthetic".
+const UNION_ROOT_KEY: &str = "_nebula_union";
+
+pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let crate_path = crate::crate_path();
+    let ty_name = &input.ident;
+    let generics = &input.generics;
+    let (impl_g, ty_g, where_g) = generics.split_for_impl();
+
+    let Data::Enum(DataEnum { variants, .. }) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            ty_name,
+            "internal error: derive_enum_union expects an enum",
+        ));
+    };
+
+    let container_serde = SerdeAttrs::from_attrs(&input.attrs)?;
+    if let Some(span) = container_serde.rename_all_fields_span {
+        return Err(syn::Error::new(
+            span,
+            "#[serde(rename_all_fields = ..)] is not yet honored by #[derive(Schema)] on enums; \
+             put #[serde(rename_all = ..)] on each struct variant instead",
+        ));
+    }
+    let tagging = classify_tagging(&container_serde, ty_name)?;
+
+    let enum_name = ty_name.to_string();
+    let mut variant_calls = Vec::with_capacity(variants.len());
+    let mut seen_keys: HashMap<String, Ident> = HashMap::with_capacity(variants.len());
+    for variant in variants {
+        let variant_serde = SerdeAttrs::from_attrs(&variant.attrs)?;
+        // `#[serde(skip)]` / `#[serde(skip_deserializing)]` mean the deserializer
+        // never produces this variant, so it is not a *deserialization* arm. (The
+        // union schema is a deserialization contract — see `SchemaKind::Union`. A
+        // `skip_deserializing` variant can still *serialize*, but no value-layer
+        // ingress validates serialized output against a union yet, so dropping it
+        // here keeps the input contract honest.)
+        if variant_serde.skip {
+            continue;
+        }
+        // A `#[serde(alias = "..")]` on a variant is an extra wire key serde will
+        // still deserialize into it — but the union records only one discriminant
+        // per variant, so the alias would be a serde-accepted key the validator
+        // rejects (a C1 desync). Reject it: pick one canonical wire key.
+        if !variant_serde.aliases.is_empty() {
+            return Err(syn::Error::new_spanned(
+                &variant.ident,
+                format!(
+                    "#[serde(alias = ..)] on the variant `{}` cannot be modeled by #[derive(Schema)]: \
+                     a union records exactly one wire discriminant per variant, so the alias would be \
+                     a key serde deserializes but schema validation rejects. Remove the alias, or make \
+                     it the canonical key with #[serde(rename = ..)].",
+                    variant.ident.unraw(),
+                ),
+            ));
+        }
+        let wire_key =
+            resolve_variant_key(&variant.ident, &variant_serde, container_serde.rename_all);
+        // Variant keys are used as schema path segments and as `Mode` variant keys
+        // (which the runtime lint validates via `FieldKey::new`), so an invalid key
+        // would panic the generated `schema()`. Reject it at expansion with a
+        // single, variant-anchored message.
+        if let Err(reason) = crate::validate_field_key(&wire_key) {
+            return Err(syn::Error::new(
+                variant.ident.span(),
+                format!(
+                    "variant `{}` resolves to the wire key `{wire_key}`, which is not a valid \
+                     schema key ({reason}); rename the variant (or set `#[serde(rename = \"..\")]`) \
+                     so its key is a non-empty ASCII identifier — variant keys are used as schema \
+                     path segments",
+                    variant.ident.unraw(),
+                ),
+            ));
+        }
+        if let Some(previous) = seen_keys.insert(wire_key.clone(), variant.ident.clone()) {
+            return Err(syn::Error::new_spanned(
+                &variant.ident,
+                format!(
+                    "variants `{previous}` and `{}` both map to the union wire key `{wire_key}` — \
+                     rename one so the discriminants are distinct",
+                    variant.ident.unraw(),
+                ),
+            ));
+        }
+
+        let variant_attr = FieldAttrs::from_attrs(&variant.attrs)?;
+        let label = variant_attr
+            .label
+            .unwrap_or_else(|| variant.ident.unraw().to_string());
+        variant_calls.push(build_variant_call(
+            variant,
+            &wire_key,
+            &label,
+            &variant_serde,
+            &enum_name,
+            &crate_path,
+        )?);
+    }
+
+    if variant_calls.is_empty() {
+        return Err(syn::Error::new_spanned(
+            ty_name,
+            "#[derive(Schema)] on an enum needs at least one non-skipped variant",
+        ));
+    }
+
+    let ty_name_str = ty_name.to_string();
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_g #crate_path::HasSchema for #ty_name #ty_g #where_g {
+            fn schema() -> #crate_path::ValidSchema {
+                static __CACHE: ::std::sync::OnceLock<#crate_path::ValidSchema> =
+                    ::std::sync::OnceLock::new();
+                __CACHE
+                    .get_or_init(|| {
+                        let __mode = #crate_path::Field::mode(
+                            #crate_path::FieldKey::new(#UNION_ROOT_KEY)
+                                .expect("union root key is a valid FieldKey"),
+                        )
+                        #( #variant_calls )*;
+                        match #crate_path::ValidSchema::union(__mode, #tagging) {
+                            ::core::result::Result::Ok(s) => s,
+                            ::core::result::Result::Err(report) => {
+                                #crate_path::__private::tracing::error!(
+                                    target: "nebula_schema::derive",
+                                    type_name = #ty_name_str,
+                                    report = ?report,
+                                    "#[derive(Schema)] union schema-level lint failed at runtime"
+                                );
+                                ::core::panic!(
+                                    "#[derive(Schema)] on enum `{}` produced an invalid union \
+                                     schema — a variant's payload conflicts with a schema-level \
+                                     lint. Report: {:?}",
+                                    #ty_name_str,
+                                    report,
+                                );
+                            },
+                        }
+                    })
+                    .clone()
+            }
+        }
+    })
+}
+
+/// Map the container's serde tagging attributes to a `SerdeTagging` constructor
+/// token stream, rejecting the representations a faithful union schema cannot model.
+fn classify_tagging(serde: &SerdeAttrs, ty_name: &Ident) -> syn::Result<TokenStream2> {
+    let crate_path = crate::crate_path();
+    if serde.untagged {
+        return Err(syn::Error::new_spanned(
+            ty_name,
+            "#[serde(untagged)] enums are not supported by #[derive(Schema)] — an untagged union \
+             has no discriminant key, so the schema cannot reproduce its wire shape",
+        ));
+    }
+    match (&serde.tag, &serde.content) {
+        (Some(tag), Some(content)) => Ok(quote! {
+            #crate_path::SerdeTagging::Adjacent {
+                tag: #tag.to_owned(),
+                content: #content.to_owned(),
+            }
+        }),
+        (Some(_), None) => Err(syn::Error::new_spanned(
+            ty_name,
+            "internally-tagged enums (`#[serde(tag = ..)]` without `content`) are not supported — \
+             the tag inlines into the payload's field namespace; add `#[serde(content = ..)]` for \
+             adjacent tagging",
+        )),
+        (None, Some(_)) => Err(syn::Error::new_spanned(
+            ty_name,
+            "#[serde(content = ..)] requires #[serde(tag = ..)]",
+        )),
+        (None, None) => Ok(quote! { #crate_path::SerdeTagging::External }),
+    }
+}
+
+/// Resolve a variant's wire key, following serde exactly: an explicit
+/// `#[serde(rename = "..")]` wins, else the container's `#[serde(rename_all)]`
+/// applied to the variant via serde's variant algorithm, else the variant ident
+/// **verbatim** (serde's real default for enum variants).
+fn resolve_variant_key(
+    variant_name: &Ident,
+    serde: &SerdeAttrs,
+    container_rename_all: Option<RenameRule>,
+) -> String {
+    if let Some(rename) = &serde.rename {
+        return rename.clone();
+    }
+    let base = variant_name.unraw().to_string();
+    match container_rename_all {
+        Some(rule) => rule.apply_to_variant(&base),
+        None => base,
+    }
+}
+
+/// Build the `.variant(..)` / `.variant_empty(..)` call for one enum variant.
+fn build_variant_call(
+    variant: &Variant,
+    wire_key: &str,
+    label: &str,
+    variant_serde: &SerdeAttrs,
+    enum_name: &str,
+    crate_path: &TokenStream2,
+) -> syn::Result<TokenStream2> {
+    match &variant.fields {
+        Fields::Unit => Ok(quote! { .variant_empty(#wire_key, #label) }),
+        Fields::Unnamed(unnamed) => {
+            let mut fields = unnamed.unnamed.iter();
+            let (Some(only), None) = (fields.next(), fields.next()) else {
+                return Err(syn::Error::new_spanned(
+                    variant,
+                    "tuple variants with more than one field are not supported by \
+                     #[derive(Schema)]; use a struct variant `{ .. }` with named fields",
+                ));
+            };
+            // A newtype variant `V(T)`: serde external emits `{ "V": <T> }`, so the
+            // payload is `T`'s schema. `classify` is syntactic and cannot tell a
+            // struct from an enum or `serde_json::Value`, so the macro accepts any
+            // `UserDefined` type here and the runtime guard `union_newtype_payload`
+            // rejects a non-record payload at `schema()` init (a union/`Any` payload
+            // would otherwise splice keys serde never emits — a C1 break). Primitive
+            // / `Vec` / `Option` payloads are rejected at expansion (no field shape).
+            match classify(&only.ty) {
+                FieldKind::UserDefined(ty) => {
+                    let payload_ty = &*ty;
+                    let payload = quote! {
+                        #crate_path::__private::union_newtype_payload(
+                            #crate_path::FieldKey::new(#wire_key)
+                                .expect("variant wire key validated at macro expansion"),
+                            <#payload_ty as #crate_path::HasSchema>::schema(),
+                            #enum_name,
+                            #wire_key,
+                        )
+                    };
+                    Ok(quote! { .variant(#wire_key, #label, #payload) })
+                },
+                _ => Err(syn::Error::new_spanned(
+                    &only.ty,
+                    "a newtype variant's payload must be a struct that derives `Schema`; \
+                     primitive, `Vec`, and `Option` newtype payloads are not yet supported — \
+                     wrap the value in a `#[derive(Schema)]` struct",
+                )),
+            }
+        },
+        Fields::Named(named) => {
+            let mut field_exprs = Vec::with_capacity(named.named.len());
+            for field in &named.named {
+                let field_name = field.ident.as_ref().ok_or_else(|| {
+                    syn::Error::new_spanned(field, "anonymous struct-variant field")
+                })?;
+                let field_serde = SerdeAttrs::from_attrs(&field.attrs)?;
+                if let Some(flatten_span) = field_serde.flatten_span {
+                    return Err(syn::Error::new(
+                        flatten_span,
+                        "#[serde(flatten)] is not supported inside a struct variant",
+                    ));
+                }
+                let field_attr = FieldAttrs::from_attrs(&field.attrs)?;
+                if field_attr.skip || field_serde.skip {
+                    continue;
+                }
+                let validate = ValidateAttrs::from_attrs(&field.attrs)?;
+                let kind = classify(&field.ty);
+                // Struct-variant field keys follow the VARIANT's own rename_all
+                // (serde does not cascade the container rule to them).
+                let key_str =
+                    resolve_field_key(field_name, &field_serde, variant_serde.rename_all)?;
+                // Field-level `#[serde(alias)]` become read-aliases on the payload
+                // field (deduped — serde tolerates a repeated alias but the runtime
+                // alias lint rejects duplicates; each validated as a `FieldKey`).
+                let mut field_read_aliases: Vec<String> =
+                    Vec::with_capacity(field_serde.aliases.len());
+                for alias in &field_serde.aliases {
+                    if field_read_aliases.iter().any(|seen| seen == alias) {
+                        continue;
+                    }
+                    crate::derive_schema::check_field_key(alias, field_name.span())?;
+                    field_read_aliases.push(alias.clone());
+                }
+                field_exprs.push(build_field_expr(
+                    field_name,
+                    &key_str,
+                    &kind,
+                    &field_attr,
+                    &validate,
+                    &field_read_aliases,
+                    crate_path,
+                )?);
+            }
+            let payload = quote! {
+                #crate_path::Field::object(
+                    #crate_path::FieldKey::new(#wire_key)
+                        .expect("variant wire key validated at macro expansion"),
+                )
+                #( .add(#field_exprs) )*
+            };
+            Ok(quote! { .variant(#wire_key, #label, #payload) })
+        },
+    }
+}

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -28,6 +28,30 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
     let generics = &input.generics;
     let (impl_g, ty_g, where_g) = generics.split_for_impl();
 
+    // Reject generic type/const parameters (lifetimes are fine — a schema does not
+    // depend on one). The generated `schema()` caches its result in a single
+    // `static OnceLock`, which is shared across ALL monomorphizations of a generic
+    // type: the first-instantiated `T` would populate it and every other `T` would
+    // get that wrong schema (a silent wire-key drift). Refuse to emit an impl we
+    // cannot make correct, rather than ship the footgun. (Covers the enum/union
+    // path too: it is reached from the dispatch below.)
+    if let Some(param) = generics.type_params().next() {
+        return Err(syn::Error::new_spanned(
+            param,
+            "#[derive(Schema)] does not support generic type parameters: the generated `schema()` \
+             caches one `OnceLock` shared across every monomorphization, so all but the first `T` \
+             would get the wrong schema. Implement `HasSchema` by hand for generic types.",
+        ));
+    }
+    if let Some(param) = generics.const_params().next() {
+        return Err(syn::Error::new_spanned(
+            param,
+            "#[derive(Schema)] does not support const generic parameters: the generated `schema()` \
+             caches one `OnceLock` shared across every monomorphization. Implement `HasSchema` by \
+             hand instead.",
+        ));
+    }
+
     let fields = match &input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(named),
@@ -39,10 +63,17 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
                 "#[derive(Schema)] only supports structs with named fields",
             ));
         },
-        Data::Enum(_) | Data::Union(_) => {
+        // `#[derive(Schema)]` on an enum means "this enum IS a schema" — a tagged
+        // union (`SchemaKind::Union`), one variant per enum variant. (To embed an
+        // enum as a select *field* inside a struct, use `#[field(enum_select)]` +
+        // `#[derive(EnumSelect)]` instead — that is a `SelectField`, not a union.)
+        // Borrowing `&input` here while the match borrows `&input.data` is fine:
+        // both are shared borrows.
+        Data::Enum(_) => return crate::derive_enum_union::expand(&input),
+        Data::Union(_) => {
             return Err(syn::Error::new_spanned(
                 ty_name,
-                "#[derive(Schema)] only supports structs; use #[derive(EnumSelect)] for enums",
+                "#[derive(Schema)] does not support `union` types",
             ));
         },
     };
@@ -194,7 +225,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
 /// so an invalid key — e.g. a `kebab-case` rename, which `FieldKey` forbids — is
 /// a spanned compile error instead of a runtime `.expect()` panic in the
 /// consuming crate.
-fn resolve_field_key(
+pub(crate) fn resolve_field_key(
     field_name: &Ident,
     serde: &SerdeAttrs,
     container_rename_all: Option<RenameRule>,
@@ -214,7 +245,7 @@ fn resolve_field_key(
 
 /// Validate a generated schema-key string against the shared `FieldKey` rules
 /// (`crate::validate_field_key`) and report a violation as a spanned error.
-fn check_field_key(key: &str, span: Span) -> syn::Result<()> {
+pub(crate) fn check_field_key(key: &str, span: Span) -> syn::Result<()> {
     crate::validate_field_key(key).map_err(|reason| {
         syn::Error::new(
             span,
@@ -404,7 +435,7 @@ fn enforce_alias_constraints(
 }
 
 /// Build the token-stream expression that produces a `Field` for one struct field.
-fn build_field_expr(
+pub(crate) fn build_field_expr(
     field_name: &Ident,
     key_str: &str,
     kind: &FieldKind,

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -8,6 +8,7 @@ use syn::{DeriveInput, LitStr, parse_macro_input};
 
 mod attrs;
 mod derive_enum;
+mod derive_enum_union;
 mod derive_schema;
 mod type_infer;
 
@@ -59,7 +60,15 @@ pub fn field_key(input: TokenStream) -> TokenStream {
     out.into()
 }
 
-/// Derive `HasSchema` (from `nebula-schema`) for a struct.
+/// Derive `HasSchema` (from `nebula-schema`).
+///
+/// On a **struct** the schema is a record of typed fields. On an **enum** it is a
+/// tagged union (`SchemaKind::Union`) — one variant per enum variant, honoring
+/// serde's enum tagging (external by default, or adjacent via
+/// `#[serde(tag = "..", content = "..")]`); internally-tagged and untagged enums,
+/// and tuple variants with more than one field, are rejected. (To embed an enum as
+/// a select *field* inside a struct, use `#[field(enum_select)]` +
+/// `#[derive(EnumSelect)]` instead.)
 ///
 /// Supported attributes:
 /// - `#[field(...)]` — label/description/placeholder/default/hint/secret/
@@ -71,8 +80,9 @@ pub fn field_key(input: TokenStream) -> TokenStream {
 ///   misread older documents), rejected at expansion if a field's resolved key or
 ///   a `#[serde(alias = ..)]` collides.
 /// - `#[serde(...)]` — read for key alignment so the schema key equals the wire
-///   key: `rename` / `rename_all` rename the field, `skip` / `skip_deserializing`
-///   drop it. `#[serde(flatten)]` is rejected (splicing is a follow-up).
+///   key: `rename` / `rename_all` rename the field or variant, `skip` /
+///   `skip_deserializing` drop it, `tag` / `content` select adjacent enum tagging.
+///   `#[serde(flatten)]` is rejected (splicing is a follow-up).
 #[proc_macro_derive(Schema, attributes(field, validate, schema))]
 pub fn derive_schema(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -9,7 +9,10 @@
 //! `is_assignable_schema(&producer.output, &consumer.input)`. (An internal,
 //! kind-blind slice form is used only by this module's tests.)
 
-use crate::{Field, FieldKey, InputSchema, OutputSchema, RequiredMode, SchemaKind, ValidSchema};
+use crate::{
+    Field, FieldKey, InputSchema, OutputSchema, RequiredMode, SchemaKind, ValidSchema,
+    field::ModeField,
+};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -75,6 +78,33 @@ pub enum SchemaIncompat {
         producer_multiple: bool,
         /// Whether the consumer field expects multiple values.
         consumer_multiple: bool,
+    },
+    /// A `Mode` (tagged-union) field is present on both sides, but the producer
+    /// declares a variant the consumer does not accept. Sum-type subtyping is the
+    /// dual of record width-subtyping: the producer may emit *any* of its
+    /// variants at runtime, so every producer variant must have a counterpart in
+    /// the consumer — otherwise the consumer would receive a case it cannot
+    /// handle. (The reverse is fine: a consumer that accepts *more* variants than
+    /// the producer can emit is still satisfied.)
+    #[error("field `{key}` mode variant `{variant}` is not accepted by the consumer")]
+    UnhandledVariant {
+        /// Key of the `Mode` field.
+        key: FieldKey,
+        /// The producer variant key the consumer does not declare.
+        variant: String,
+    },
+    /// The two schemas have incompatible [`SchemaKind`]s: one is a tagged
+    /// [`Union`](SchemaKind::Union) and the other a plain
+    /// [`Record`](SchemaKind::Record). A union wire value carries a discriminant a
+    /// record cannot guarantee (and vice versa), so neither can stand in for the
+    /// other. (An [`Any`](SchemaKind::Any) on either side is *not* a kind mismatch
+    /// — it routes through the gradual escapes instead.)
+    #[error("schema kind mismatch: producer is {producer:?}, consumer expects {consumer:?}")]
+    KindMismatch {
+        /// The producer schema's kind.
+        producer: SchemaKind,
+        /// The consumer schema's kind.
+        consumer: SchemaKind,
     },
 }
 
@@ -155,9 +185,12 @@ pub enum SchemaIncompat {
 /// - **`File` and `Select` cardinality** — the `multiple` flag (scalar vs.
 ///   array) is checked for equality; a mismatch returns
 ///   [`SchemaIncompat::CardinalityMismatch`].
-/// - **`Mode` fields** — `Mode`-vs-`Mode` passes the binary check (never
-///   false-rejects), but [`explain_assignable`] reports it as
-///   [`UnknownReason::ModeVariance`]: sum-type variance is not modeled.
+/// - **`Mode` fields** — `Mode`-vs-`Mode` uses sum-type subtyping, the dual of
+///   record width-subtyping: every producer variant must be accepted by the
+///   consumer (a producer variant the consumer lacks is a provable
+///   [`SchemaIncompat::UnhandledVariant`]), and each shared variant's payload is
+///   checked covariantly. A consumer that accepts extra variants is still
+///   satisfied.
 /// - **`Number` integer vs. float** — both carry `type_name() == "number"`.
 ///   int→float is provably compatible; float→int passes the binary check but is
 ///   [`UnknownReason::NumberWidening`] in [`explain_assignable`] (possible
@@ -233,9 +266,10 @@ pub enum Assignability {
     /// found (depth-first, consumer-field order), not just the first.
     No(Vec<SchemaIncompat>),
     /// Assignability cannot be decided statically (e.g. a loader-backed
-    /// `Dynamic` field, an opaque `Any` producer, sum-type `Mode` variance, or
-    /// a float→int narrowing). **Not** fail-open: a strict policy treats this as
-    /// a blocked edge; a gradual policy passes it.
+    /// `Dynamic` field, an opaque `Any` producer, or a float→int narrowing).
+    /// **Not** fail-open: a strict policy treats this as a blocked edge; a
+    /// gradual policy passes it. (Sum-type `Mode` variance is *not* here — it is
+    /// decided structurally, yielding `Yes`/`No`.)
     Unknown(Vec<UnknownReason>),
 }
 
@@ -255,12 +289,6 @@ pub enum UnknownReason {
     /// so its concrete shape is unknown until runtime.
     DynamicLoaderBacked {
         /// Key of the dynamic field.
-        key: FieldKey,
-    },
-    /// A matched `Mode` (sum-type) pair: variant-level variance is not modeled,
-    /// so neither compatibility nor a conflict is proven.
-    ModeVariance {
-        /// Key of the `Mode` field.
         key: FieldKey,
     },
     /// A matched `Number` pair narrows float→int: the producer may emit a
@@ -305,12 +333,6 @@ impl core::fmt::Display for UnknownReason {
             },
             Self::DynamicLoaderBacked { key } => {
                 write!(f, "field `{key}` is dynamic/computed (resolved at runtime)")
-            },
-            Self::ModeVariance { key } => {
-                write!(
-                    f,
-                    "field `{key}` is a `Mode` sum type (variance not modeled)"
-                )
             },
             Self::NumberWidening { key } => {
                 write!(
@@ -357,8 +379,20 @@ pub(crate) fn explain_assignable_core(
         return Assignability::Yes;
     }
     // An `Any` producer may emit anything: not refuted, but not provable either.
+    // This MUST precede the union dispatch below so an `Any` producer feeding a
+    // `Union` consumer is `Unknown` (it *might* emit a valid tagged value), not a
+    // hard `KindMismatch`.
     if producer.kind() == SchemaKind::Any {
         return Assignability::Unknown(vec![UnknownReason::OpaqueProducer]);
+    }
+    // Tagged-union dispatch. Placed after all three gradual escapes (Any-consumer,
+    // empty-consumer, Any-producer) so those keep their meaning: a `Union` feeding
+    // an `Any`/no-input consumer is `Yes`, and an `Any` producer is `Unknown`.
+    // Only the concrete Union↔Record/Union cases reach here.
+    let producer_union = producer.kind() == SchemaKind::Union;
+    let consumer_union = consumer.kind() == SchemaKind::Union;
+    if producer_union || consumer_union {
+        return union_assignability(producer, consumer, producer_union, consumer_union);
     }
     let mut acc = Explain::default();
     collect_fields(producer.fields(), consumer.fields(), true, &mut acc);
@@ -459,9 +493,9 @@ fn collect_fields(
 
 /// Classify a matched field pair (same key, both present), pushing into `acc`.
 ///
-/// Provable conflicts (cardinality, type mismatch, nested) become
-/// [`SchemaIncompat`]; the leniencies the binary check silently passes —
-/// `Dynamic`/`Computed`, `Mode` variance, and float→int narrowing — become
+/// Provable conflicts (cardinality, type mismatch, nested, unhandled `Mode`
+/// variant) become [`SchemaIncompat`]; the leniencies the binary check silently
+/// passes — `Dynamic`/`Computed` and float→int narrowing — become
 /// [`UnknownReason`] so a strict policy can see them. `Number` int→float
 /// widening and equal primitive variants are provably compatible (nothing
 /// pushed).
@@ -559,11 +593,8 @@ fn collect_pair(
                     .push(UnknownReason::NumberWidening { key: key.clone() });
             }
         },
-        (Field::Mode(_), Field::Mode(_)) => {
-            // Sum-type variance is not modeled (it runs opposite to record
-            // width-subtyping) — neither proven compatible nor refuted.
-            acc.unknown
-                .push(UnknownReason::ModeVariance { key: key.clone() });
+        (Field::Mode(producer_mode), Field::Mode(consumer_mode)) => {
+            collect_mode_variants(key, producer_mode, consumer_mode, strict, acc);
         },
         // All other pairs: same type_name = compatible; different = type mismatch.
         _ => {
@@ -576,6 +607,98 @@ fn collect_pair(
             }
         },
     }
+}
+
+/// Sum-type (tagged-union) variance for a matched `Mode` field pair — the dual
+/// of record width-subtyping (ADR-0100 §L2 addendum).
+///
+/// A `Mode` producer may emit *any* of its declared variants at runtime, so the
+/// rule is **producer-variant containment**: every producer variant must have a
+/// counterpart in the consumer, otherwise the consumer would face a case it
+/// cannot handle — a provable [`SchemaIncompat::UnhandledVariant`]. The reverse
+/// is sound: a consumer that accepts *more* variants than the producer can emit
+/// is still satisfied (the extra arms are simply never taken). For each variant
+/// present on both sides the payload is checked **covariantly** — producer
+/// payload assignable to consumer payload, the same direction as records — by
+/// recursing through [`collect_pair`]; nested payload findings are wrapped under
+/// the mode field `key`, while an unhandled variant (which already names both the
+/// field and the variant) is reported at the field level.
+///
+/// Unlike the empty-producer / list-item escapes, variant containment is a real
+/// structural check, so it fires in both `strict` and gradual modes; `strict`
+/// only governs the per-payload recursion.
+fn collect_mode_variants(
+    key: &FieldKey,
+    producer: &ModeField,
+    consumer: &ModeField,
+    strict: bool,
+    acc: &mut Explain,
+) {
+    let mut payload_findings = Explain::default();
+    for producer_variant in &producer.variants {
+        match consumer
+            .variants
+            .iter()
+            .find(|consumer_variant| consumer_variant.key == producer_variant.key)
+        {
+            None => {
+                acc.incompat.push(SchemaIncompat::UnhandledVariant {
+                    key: key.clone(),
+                    variant: producer_variant.key.clone(),
+                });
+            },
+            Some(consumer_variant) => {
+                collect_pair(
+                    consumer_variant.field.key(),
+                    &producer_variant.field,
+                    &consumer_variant.field,
+                    strict,
+                    &mut payload_findings,
+                );
+            },
+        }
+    }
+    acc.wrap_nested(key, payload_findings);
+}
+
+/// Assignability when at least one side is a [`SchemaKind::Union`].
+///
+/// - **Union → Union:** route the two schemas' sole root [`Field::Mode`] (the
+///   marker design's variant carrier) through [`collect_mode_variants`] — the
+///   *same* producer-variant-containment + covariant-payload rule a nested `Mode`
+///   field uses, so there is one declarative sum-type judgment, not two. (Routing
+///   the payloads back through [`explain_assignable_core`] instead would
+///   Top-collapse on its empty-consumer escape and wrongly accept arbitrary
+///   producer payloads for a unit consumer variant.)
+/// - **Union ↔ Record:** a [`SchemaIncompat::KindMismatch`] — a union value
+///   carries a discriminant a record cannot provide, and a record is not one of a
+///   union's variants.
+fn union_assignability(
+    producer: &ValidSchema,
+    consumer: &ValidSchema,
+    producer_union: bool,
+    consumer_union: bool,
+) -> Assignability {
+    if producer_union
+        && consumer_union
+        && let (Some(Field::Mode(producer_mode)), Some(Field::Mode(consumer_mode))) =
+            (producer.fields().first(), consumer.fields().first())
+    {
+        // Label findings by the consumer's root mode key; both roots are the
+        // union's sole field by construction (`ValidSchema::union`).
+        let root_key = consumer.fields()[0].key();
+        let mut acc = Explain::default();
+        collect_mode_variants(root_key, producer_mode, consumer_mode, true, &mut acc);
+        return acc.into_verdict();
+    }
+    // Either exactly one side is a union (Union ↔ Record), or — unreachable for
+    // schemas built by `ValidSchema::union`/its deserialize, which both guarantee
+    // a single root `Field::Mode` — a union whose root field is malformed. Both
+    // are kind mismatches; stay total rather than panic.
+    Assignability::No(vec![SchemaIncompat::KindMismatch {
+        producer: producer.kind(),
+        consumer: consumer.kind(),
+    }])
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1269,11 +1392,10 @@ mod tests {
         }
     }
 
-    /// A `Mode`-vs-`Mode` pair is `Unknown(ModeVariance)` (sum-type variance is
-    /// not modeled) yet passes the binary check. The one reclassified leniency
-    /// otherwise lacking an oracle.
+    /// Identical `Mode`s are provably assignable (`Yes`): every producer variant
+    /// has a matching consumer variant with a compatible payload.
     #[test]
-    fn explain_mode_variance_is_unknown() {
+    fn explain_mode_identical_is_yes() {
         let mode_schema = || {
             crate::Schema::builder()
                 .add(Field::mode(fk("m")).variant("v", "V", Field::string(fk("x"))))
@@ -1282,11 +1404,111 @@ mod tests {
         };
         let producer = mode_schema();
         let consumer = mode_schema();
+        assert_eq!(explain_assignable(&producer, &consumer), Assignability::Yes);
+        assert!(is_assignable_schema(&producer, &consumer).is_ok());
+    }
+
+    /// Sum-type containment (the dual of records): a producer `Mode` that can emit
+    /// a variant the consumer does not declare is a provable `No` — the consumer
+    /// would face an unhandled case. This is the soundness fix: it was previously a
+    /// blanket `Unknown` that the binary check let through.
+    #[test]
+    fn explain_mode_extra_producer_variant_is_unhandled() {
+        let producer = crate::Schema::builder()
+            .add(
+                Field::mode(fk("auth"))
+                    .variant("api_key", "API key", Field::string(fk("key")))
+                    .variant("oauth", "OAuth", Field::string(fk("token"))),
+            )
+            .build()
+            .unwrap();
+        // Consumer handles only `api_key` — it cannot handle the producer's `oauth`.
+        let consumer = crate::Schema::builder()
+            .add(Field::mode(fk("auth")).variant("api_key", "API key", Field::string(fk("key"))))
+            .build()
+            .unwrap();
         assert_eq!(
             explain_assignable(&producer, &consumer),
-            Assignability::Unknown(vec![UnknownReason::ModeVariance { key: fk("m") }]),
+            Assignability::No(vec![SchemaIncompat::UnhandledVariant {
+                key: fk("auth"),
+                variant: "oauth".to_owned(),
+            }]),
         );
-        assert!(is_assignable_schema(&producer, &consumer).is_ok());
+        // The soundness fix: the binary check now also rejects it (was `Ok`).
+        assert_eq!(
+            is_assignable_schema(&producer, &consumer),
+            Err(SchemaIncompat::UnhandledVariant {
+                key: fk("auth"),
+                variant: "oauth".to_owned(),
+            }),
+        );
+    }
+
+    /// The reverse direction is sound: a consumer that accepts *more* variants
+    /// than the producer can emit is still satisfied — the extra arms are never
+    /// taken.
+    #[test]
+    fn explain_mode_extra_consumer_variant_is_yes() {
+        let producer = crate::Schema::builder()
+            .add(Field::mode(fk("auth")).variant("api_key", "API key", Field::string(fk("key"))))
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(
+                Field::mode(fk("auth"))
+                    .variant("api_key", "API key", Field::string(fk("key")))
+                    .variant("oauth", "OAuth", Field::string(fk("token"))),
+            )
+            .build()
+            .unwrap();
+        assert_eq!(explain_assignable(&producer, &consumer), Assignability::Yes);
+    }
+
+    /// Variant payloads are checked covariantly (producer payload → consumer
+    /// payload): a shared variant whose payload type mismatches is a nested `No`
+    /// keyed by the mode field then the payload field.
+    #[test]
+    fn explain_mode_variant_payload_mismatch_is_nested() {
+        let producer = crate::Schema::builder()
+            .add(Field::mode(fk("m")).variant("v", "V", Field::number(fk("x"))))
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(Field::mode(fk("m")).variant("v", "V", Field::string(fk("x"))))
+            .build()
+            .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::No(vec![SchemaIncompat::NestedIncompat {
+                key: fk("m"),
+                inner: Box::new(SchemaIncompat::FieldTypeMismatch {
+                    key: fk("x"),
+                    producer: "number",
+                    consumer: "string",
+                }),
+            }]),
+        );
+    }
+
+    /// An undecidable payload (a `Dynamic` variant field) bubbles up as a nested
+    /// `Unknown`, not a blanket Mode `Unknown` — variance itself is decided.
+    #[test]
+    fn explain_mode_dynamic_payload_bubbles_unknown() {
+        let producer = crate::Schema::builder()
+            .add(Field::mode(fk("m")).variant("v", "V", Field::dynamic(fk("x"))))
+            .build()
+            .unwrap();
+        let consumer = crate::Schema::builder()
+            .add(Field::mode(fk("m")).variant("v", "V", Field::string(fk("x"))))
+            .build()
+            .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::Unknown(vec![UnknownReason::NestedUnknown {
+                key: fk("m"),
+                inner: Box::new(UnknownReason::DynamicLoaderBacked { key: fk("x") }),
+            }]),
+        );
     }
 
     /// An undecidable field nested inside an `Object` keeps its path: the reason
@@ -1382,10 +1604,10 @@ mod tests {
         assert_eq!(
             UnknownReason::NestedUnknown {
                 key: fk("cfg"),
-                inner: Box::new(UnknownReason::ModeVariance { key: fk("m") }),
+                inner: Box::new(UnknownReason::NumberWidening { key: fk("n") }),
             }
             .to_string(),
-            "in field `cfg`: field `m` is a `Mode` sum type (variance not modeled)"
+            "in field `cfg`: field `n` narrows float to integer (possible precision loss)"
         );
     }
 
@@ -1437,6 +1659,168 @@ mod tests {
         assert!(
             narrower.is_compatible_successor_of(&any_prev).is_ok(),
             "an `Any` old output constrains nothing"
+        );
+    }
+
+    // ── Sum-type union (SchemaKind::Union) assignability ───────────────────────
+
+    /// An external-tagged union whose variants each carry a string payload.
+    fn ext_union(variant_keys: &[&str]) -> ValidSchema {
+        let mut mode = Field::mode(fk("u"));
+        for key in variant_keys {
+            mode = mode.variant(*key, *key, Field::string(fk("x")));
+        }
+        ValidSchema::union(mode, crate::SerdeTagging::External).expect("union builds")
+    }
+
+    /// Identical unions are provably assignable.
+    #[test]
+    fn union_identical_is_yes() {
+        let producer = ext_union(&["a", "b"]);
+        let consumer = ext_union(&["a", "b"]);
+        assert_eq!(explain_assignable(&producer, &consumer), Assignability::Yes);
+        assert!(is_assignable_schema(&producer, &consumer).is_ok());
+    }
+
+    /// Sum-type containment via the SAME `collect_mode_variants` rule: a producer
+    /// union that can emit a variant the consumer does not accept is a provable
+    /// `No` (`UnhandledVariant`), keyed by the root mode.
+    #[test]
+    fn union_extra_producer_variant_is_unhandled() {
+        let producer = ext_union(&["a", "b"]);
+        let consumer = ext_union(&["a"]);
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::No(vec![SchemaIncompat::UnhandledVariant {
+                key: fk("u"),
+                variant: "b".to_owned(),
+            }]),
+        );
+        assert_eq!(
+            is_assignable_schema(&producer, &consumer),
+            Err(SchemaIncompat::UnhandledVariant {
+                key: fk("u"),
+                variant: "b".to_owned(),
+            }),
+        );
+    }
+
+    /// The reverse is sound: a consumer union accepting MORE variants than the
+    /// producer can emit is satisfied.
+    #[test]
+    fn union_extra_consumer_variant_is_yes() {
+        let producer = ext_union(&["a"]);
+        let consumer = ext_union(&["a", "b"]);
+        assert_eq!(explain_assignable(&producer, &consumer), Assignability::Yes);
+    }
+
+    /// Variant payloads are checked covariantly: a shared variant whose payload
+    /// type mismatches is a nested `No` keyed by the root mode then the payload.
+    #[test]
+    fn union_variant_payload_mismatch_is_nested_no() {
+        let producer = ValidSchema::union(
+            Field::mode(fk("u")).variant("a", "a", Field::number(fk("x"))),
+            crate::SerdeTagging::External,
+        )
+        .unwrap();
+        let consumer = ValidSchema::union(
+            Field::mode(fk("u")).variant("a", "a", Field::string(fk("x"))),
+            crate::SerdeTagging::External,
+        )
+        .unwrap();
+        assert_eq!(
+            explain_assignable(&producer, &consumer),
+            Assignability::No(vec![SchemaIncompat::NestedIncompat {
+                key: fk("u"),
+                inner: Box::new(SchemaIncompat::FieldTypeMismatch {
+                    key: fk("x"),
+                    producer: "number",
+                    consumer: "string",
+                }),
+            }]),
+        );
+    }
+
+    /// A union and a plain record are a `KindMismatch` in both directions — a
+    /// union value carries a discriminant a record cannot, and vice versa.
+    #[test]
+    fn union_and_record_are_kind_mismatch() {
+        let union = ext_union(&["a"]);
+        let record = required_record("name");
+        assert_eq!(
+            explain_assignable(&union, &record),
+            Assignability::No(vec![SchemaIncompat::KindMismatch {
+                producer: SchemaKind::Union,
+                consumer: SchemaKind::Record,
+            }]),
+        );
+        assert_eq!(
+            explain_assignable(&record, &union),
+            Assignability::No(vec![SchemaIncompat::KindMismatch {
+                producer: SchemaKind::Record,
+                consumer: SchemaKind::Union,
+            }]),
+        );
+    }
+
+    /// Gradual escapes still win over the union dispatch (the verified ordering):
+    /// an `Any` producer feeding a union consumer is `Unknown` (it *might* emit a
+    /// valid tagged value), NOT a hard `KindMismatch`.
+    #[test]
+    fn any_producer_into_union_consumer_is_unknown() {
+        assert_eq!(
+            explain_assignable(&ValidSchema::any(), &ext_union(&["a"])),
+            Assignability::Unknown(vec![UnknownReason::OpaqueProducer]),
+        );
+    }
+
+    /// A union producer feeding an `Any` consumer — or a no-input (empty-record)
+    /// consumer — is provably `Yes`: the consumer requires nothing.
+    #[test]
+    fn union_producer_into_any_or_empty_consumer_is_yes() {
+        assert_eq!(
+            explain_assignable(&ext_union(&["a"]), &ValidSchema::any()),
+            Assignability::Yes,
+        );
+        assert_eq!(
+            explain_assignable(&ext_union(&["a"]), &ValidSchema::empty()),
+            Assignability::Yes,
+        );
+    }
+
+    /// Output evolution (sum-type variance): a new output union that ADDS a
+    /// variant is a breaking successor (old consumers can't handle it); one that
+    /// DROPS a variant is compatible (it just emits fewer cases).
+    #[test]
+    fn union_output_successor_variance() {
+        let old = OutputSchema::new(ext_union(&["a", "b"]));
+        let adds = OutputSchema::new(ext_union(&["a", "b", "c"]));
+        let drops = OutputSchema::new(ext_union(&["a"]));
+        assert_eq!(
+            adds.is_compatible_successor_of(&old),
+            Err(SchemaIncompat::UnhandledVariant {
+                key: fk("u"),
+                variant: "c".to_owned(),
+            }),
+            "adding an output variant is breaking — old consumers can't handle it"
+        );
+        assert!(
+            drops.is_compatible_successor_of(&old).is_ok(),
+            "dropping an output variant is compatible — fewer cases emitted"
+        );
+    }
+
+    /// A record output cannot evolve into a union output (or vice versa).
+    #[test]
+    fn record_to_union_successor_is_kind_mismatch() {
+        let old = OutputSchema::new(required_record("result"));
+        let new = OutputSchema::new(ext_union(&["a"]));
+        assert_eq!(
+            new.is_compatible_successor_of(&old),
+            Err(SchemaIncompat::KindMismatch {
+                producer: SchemaKind::Union,
+                consumer: SchemaKind::Record,
+            }),
         );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -10,8 +10,8 @@
 //! kind-blind slice form is used only by this module's tests.)
 
 use crate::{
-    Field, FieldKey, InputSchema, OutputSchema, RequiredMode, SchemaKind, ValidSchema,
-    field::ModeField,
+    Field, FieldKey, InputSchema, OutputSchema, RequiredMode, SchemaKind, SerdeTagging,
+    ValidSchema, field::ModeField,
 };
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -105,6 +105,19 @@ pub enum SchemaIncompat {
         producer: SchemaKind,
         /// The consumer schema's kind.
         consumer: SchemaKind,
+    },
+    /// Both schemas are tagged [`Union`](SchemaKind::Union)s, but their serde
+    /// tagging differs (e.g. external vs adjacent). The variant keys may match,
+    /// yet the on-the-wire shapes do not (`{"V": payload}` vs
+    /// `{"<tag>": "V", "<content>": payload}`) and are not interconvertible, so the
+    /// consumer cannot deserialize the producer's output. `serde_tagging` is part
+    /// of schema identity (see the `ValidSchema` `PartialEq`).
+    #[error("union serde tagging mismatch: producer {producer:?}, consumer expects {consumer:?}")]
+    UnionTaggingMismatch {
+        /// The producer union's serde tagging (`None` only on a malformed union).
+        producer: Option<SerdeTagging>,
+        /// The consumer union's serde tagging.
+        consumer: Option<SerdeTagging>,
     },
 }
 
@@ -634,7 +647,11 @@ fn collect_mode_variants(
     strict: bool,
     acc: &mut Explain,
 ) {
-    let mut payload_findings = Explain::default();
+    // Push each variant's findings as it is visited (an unhandled variant, or its
+    // wrapped payload findings) so the overall order stays depth-first /
+    // producer-variant order — the first-incompatibility contract `is_assignable`
+    // relies on. (Accumulating all payloads and wrapping once at the end would let
+    // a later unhandled variant precede an earlier payload mismatch.)
     for producer_variant in &producer.variants {
         match consumer
             .variants
@@ -648,6 +665,7 @@ fn collect_mode_variants(
                 });
             },
             Some(consumer_variant) => {
+                let mut payload_findings = Explain::default();
                 collect_pair(
                     consumer_variant.field.key(),
                     &producer_variant.field,
@@ -655,10 +673,10 @@ fn collect_mode_variants(
                     strict,
                     &mut payload_findings,
                 );
+                acc.wrap_nested(key, payload_findings);
             },
         }
     }
-    acc.wrap_nested(key, payload_findings);
 }
 
 /// Assignability when at least one side is a [`SchemaKind::Union`].
@@ -684,6 +702,16 @@ fn union_assignability(
         && let (Some(Field::Mode(producer_mode)), Some(Field::Mode(consumer_mode))) =
             (producer.fields().first(), consumer.fields().first())
     {
+        // Serde tagging is part of schema identity: two unions with matching
+        // variant keys but different tagging (external vs adjacent) have different
+        // wire shapes and are NOT interconvertible, so the consumer cannot
+        // deserialize the producer's output. Reject before comparing variants.
+        if producer.serde_tagging() != consumer.serde_tagging() {
+            return Assignability::No(vec![SchemaIncompat::UnionTaggingMismatch {
+                producer: producer.serde_tagging().cloned(),
+                consumer: consumer.serde_tagging().cloned(),
+            }]);
+        }
         // Label findings by the consumer's root mode key; both roots are the
         // union's sole field by construction (`ValidSchema::union`).
         let root_key = consumer.fields()[0].key();
@@ -1670,7 +1698,7 @@ mod tests {
         for key in variant_keys {
             mode = mode.variant(*key, *key, Field::string(fk("x")));
         }
-        ValidSchema::union(mode, crate::SerdeTagging::External).expect("union builds")
+        ValidSchema::union(mode, SerdeTagging::External).expect("union builds")
     }
 
     /// Identical unions are provably assignable.
@@ -1720,12 +1748,12 @@ mod tests {
     fn union_variant_payload_mismatch_is_nested_no() {
         let producer = ValidSchema::union(
             Field::mode(fk("u")).variant("a", "a", Field::number(fk("x"))),
-            crate::SerdeTagging::External,
+            SerdeTagging::External,
         )
         .unwrap();
         let consumer = ValidSchema::union(
             Field::mode(fk("u")).variant("a", "a", Field::string(fk("x"))),
-            crate::SerdeTagging::External,
+            SerdeTagging::External,
         )
         .unwrap();
         assert_eq!(
@@ -1786,6 +1814,58 @@ mod tests {
             explain_assignable(&ext_union(&["a"]), &ValidSchema::empty()),
             Assignability::Yes,
         );
+    }
+
+    /// Two unions with identical variants but DIFFERENT serde tagging are not
+    /// assignable — their wire shapes (`{"a": ..}` vs `{tag, content}`) differ and
+    /// are not interconvertible, so the consumer cannot deserialize the producer.
+    #[test]
+    fn union_tagging_mismatch_is_rejected() {
+        let external = ext_union(&["a"]); // SerdeTagging::External
+        let adjacent = ValidSchema::union(
+            Field::mode(fk("u")).variant("a", "a", Field::string(fk("x"))),
+            SerdeTagging::Adjacent {
+                tag: "t".to_owned(),
+                content: "c".to_owned(),
+            },
+        )
+        .unwrap();
+        match explain_assignable(&external, &adjacent) {
+            Assignability::No(v) => assert!(
+                matches!(v.first(), Some(SchemaIncompat::UnionTaggingMismatch { .. })),
+                "expected a tagging mismatch, got {v:?}"
+            ),
+            other => panic!("expected No(UnionTaggingMismatch), got {other:?}"),
+        }
+    }
+
+    /// Findings keep producer-variant order: an earlier variant's payload mismatch
+    /// precedes a later unhandled variant (the first-incompatibility contract).
+    #[test]
+    fn union_findings_preserve_producer_variant_order() {
+        let producer = ValidSchema::union(
+            Field::mode(fk("u"))
+                .variant("a", "a", Field::number(fk("x")))
+                .variant("b", "b", Field::string(fk("y"))),
+            SerdeTagging::External,
+        )
+        .unwrap();
+        // Consumer handles only `a`, and types its payload as a string (so `a`
+        // mismatches) — `b` is unhandled.
+        let consumer = ext_union(&["a"]);
+        match explain_assignable(&producer, &consumer) {
+            Assignability::No(v) => {
+                assert!(
+                    matches!(v[0], SchemaIncompat::NestedIncompat { .. }),
+                    "earlier variant `a`'s payload mismatch must come first, got {v:?}"
+                );
+                assert!(
+                    matches!(&v[1], SchemaIncompat::UnhandledVariant { variant, .. } if variant == "b"),
+                    "later unhandled variant `b` must come second, got {v:?}"
+                );
+            },
+            other => panic!("expected No, got {other:?}"),
+        }
     }
 
     /// Output evolution (sum-type variance): a new output union that ADDS a

--- a/crates/schema/src/json_schema.rs
+++ b/crates/schema/src/json_schema.rs
@@ -10,8 +10,13 @@ use std::{error::Error as StdError, fmt};
 use serde_json::{Map, Value};
 
 use crate::{
-    field::{ComputedReturn, Field, ListField, ModeField, NumberField, ObjectField, SelectField},
+    SchemaKind,
+    field::{
+        ComputedReturn, Field, ListField, ModeField, ModeVariant, NumberField, ObjectField,
+        SelectField,
+    },
     mode::{ExpressionMode, RequiredMode, VisibilityMode},
+    validated::SerdeTagging,
 };
 
 /// Canonical draft URI emitted by [`ValidSchema::json_schema`].
@@ -79,7 +84,102 @@ impl crate::validated::ValidSchema {
         )
     )]
     pub fn json_schema(&self) -> Result<schemars::Schema, JsonSchemaExportError> {
-        schema_for_fields(self.fields(), self.root_rules())
+        match self.kind() {
+            // A tagged union exports as a `oneOf` faithful to its serde tagging —
+            // not as a record wrapping the internal `{mode,value}` envelope.
+            SchemaKind::Union => schema_for_union(self),
+            SchemaKind::Record | SchemaKind::Any => {
+                schema_for_fields(self.fields(), self.root_rules())
+            },
+        }
+    }
+}
+
+/// Export a [`SchemaKind::Union`] schema as a JSON Schema `oneOf`, faithful to the
+/// recorded [`SerdeTagging`] so the document matches serde's wire form (the C1
+/// invariant — schema variant key == wire key):
+///
+/// - **External** — a data variant is `{ "<variant>": payload }` and a unit
+///   variant is the bare string `{ "const": "<variant>" }`.
+/// - **Adjacent** `{ tag, content }` — a data variant is
+///   `{ "<tag>": "<variant>", "<content>": payload }`, a unit variant omits the
+///   content key, and a top-level `discriminator: { propertyName: "<tag>" }` is
+///   emitted.
+///
+/// The union's variants live in its sole root [`Field::Mode`] (the marker design);
+/// unit variants are recognized by the [`ModeField::EMPTY_PLACEHOLDER_KEY`] payload
+/// that [`ModeField::variant_empty`] installs.
+fn schema_for_union(
+    schema: &crate::validated::ValidSchema,
+) -> Result<schemars::Schema, JsonSchemaExportError> {
+    let Some(Field::Mode(mode)) = schema.fields().first() else {
+        // Unreachable for schemas built by `ValidSchema::union` / its deserialize
+        // (both guarantee one root `Field::Mode`); fall back to the record export
+        // rather than panic on a malformed value.
+        return schema_for_fields(schema.fields(), schema.root_rules());
+    };
+    let tagging = schema.serde_tagging().unwrap_or(&SerdeTagging::External);
+
+    let branches: Vec<Value> = mode
+        .variants
+        .iter()
+        .map(|variant| union_variant_branch(variant, tagging))
+        .collect();
+
+    let mut root = Map::new();
+    root.insert(
+        "$schema".to_owned(),
+        Value::String(DRAFT_2020_12.to_owned()),
+    );
+    root.insert("oneOf".to_owned(), Value::Array(branches));
+    if let SerdeTagging::Adjacent { tag, .. } = tagging {
+        let mut discriminator = Map::new();
+        discriminator.insert("propertyName".to_owned(), Value::String(tag.clone()));
+        root.insert("discriminator".to_owned(), Value::Object(discriminator));
+    }
+    schemars::Schema::try_from(Value::Object(root)).map_err(JsonSchemaExportError::InvalidSchema)
+}
+
+/// One JSON-Schema `oneOf` branch for a union variant under the given tagging.
+fn union_variant_branch(variant: &ModeVariant, tagging: &SerdeTagging) -> Value {
+    let is_unit = variant.field.key().as_str() == ModeField::EMPTY_PLACEHOLDER_KEY;
+    match tagging {
+        SerdeTagging::External if is_unit => {
+            // serde external unit variant: the bare string `"Variant"`.
+            let mut branch = Map::new();
+            branch.insert("const".to_owned(), Value::String(variant.key.clone()));
+            Value::Object(branch)
+        },
+        SerdeTagging::External => {
+            // serde external data variant: `{ "Variant": payload }`.
+            let mut props = Map::new();
+            props.insert(variant.key.clone(), field_schema_value(&variant.field));
+            let mut branch = primitive_schema("object");
+            branch.insert("properties".to_owned(), Value::Object(props));
+            branch.insert(
+                "required".to_owned(),
+                Value::Array(vec![Value::String(variant.key.clone())]),
+            );
+            branch.insert("additionalProperties".to_owned(), Value::Bool(false));
+            Value::Object(branch)
+        },
+        SerdeTagging::Adjacent { tag, content } => {
+            let mut props = Map::new();
+            let mut tag_const = Map::new();
+            tag_const.insert("const".to_owned(), Value::String(variant.key.clone()));
+            props.insert(tag.clone(), Value::Object(tag_const));
+            let mut required = vec![Value::String(tag.clone())];
+            if !is_unit {
+                // serde emits the content key for every data variant.
+                props.insert(content.clone(), field_schema_value(&variant.field));
+                required.push(Value::String(content.clone()));
+            }
+            let mut branch = primitive_schema("object");
+            branch.insert("properties".to_owned(), Value::Object(props));
+            branch.insert("required".to_owned(), Value::Array(required));
+            branch.insert("additionalProperties".to_owned(), Value::Bool(false));
+            Value::Object(branch)
+        },
     }
 }
 
@@ -610,7 +710,7 @@ fn apply_contract_keywords(field: &Field, schema: &mut Map<String, Value>) {
 mod tests {
     use serde_json::{Value, json};
 
-    use crate::{Field, FieldKey, Schema};
+    use crate::{Field, FieldKey, Schema, SerdeTagging, ValidSchema};
 
     #[test]
     fn exports_basic_object_shape_and_required() {
@@ -889,6 +989,87 @@ mod tests {
             .collect();
         assert!(required_keys.contains(&"email"));
         assert!(required_keys.contains(&"emailAddress"));
+    }
+
+    #[test]
+    fn exports_external_union_as_oneof_with_unit_string_const() {
+        let schema = ValidSchema::union(
+            Field::mode(FieldKey::new("auth").expect("static key"))
+                .variant(
+                    "oauth",
+                    "OAuth",
+                    Field::object(FieldKey::new("oauth").expect("static key"))
+                        .add(Field::secret(FieldKey::new("token").expect("static key")).required()),
+                )
+                .variant_empty("none", "None"),
+            SerdeTagging::External,
+        )
+        .expect("union builds");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        let one_of = json["oneOf"].as_array().expect("oneOf array");
+        assert_eq!(one_of.len(), 2);
+
+        // External data variant: { "oauth": <payload> }, required [oauth].
+        let oauth = one_of
+            .iter()
+            .find(|b| b["properties"]["oauth"].is_object())
+            .expect("oauth data branch");
+        assert_eq!(oauth["required"], json!(["oauth"]));
+        assert_eq!(oauth["additionalProperties"], json!(false));
+
+        // External unit variant: the bare string const "none" (C1: serde emits a
+        // bare string for a unit variant, not { "none": {} }).
+        assert!(
+            one_of.iter().any(|b| b["const"] == json!("none")),
+            "external unit variant must export as a bare string const"
+        );
+        assert!(
+            json.get("discriminator").is_none(),
+            "external tagging has no discriminator"
+        );
+    }
+
+    #[test]
+    fn exports_adjacent_union_with_discriminator_and_omitted_unit_content() {
+        let schema = ValidSchema::union(
+            Field::mode(FieldKey::new("event").expect("static key"))
+                .variant(
+                    "click",
+                    "Click",
+                    Field::object(FieldKey::new("click").expect("static key"))
+                        .add(Field::number(FieldKey::new("x").expect("static key")).required()),
+                )
+                .variant_empty("noop", "No-op"),
+            SerdeTagging::Adjacent {
+                tag: "type".to_owned(),
+                content: "data".to_owned(),
+            },
+        )
+        .expect("union builds");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        assert_eq!(json["discriminator"]["propertyName"], json!("type"));
+        let one_of = json["oneOf"].as_array().expect("oneOf array");
+
+        // Adjacent data variant: tag const + content, required [type, data].
+        let click = one_of
+            .iter()
+            .find(|b| b["properties"]["type"]["const"] == json!("click"))
+            .expect("click branch");
+        assert!(click["properties"]["data"].is_object());
+        assert_eq!(click["required"], json!(["type", "data"]));
+
+        // Adjacent unit variant: tag const only, content omitted, required [type].
+        let noop = one_of
+            .iter()
+            .find(|b| b["properties"]["type"]["const"] == json!("noop"))
+            .expect("noop branch");
+        assert!(
+            noop["properties"].get("data").is_none(),
+            "adjacent unit variant must omit the content key"
+        );
+        assert_eq!(noop["required"], json!(["type"]));
     }
 
     #[test]

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -334,29 +334,38 @@ pub mod __private {
     /// construction instead — consistent with the derive's other schema-build
     /// panics — naming the offending variant.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics when `payload`'s kind is not [`Record`](crate::SchemaKind::Record)
-    /// (e.g. a newtype over an enum, over `serde_json::Value`, or over any other
-    /// `Any`-typed payload).
-    #[must_use]
+    /// Returns a [`ValidationReport`](crate::error::ValidationReport) when
+    /// `payload`'s kind is not [`Record`](crate::SchemaKind::Record) (e.g. a
+    /// newtype over an enum, over `serde_json::Value`, or over any other
+    /// `Any`-typed payload). The derive routes this through the same
+    /// schema-build error path as a failed `ValidSchema::union`, so the failure
+    /// surfaces at `schema()` construction — it does not panic from library code.
     pub fn union_newtype_payload(
         wire_key: crate::FieldKey,
         payload: crate::ValidSchema,
         enum_name: &str,
         variant: &str,
-    ) -> crate::Field {
-        assert!(
-            payload.kind() == crate::SchemaKind::Record,
-            "#[derive(Schema)] on enum `{enum_name}`: newtype variant `{variant}` wraps a type \
-             whose schema is `{:?}`, not a record — a payload that is itself a union (another \
-             enum), `serde_json::Value`, or otherwise shape-unknown cannot be modeled as a \
-             variant payload (its keys would not match the wire). Wrap the value in a plain \
-             `#[derive(Schema)]` struct.",
-            payload.kind(),
-        );
-        crate::Field::object(wire_key)
-            .add_many(payload.fields().iter().cloned())
-            .into()
+    ) -> ::core::result::Result<crate::Field, crate::error::ValidationReport> {
+        if payload.kind() != crate::SchemaKind::Record {
+            return ::core::result::Result::Err(crate::error::ValidationReport::from(
+                crate::error::ValidationError::builder("union.newtype_not_record")
+                    .message(format!(
+                        "#[derive(Schema)] on enum `{enum_name}`: newtype variant `{variant}` \
+                         wraps a type whose schema is `{:?}`, not a record — a payload that is \
+                         itself a union (another enum), `serde_json::Value`, or otherwise \
+                         shape-unknown cannot be modeled as a variant payload (its keys would not \
+                         match the wire). Wrap the value in a plain `#[derive(Schema)]` struct.",
+                        payload.kind(),
+                    ))
+                    .build(),
+            ));
+        }
+        ::core::result::Result::Ok(
+            crate::Field::object(wire_key)
+                .add_many(payload.fields().iter().cloned())
+                .into(),
+        )
     }
 }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -296,7 +296,8 @@ pub use schema::{Schema, SchemaBuilder};
 pub use secret::{SECRET_REDACTED, SecretBytes, SecretString, SecretValue, SecretWire};
 pub use transformer::Transformer;
 pub use validated::{
-    FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, SchemaKind, ValidSchema, ValidValues,
+    FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, SchemaKind, SerdeTagging,
+    ValidSchema, ValidValues,
 };
 pub use value::{ContentId, EXPRESSION_KEY, FieldValue, FieldValues, VALUE_CANON_VERSION};
 pub use widget::{
@@ -318,4 +319,44 @@ pub mod __private {
     //! path — the latter only resolves if the deriving crate happens to have an
     //! unrenamed `serde_json` dependency of its own.
     pub use {serde_json, tracing};
+
+    /// Build a union newtype-variant's payload field from the payload type's
+    /// schema, enforcing that the schema is a
+    /// [`Record`](crate::SchemaKind::Record).
+    ///
+    /// `#[derive(Schema)]` on an enum cannot tell at macro-expansion time whether a
+    /// newtype variant's payload type is a struct (a record) or itself an enum (a
+    /// union) or `serde_json::Value` (the gradual `Any`) — the macro's type
+    /// classification is purely syntactic. Splicing the top-level fields of a
+    /// non-record schema would declare keys serde never emits (a union schema's
+    /// synthetic root key) or a closed empty object (`Any`'s zero fields), breaking
+    /// the schema↔wire-key invariant. This guard fails loud at `schema()`
+    /// construction instead — consistent with the derive's other schema-build
+    /// panics — naming the offending variant.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `payload`'s kind is not [`Record`](crate::SchemaKind::Record)
+    /// (e.g. a newtype over an enum, over `serde_json::Value`, or over any other
+    /// `Any`-typed payload).
+    #[must_use]
+    pub fn union_newtype_payload(
+        wire_key: crate::FieldKey,
+        payload: crate::ValidSchema,
+        enum_name: &str,
+        variant: &str,
+    ) -> crate::Field {
+        assert!(
+            payload.kind() == crate::SchemaKind::Record,
+            "#[derive(Schema)] on enum `{enum_name}`: newtype variant `{variant}` wraps a type \
+             whose schema is `{:?}`, not a record — a payload that is itself a union (another \
+             enum), `serde_json::Value`, or otherwise shape-unknown cannot be modeled as a \
+             variant payload (its keys would not match the wire). Wrap the value in a plain \
+             `#[derive(Schema)]` struct.",
+            payload.kind(),
+        );
+        crate::Field::object(wire_key)
+            .add_many(payload.fields().iter().cloned())
+            .into()
+    }
 }

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -503,6 +503,33 @@ impl SchemaBuilder {
     /// Returns a [`ValidationReport`] when structural linting or index-limit
     /// checks fail.
     pub fn build(self) -> Result<ValidSchema, ValidationReport> {
+        self.build_inner(crate::SchemaKind::Record, None)
+    }
+
+    /// Build a [`SchemaKind::Union`] from a builder carrying exactly one root
+    /// `Field::Mode` (the union's variants), recording its serde `tagging`.
+    ///
+    /// Runs the same lint / index / depth checks as [`build`](Self::build), then
+    /// stamps the kind and tagging — so the union goes through one construction
+    /// path (no post-build `Arc` surgery) and a malformed shape is rejected as a
+    /// [`ValidationReport`], never a panic.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ValidationReport`] when structural linting or index-limit
+    /// checks fail.
+    pub(crate) fn build_union(
+        self,
+        tagging: crate::SerdeTagging,
+    ) -> Result<ValidSchema, ValidationReport> {
+        self.build_inner(crate::SchemaKind::Union, Some(tagging))
+    }
+
+    fn build_inner(
+        self,
+        kind: crate::SchemaKind,
+        serde_tagging: Option<crate::SerdeTagging>,
+    ) -> Result<ValidSchema, ValidationReport> {
         let mut fields = self.fields;
         let mut report = ValidationReport::new();
 
@@ -534,8 +561,8 @@ impl SchemaBuilder {
         build_index(&fields, &mut index, &mut flags);
 
         Ok(ValidSchema::from_inner(ValidSchemaInner {
-            kind: crate::SchemaKind::Record,
-            serde_tagging: None,
+            kind,
+            serde_tagging,
             fields,
             index,
             flags,

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -535,6 +535,7 @@ impl SchemaBuilder {
 
         Ok(ValidSchema::from_inner(ValidSchemaInner {
             kind: crate::SchemaKind::Record,
+            serde_tagging: None,
             fields,
             index,
             flags,

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -370,17 +370,27 @@ impl ValidSchema {
     /// a valid [`FieldKey`], two variants collide, or the schema otherwise fails a
     /// build-time lint.
     pub fn union(mode_field: ModeField, tagging: SerdeTagging) -> Result<Self, ValidationReport> {
-        let built = crate::schema::Schema::builder()
+        // A tagged union has no default variant: serde always requires the
+        // discriminant on the wire, and mode validation otherwise falls back to a
+        // `default_variant` when the selector is absent — which would let a value
+        // with no discriminant validate, breaking the tagged-union contract.
+        if mode_field.default_variant.is_some() {
+            return Err(ValidationReport::from(
+                ValidationError::builder("union.default_variant")
+                    .message(
+                        "a tagged union has no default variant — serde always requires the \
+                         discriminant; remove `default_variant` before building the union",
+                    )
+                    .build(),
+            ));
+        }
+        // Build through the normal builder so the union runs the same field lint
+        // (variant-key validity / uniqueness), index, and depth guard; `build_union`
+        // stamps the kind + tagging during construction (no post-build `Arc`
+        // surgery, no panic path).
+        crate::schema::Schema::builder()
             .add(mode_field.required())
-            .build()?;
-        // The builder just allocated this `Arc`, so it is uniquely owned: retag it
-        // in place (the one thing the Record builder path cannot express) instead
-        // of rebuilding the index and flags.
-        let mut inner =
-            Arc::try_unwrap(built.0).expect("a freshly built ValidSchema owns its Arc uniquely");
-        inner.kind = SchemaKind::Union;
-        inner.serde_tagging = Some(tagging);
-        Ok(Self::from_inner(inner))
+            .build_union(tagging)
     }
 
     /// Whether this schema is a concrete [`Record`](SchemaKind::Record), the
@@ -2582,6 +2592,26 @@ mod tests {
             content: "data".to_owned(),
         });
         assert_ne!(external, adjacent);
+    }
+
+    #[test]
+    fn union_rejects_default_variant() {
+        // A tagged union has no default variant — serde always requires the
+        // discriminant, and a default would let mode validation accept a value
+        // with no selector, breaking the tagged-union contract.
+        let mode = Field::mode(field_key!("auth"))
+            .variant(
+                "oauth",
+                "OAuth",
+                Field::object(field_key!("oauth"))
+                    .add(Field::string(field_key!("token")).required()),
+            )
+            .default_variant("oauth");
+        let err = ValidSchema::union(mode, SerdeTagging::External).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("default_variant"),
+            "the union constructor must reject a default variant, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -78,6 +78,56 @@ pub enum SchemaKind {
     Record,
     /// Gradual-typing `Any` — the shape is unknown (`serde_json::Value`).
     Any,
+    /// A tagged union (sum type) — the schema is one-of N typed variants
+    /// (a Rust enum with data). This is a **marker**: the variants are not stored
+    /// in a parallel structure but as the schema's sole root [`Field::Mode`],
+    /// whose [`ModeVariant`](crate::field::ModeVariant) keys are the serde wire
+    /// discriminants. Keeping the union as a root `Mode` means every existing
+    /// traversal — [`validate`](ValidSchema::validate), path lookup, projection,
+    /// alias canonicalization, the depth guard, and the assignability lattice's
+    /// `collect_mode_variants` rule — applies by construction, with no fail-open
+    /// gap (a parallel variant store would leave `fields` empty, and `validate`
+    /// iterates `fields` unconditionally). The serde tagging that maps the Rust
+    /// enum's wire shape onto those variant keys lives in
+    /// [`ValidSchemaInner::serde_tagging`].
+    Union,
+}
+
+/// How a Rust enum's wire form maps onto a [`SchemaKind::Union`]'s variant keys.
+///
+/// Recorded on a union schema so the JSON-Schema export can reproduce serde's
+/// exact wire shape — preserving the C1 invariant (schema variant key == serde
+/// wire key). Only the two taggings with a stable, statically-known discriminant
+/// are representable; internally-tagged and untagged enums are rejected at the
+/// derive (they cannot satisfy C1: the former inlines the tag into the payload
+/// namespace, the latter has no discriminant key at all).
+///
+/// # Scope (honest)
+///
+/// Today `serde_tagging` is consumed by the `json_schema` export (feature
+/// `schemars`) and by the assignability lattice. There is **no value-layer
+/// ingress yet** that rewrites serde's external/adjacent wire
+/// (`{"Variant": payload}` / `{tag, content}`) into the internal `{mode, value}`
+/// envelope that [`validate`](ValidSchema::validate) consumes — so a derived union
+/// currently guarantees C1 for *contract export and static type-checking*, not for
+/// runtime value validation of a serialized enum. That ingress adapter lands with
+/// the engine dispatch boundary that needs it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SerdeTagging {
+    /// serde's default: a data variant is `{"Variant": payload}` and a unit
+    /// variant is the bare string `"Variant"`.
+    External,
+    /// `#[serde(tag = "...", content = "...")]`: a data variant is
+    /// `{"<tag>": "Variant", "<content>": payload}` and a unit variant omits the
+    /// content key (`{"<tag>": "Variant"}`).
+    Adjacent {
+        /// The discriminant key (serde `tag`).
+        tag: String,
+        /// The payload key (serde `content`).
+        content: String,
+    },
 }
 
 /// Shared interior of a `ValidSchema`.
@@ -89,9 +139,16 @@ pub enum SchemaKind {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ValidSchemaInner {
-    /// Whether this is a concrete record or the gradual-typing `Any`.
+    /// Whether this is a concrete record, the gradual-typing `Any`, or a tagged
+    /// union ([`SchemaKind::Union`]).
     pub kind: SchemaKind,
-    /// Top-level ordered fields.
+    /// For a [`SchemaKind::Union`], how the Rust enum's wire form maps onto the
+    /// variant keys; `None` for `Record`/`Any`. Part of schema identity (see the
+    /// `PartialEq` impl): an `External` and an `Adjacent` union with otherwise
+    /// identical variants are *not* the same schema.
+    pub serde_tagging: Option<SerdeTagging>,
+    /// Top-level ordered fields. For a [`SchemaKind::Union`] this is exactly one
+    /// required root [`Field::Mode`].
     pub fields: Vec<Field>,
     /// Flat index from `FieldPath` → `FieldHandle` for O(1) path lookup.
     pub index: IndexMap<FieldPath, FieldHandle>,
@@ -123,6 +180,7 @@ impl PartialEq for ValidSchema {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
             || (self.0.kind == other.0.kind
+                && self.0.serde_tagging == other.0.serde_tagging
                 && self.0.fields == other.0.fields
                 && self.0.root_rules == other.0.root_rules)
     }
@@ -137,11 +195,16 @@ impl Serialize for ValidSchema {
         // `Record` schema keeps its `{"fields": [...]}` wire shape and a reader
         // that pre-dates `kind` still round-trips it as a record.
         let emit_kind = self.0.kind != SchemaKind::Record;
+        // `serde_tagging` is `Some` only for a `Union`; it rides next to `kind`.
+        let emit_tagging = self.0.serde_tagging.is_some();
         let has_rules = !self.0.root_rules.is_empty();
-        let len = 1 + usize::from(emit_kind) + usize::from(has_rules);
+        let len = 1 + usize::from(emit_kind) + usize::from(emit_tagging) + usize::from(has_rules);
         let mut s = serializer.serialize_struct("ValidSchema", len)?;
         if emit_kind {
             s.serialize_field("kind", &self.0.kind)?;
+        }
+        if let Some(tagging) = &self.0.serde_tagging {
+            s.serialize_field("serde_tagging", tagging)?;
         }
         s.serialize_field("fields", &self.0.fields)?;
         if has_rules {
@@ -160,12 +223,53 @@ impl<'de> Deserialize<'de> for ValidSchema {
             /// `kind` (`{"fields": [...]}`) round-trips as a record.
             #[serde(default)]
             kind: SchemaKind,
+            /// `Some` only for a [`SchemaKind::Union`]; `None` otherwise.
+            #[serde(default)]
+            serde_tagging: Option<SerdeTagging>,
             #[serde(default)]
             fields: Vec<Field>,
             #[serde(default)]
             root_rules: Vec<nebula_validator::Rule>,
         }
         let repr = ValidSchemaRepr::deserialize(deserializer)?;
+        if repr.kind == SchemaKind::Union {
+            // Fail closed: a union is exactly one required root `Field::Mode`
+            // plus a `serde_tagging`. Reconstruct through `ValidSchema::union`
+            // so the same lint / index / required-root invariants the in-process
+            // constructor enforces also gate wire-loaded unions — a malformed
+            // shape (wrong field count, non-`Mode` root, missing tagging, stray
+            // root rules) is rejected, never silently coerced into a permissive
+            // schema.
+            let Some(tagging) = repr.serde_tagging else {
+                return Err(serde::de::Error::custom(
+                    "schema tagged `kind: \"union\"` must carry `serde_tagging`",
+                ));
+            };
+            if !repr.root_rules.is_empty() {
+                return Err(serde::de::Error::custom(
+                    "schema tagged `kind: \"union\"` must not carry `root_rules`",
+                ));
+            }
+            if repr.fields.len() != 1 {
+                return Err(serde::de::Error::custom(
+                    "union schema must carry exactly one root mode field",
+                ));
+            }
+            let Some(Field::Mode(mode)) = repr.fields.into_iter().next() else {
+                return Err(serde::de::Error::custom(
+                    "union schema's root field must be a mode field",
+                ));
+            };
+            return Self::union(mode, tagging)
+                .map_err(|report| serde::de::Error::custom(format!("invalid union: {report:?}")));
+        }
+        // `serde_tagging` belongs only to a union; a `Record`/`Any` carrying it is
+        // malformed — reject rather than silently drop it.
+        if repr.serde_tagging.is_some() {
+            return Err(serde::de::Error::custom(
+                "only a schema tagged `kind: \"union\"` may carry `serde_tagging`",
+            ));
+        }
         if repr.kind == SchemaKind::Any {
             // Fail closed: an `Any` schema carries no constraints. A payload
             // tagged `Any` that also lists `fields`/`root_rules` is malformed
@@ -212,6 +316,7 @@ impl ValidSchema {
             .get_or_init(|| {
                 Self::from_inner(ValidSchemaInner {
                     kind: SchemaKind::Record,
+                    serde_tagging: None,
                     fields: Vec::new(),
                     index: IndexMap::new(),
                     flags: SchemaFlags::default(),
@@ -235,6 +340,7 @@ impl ValidSchema {
         ANY.get_or_init(|| {
             Self::from_inner(ValidSchemaInner {
                 kind: SchemaKind::Any,
+                serde_tagging: None,
                 fields: Vec::new(),
                 index: IndexMap::new(),
                 flags: SchemaFlags::default(),
@@ -244,11 +350,52 @@ impl ValidSchema {
         .clone()
     }
 
-    /// Whether this schema is a concrete [`Record`](SchemaKind::Record) or the
-    /// gradual-typing [`Any`](SchemaKind::Any).
+    /// Build a tagged-union (sum-type) schema from its variants.
+    ///
+    /// `mode_field` carries the union's variants — one
+    /// [`ModeVariant`](crate::field::ModeVariant) per Rust enum variant, its key
+    /// the serde wire discriminant; `tagging` records how the enum's wire form
+    /// maps onto those keys (see [`SerdeTagging`]). The union is stored as the
+    /// schema's sole **required** root [`Field::Mode`] (see [`SchemaKind::Union`]),
+    /// so it is built through the normal
+    /// [`SchemaBuilder`](crate::schema::SchemaBuilder) — running the same field
+    /// lint (variant-key validity and uniqueness), index build, and depth/fan-out
+    /// guard as any other schema — then retagged as a union. The root mode is
+    /// forced [`RequiredMode::Always`](crate::RequiredMode): a sum-type value is
+    /// never optional, so an absent value must fail rather than validate clean.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`ValidationReport`] from the builder when a variant key is not
+    /// a valid [`FieldKey`], two variants collide, or the schema otherwise fails a
+    /// build-time lint.
+    pub fn union(mode_field: ModeField, tagging: SerdeTagging) -> Result<Self, ValidationReport> {
+        let built = crate::schema::Schema::builder()
+            .add(mode_field.required())
+            .build()?;
+        // The builder just allocated this `Arc`, so it is uniquely owned: retag it
+        // in place (the one thing the Record builder path cannot express) instead
+        // of rebuilding the index and flags.
+        let mut inner =
+            Arc::try_unwrap(built.0).expect("a freshly built ValidSchema owns its Arc uniquely");
+        inner.kind = SchemaKind::Union;
+        inner.serde_tagging = Some(tagging);
+        Ok(Self::from_inner(inner))
+    }
+
+    /// Whether this schema is a concrete [`Record`](SchemaKind::Record), the
+    /// gradual-typing [`Any`](SchemaKind::Any), or a tagged
+    /// [`Union`](SchemaKind::Union).
     #[must_use]
     pub fn kind(&self) -> SchemaKind {
         self.0.kind
+    }
+
+    /// The serde tagging of a [`Union`](SchemaKind::Union) schema, or `None` for a
+    /// `Record`/`Any`.
+    #[must_use]
+    pub fn serde_tagging(&self) -> Option<&SerdeTagging> {
+        self.0.serde_tagging.as_ref()
     }
 
     /// Return `true` when two `ValidSchema` values share the same backing
@@ -2366,6 +2513,114 @@ mod tests {
             .unwrap();
         assert!(s.find(&FieldKey::new("x").unwrap()).is_some());
         assert!(s.find(&FieldKey::new("y").unwrap()).is_none());
+    }
+
+    // ── Sum-type union (SchemaKind::Union) ─────────────────────────────────────
+
+    fn sample_union(tagging: SerdeTagging) -> ValidSchema {
+        ValidSchema::union(
+            Field::mode(field_key!("auth"))
+                .variant(
+                    "oauth",
+                    "OAuth",
+                    Field::object(field_key!("oauth"))
+                        .add(Field::string(field_key!("token")).required()),
+                )
+                .variant_empty("none", "None"),
+            tagging,
+        )
+        .expect("sample union builds")
+    }
+
+    #[test]
+    fn union_kind_and_tagging_accessors() {
+        let u = sample_union(SerdeTagging::External);
+        assert_eq!(u.kind(), SchemaKind::Union);
+        assert_eq!(u.serde_tagging(), Some(&SerdeTagging::External));
+        // The variants live as the sole root Field::Mode (the marker design),
+        // not in a parallel store.
+        assert_eq!(u.fields().len(), 1);
+        assert!(matches!(u.fields()[0], Field::Mode(_)));
+    }
+
+    #[test]
+    fn union_root_mode_is_required_no_fail_open() {
+        // A sum-type value is never optional: the root mode is RequiredMode::Always,
+        // so an absent value FAILS rather than validating clean (the fail-open the
+        // parallel-Vec design would have allowed).
+        let u = sample_union(SerdeTagging::External);
+        let empty = FieldValues::from_json(serde_json::json!({})).unwrap();
+        assert!(
+            u.validate(&empty).is_err(),
+            "an absent sum-type value must fail the required root mode"
+        );
+    }
+
+    #[test]
+    fn union_roundtrips_external_and_adjacent() {
+        for tagging in [
+            SerdeTagging::External,
+            SerdeTagging::Adjacent {
+                tag: "type".to_owned(),
+                content: "data".to_owned(),
+            },
+        ] {
+            let u = sample_union(tagging);
+            let json = serde_json::to_string(&u).expect("serialize union");
+            let back: ValidSchema = serde_json::from_str(&json).expect("deserialize union");
+            assert_eq!(u, back, "a union must round-trip including its tagging");
+        }
+    }
+
+    #[test]
+    fn union_partial_eq_distinguishes_tagging() {
+        // Same variants, different tagging => different schema. Without serde_tagging
+        // in PartialEq these would falsely compare equal (a type-DAG cache defect).
+        let external = sample_union(SerdeTagging::External);
+        let adjacent = sample_union(SerdeTagging::Adjacent {
+            tag: "type".to_owned(),
+            content: "data".to_owned(),
+        });
+        assert_ne!(external, adjacent);
+    }
+
+    #[test]
+    fn union_deserialize_fails_closed() {
+        let union_wire = serde_json::to_value(sample_union(SerdeTagging::External)).unwrap();
+        let record_wire = serde_json::to_value(
+            Schema::builder()
+                .add(Field::string(field_key!("x")))
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+        // Missing serde_tagging on a union.
+        let mut missing_tag = union_wire.clone();
+        missing_tag.as_object_mut().unwrap().remove("serde_tagging");
+        assert!(serde_json::from_value::<ValidSchema>(missing_tag).is_err());
+
+        // Root field is not a mode field.
+        let mut not_mode = union_wire.clone();
+        not_mode["fields"] = record_wire["fields"].clone();
+        assert!(serde_json::from_value::<ValidSchema>(not_mode).is_err());
+
+        // More than one root field. (Last use of `union_wire` — move, don't clone.)
+        let mut multi = union_wire;
+        let doubled: Vec<serde_json::Value> = {
+            let mode_fields = multi["fields"].as_array().unwrap();
+            mode_fields.iter().chain(mode_fields).cloned().collect()
+        };
+        multi["fields"] = serde_json::Value::Array(doubled);
+        assert!(serde_json::from_value::<ValidSchema>(multi).is_err());
+
+        // A non-union (Record) must not carry serde_tagging.
+        let mut stray_tag = record_wire;
+        stray_tag
+            .as_object_mut()
+            .unwrap()
+            .insert("serde_tagging".to_owned(), serde_json::json!("external"));
+        assert!(serde_json::from_value::<ValidSchema>(stray_tag).is_err());
     }
 
     #[test]

--- a/crates/schema/tests/compile_fail/derive_schema_struct_generic.rs
+++ b/crates/schema/tests/compile_fail/derive_schema_struct_generic.rs
@@ -1,0 +1,11 @@
+//! `#[derive(Schema)]` rejects generic structs too (the struct path shares the
+//! same `OnceLock`-per-monomorphization hazard as the enum path).
+
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+struct Bad<T> {
+    field: T,
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_schema_struct_generic.stderr
+++ b/crates/schema/tests/compile_fail/derive_schema_struct_generic.stderr
@@ -1,0 +1,5 @@
+error: #[derive(Schema)] does not support generic type parameters: the generated `schema()` caches one `OnceLock` shared across every monomorphization, so all but the first `T` would get the wrong schema. Implement `HasSchema` by hand for generic types.
+ --> tests/compile_fail/derive_schema_struct_generic.rs:7:12
+  |
+7 | struct Bad<T> {
+  |            ^

--- a/crates/schema/tests/compile_fail/derive_union_generic.rs
+++ b/crates/schema/tests/compile_fail/derive_union_generic.rs
@@ -1,0 +1,12 @@
+//! `#[derive(Schema)]` rejects generic enums — the generated `schema()` caches one
+//! `OnceLock` shared across every monomorphization, so all but the first `T` would
+//! get the wrong schema.
+
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+enum Bad<T> {
+    A(T),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_generic.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_generic.stderr
@@ -1,0 +1,5 @@
+error: #[derive(Schema)] does not support generic type parameters: the generated `schema()` caches one `OnceLock` shared across every monomorphization, so all but the first `T` would get the wrong schema. Implement `HasSchema` by hand for generic types.
+ --> tests/compile_fail/derive_union_generic.rs:8:10
+  |
+8 | enum Bad<T> {
+  |          ^

--- a/crates/schema/tests/compile_fail/derive_union_internal.rs
+++ b/crates/schema/tests/compile_fail/derive_union_internal.rs
@@ -1,0 +1,13 @@
+//! `#[derive(Schema)]` rejects internally-tagged enums (`#[serde(tag = ..)]`
+//! without `content`): the tag inlines into the payload's field namespace, so the
+//! schema cannot keep the variant key disjoint from the payload keys.
+
+use nebula_schema::Schema;
+
+#[derive(serde::Serialize, Schema)]
+#[serde(tag = "kind")]
+enum Bad {
+    A { x: i64 },
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_internal.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_internal.stderr
@@ -1,0 +1,5 @@
+error: internally-tagged enums (`#[serde(tag = ..)]` without `content`) are not supported — the tag inlines into the payload's field namespace; add `#[serde(content = ..)]` for adjacent tagging
+ --> tests/compile_fail/derive_union_internal.rs:9:6
+  |
+9 | enum Bad {
+  |      ^^^

--- a/crates/schema/tests/compile_fail/derive_union_kebab_key.rs
+++ b/crates/schema/tests/compile_fail/derive_union_kebab_key.rs
@@ -1,0 +1,18 @@
+//! `#[derive(Schema)]` rejects a variant whose resolved wire key is not a valid
+//! `FieldKey`: `kebab-case` produces `foo-bar`, and a hyphen is illegal in a key
+//! (variant keys are used as schema path segments).
+
+use nebula_schema::Schema;
+
+#[derive(serde::Serialize, Schema)]
+struct Cfg {
+    x: String,
+}
+
+#[derive(serde::Serialize, Schema)]
+#[serde(rename_all = "kebab-case")]
+enum Bad {
+    FooBar(Cfg),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_kebab_key.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_kebab_key.stderr
@@ -1,0 +1,5 @@
+error: variant `FooBar` resolves to the wire key `foo-bar`, which is not a valid schema key (key must be ASCII alphanumeric or underscore); rename the variant (or set `#[serde(rename = "..")]`) so its key is a non-empty ASCII identifier — variant keys are used as schema path segments
+  --> tests/compile_fail/derive_union_kebab_key.rs:15:5
+   |
+15 |     FooBar(Cfg),
+   |     ^^^^^^

--- a/crates/schema/tests/compile_fail/derive_union_newtype_primitive.rs
+++ b/crates/schema/tests/compile_fail/derive_union_newtype_primitive.rs
@@ -1,0 +1,12 @@
+//! `#[derive(Schema)]` rejects a newtype variant over a non-struct payload — a
+//! primitive (or `Vec` / `Option`) payload has no field schema yet; wrap it in a
+//! `#[derive(Schema)]` struct.
+
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+enum Bad {
+    A(String),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_newtype_primitive.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_newtype_primitive.stderr
@@ -1,0 +1,5 @@
+error: a newtype variant's payload must be a struct that derives `Schema`; primitive, `Vec`, and `Option` newtype payloads are not yet supported — wrap the value in a `#[derive(Schema)]` struct
+ --> tests/compile_fail/derive_union_newtype_primitive.rs:9:7
+  |
+9 |     A(String),
+  |       ^^^^^^

--- a/crates/schema/tests/compile_fail/derive_union_tuple.rs
+++ b/crates/schema/tests/compile_fail/derive_union_tuple.rs
@@ -1,0 +1,11 @@
+//! `#[derive(Schema)]` rejects tuple variants with more than one field — a
+//! positional array has no named-field schema.
+
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+enum Bad {
+    A(i64, i64),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_tuple.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_tuple.stderr
@@ -1,0 +1,5 @@
+error: tuple variants with more than one field are not supported by #[derive(Schema)]; use a struct variant `{ .. }` with named fields
+ --> tests/compile_fail/derive_union_tuple.rs:8:5
+  |
+8 |     A(i64, i64),
+  |     ^^^^^^^^^^^

--- a/crates/schema/tests/compile_fail/derive_union_untagged.rs
+++ b/crates/schema/tests/compile_fail/derive_union_untagged.rs
@@ -1,0 +1,17 @@
+//! `#[derive(Schema)]` rejects `#[serde(untagged)]` enums — an untagged union has
+//! no discriminant key, so the schema cannot reproduce its wire shape (C1).
+
+use nebula_schema::Schema;
+
+#[derive(serde::Serialize, Schema)]
+struct Cfg {
+    x: String,
+}
+
+#[derive(serde::Serialize, Schema)]
+#[serde(untagged)]
+enum Bad {
+    A(Cfg),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_untagged.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_untagged.stderr
@@ -1,0 +1,5 @@
+error: #[serde(untagged)] enums are not supported by #[derive(Schema)] — an untagged union has no discriminant key, so the schema cannot reproduce its wire shape
+  --> tests/compile_fail/derive_union_untagged.rs:13:6
+   |
+13 | enum Bad {
+   |      ^^^

--- a/crates/schema/tests/compile_fail/derive_union_variant_alias.rs
+++ b/crates/schema/tests/compile_fail/derive_union_variant_alias.rs
@@ -1,0 +1,18 @@
+//! `#[derive(Schema)]` rejects `#[serde(alias = ..)]` on an enum variant — a union
+//! records one wire discriminant per variant, so an alias serde would still
+//! deserialize becomes a key schema validation rejects (a C1 desync).
+
+use nebula_schema::Schema;
+
+#[derive(serde::Serialize, Schema)]
+struct Cfg {
+    x: String,
+}
+
+#[derive(serde::Serialize, Schema)]
+enum Bad {
+    #[serde(alias = "Alt")]
+    Primary(Cfg),
+}
+
+fn main() {}

--- a/crates/schema/tests/compile_fail/derive_union_variant_alias.stderr
+++ b/crates/schema/tests/compile_fail/derive_union_variant_alias.stderr
@@ -1,0 +1,5 @@
+error: #[serde(alias = ..)] on the variant `Primary` cannot be modeled by #[derive(Schema)]: a union records exactly one wire discriminant per variant, so the alias would be a key serde deserializes but schema validation rejects. Remove the alias, or make it the canonical key with #[serde(rename = ..)].
+  --> tests/compile_fail/derive_union_variant_alias.rs:15:5
+   |
+15 |     Primary(Cfg),
+   |     ^^^^^^^

--- a/crates/schema/tests/derive_union.rs
+++ b/crates/schema/tests/derive_union.rs
@@ -1,0 +1,317 @@
+//! `#[derive(Schema)]` on payload-carrying enums → tagged-union schemas.
+//!
+//! The C1 invariant (schema variant key == serde wire key) is checked against an
+//! independent oracle: each enum derives `Serialize` too, and the test asserts the
+//! key serde actually emits equals the key the schema declares — so a drift
+//! between the derive's variant-key algorithm and serde_derive's fails the test.
+
+use nebula_schema::{HasSchema, Schema, SchemaKind, SerdeTagging, schema_of};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+// ── helpers (read the union shape off the serialized schema wire) ─────────────
+
+fn schema_wire<T: HasSchema>() -> Value {
+    serde_json::to_value(schema_of::<T>()).expect("schema serializes")
+}
+
+fn variant_keys<T: HasSchema>() -> Vec<String> {
+    schema_wire::<T>()["fields"][0]["variants"]
+        .as_array()
+        .expect("a union has one root mode field with variants")
+        .iter()
+        .map(|v| {
+            v["key"]
+                .as_str()
+                .expect("variant key is a string")
+                .to_owned()
+        })
+        .collect()
+}
+
+fn variant_payload_field_keys<T: HasSchema>(variant_key: &str) -> Vec<String> {
+    let wire = schema_wire::<T>();
+    let variants = wire["fields"][0]["variants"].as_array().expect("variants");
+    let variant = variants
+        .iter()
+        .find(|v| v["key"] == json!(variant_key))
+        .expect("variant present");
+    variant["field"]["fields"]
+        .as_array()
+        .map(|fields| {
+            fields
+                .iter()
+                .map(|f| f["key"].as_str().expect("field key").to_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ── External tagging (serde default) ─────────────────────────────────────────
+
+#[derive(Serialize, Schema)]
+struct OAuthCfg {
+    client_id: String,
+}
+
+#[derive(Serialize, Schema)]
+enum ExternalAuth {
+    OAuth(OAuthCfg),
+    ApiKey { key: String },
+    None,
+}
+
+#[test]
+fn external_enum_is_a_union_with_verbatim_keys() {
+    let schema = schema_of::<ExternalAuth>();
+    assert_eq!(schema.kind(), SchemaKind::Union);
+    assert_eq!(schema.serde_tagging(), Some(&SerdeTagging::External));
+    // serde's default variant key is the ident VERBATIM (NOT snake_case — that was
+    // the EnumSelect UI convention, wrong for serde fidelity).
+    assert_eq!(variant_keys::<ExternalAuth>(), ["OAuth", "ApiKey", "None"]);
+}
+
+#[test]
+fn external_wire_keys_match_schema_variants() {
+    // Newtype variant → { "OAuth": { .. } }.
+    let oauth = serde_json::to_value(ExternalAuth::OAuth(OAuthCfg {
+        client_id: "x".to_owned(),
+    }))
+    .unwrap();
+    assert_eq!(oauth.as_object().unwrap().keys().next().unwrap(), "OAuth");
+
+    // Struct variant → { "ApiKey": { "key": .. } }.
+    let api = serde_json::to_value(ExternalAuth::ApiKey {
+        key: "k".to_owned(),
+    })
+    .unwrap();
+    assert_eq!(api.as_object().unwrap().keys().next().unwrap(), "ApiKey");
+
+    // Unit variant → the bare string "None" (NOT { "None": {} }).
+    let none = serde_json::to_value(ExternalAuth::None).unwrap();
+    assert_eq!(none, json!("None"));
+
+    // Every serde wire key is a declared schema variant.
+    let keys = variant_keys::<ExternalAuth>();
+    for expected in ["OAuth", "ApiKey", "None"] {
+        assert!(keys.iter().any(|k| k == expected), "missing {expected}");
+    }
+}
+
+#[test]
+fn newtype_payload_fields_come_from_the_inner_struct() {
+    // External `{ "OAuth": { "client_id": .. } }` — the payload schema is OAuthCfg.
+    assert_eq!(
+        variant_payload_field_keys::<ExternalAuth>("OAuth"),
+        ["client_id"]
+    );
+    let oauth = serde_json::to_value(ExternalAuth::OAuth(OAuthCfg {
+        client_id: "x".to_owned(),
+    }))
+    .unwrap();
+    assert!(oauth["OAuth"].get("client_id").is_some());
+}
+
+// ── Container rename_all uses serde's EXACT variant algorithm ─────────────────
+
+#[derive(Serialize, Schema)]
+#[serde(rename_all = "snake_case")]
+enum Renamed {
+    HTTPProxy(OAuthCfg),
+    PlainText,
+}
+
+#[test]
+fn rename_all_matches_serde_variant_algorithm_exactly() {
+    // serde's snake_case for a VARIANT inserts `_` before every uppercase letter
+    // (no acronym grouping): HTTPProxy → h_t_t_p_proxy, not http_proxy.
+    assert_eq!(variant_keys::<Renamed>(), ["h_t_t_p_proxy", "plain_text"]);
+
+    // Oracle: serde emits the identical key.
+    let wire = serde_json::to_value(Renamed::HTTPProxy(OAuthCfg {
+        client_id: "x".to_owned(),
+    }))
+    .unwrap();
+    assert_eq!(
+        wire.as_object().unwrap().keys().next().unwrap(),
+        "h_t_t_p_proxy"
+    );
+    assert_eq!(
+        serde_json::to_value(Renamed::PlainText).unwrap(),
+        json!("plain_text")
+    );
+}
+
+// ── Per-variant #[serde(rename)] ─────────────────────────────────────────────
+
+#[derive(Serialize, Schema)]
+enum WithRename {
+    #[serde(rename = "v2")]
+    Version2 { n: i64 },
+}
+
+#[test]
+fn variant_rename_wins() {
+    assert_eq!(variant_keys::<WithRename>(), ["v2"]);
+    let wire = serde_json::to_value(WithRename::Version2 { n: 1 }).unwrap();
+    assert_eq!(wire.as_object().unwrap().keys().next().unwrap(), "v2");
+}
+
+// ── Struct-variant field keys follow the VARIANT's rename_all ─────────────────
+
+#[derive(Serialize, Schema)]
+enum Mixed {
+    #[serde(rename_all = "camelCase")]
+    Create { user_name: String, is_admin: bool },
+}
+
+#[test]
+fn struct_variant_field_keys_follow_variant_rename_all() {
+    assert_eq!(
+        variant_payload_field_keys::<Mixed>("Create"),
+        ["userName", "isAdmin"]
+    );
+    // Oracle: serde renames the variant's fields the same way.
+    let wire = serde_json::to_value(Mixed::Create {
+        user_name: "a".to_owned(),
+        is_admin: true,
+    })
+    .unwrap();
+    let payload = &wire["Create"];
+    assert!(payload.get("userName").is_some());
+    assert!(payload.get("isAdmin").is_some());
+}
+
+// ── Adjacent tagging records the SerdeTagging ────────────────────────────────
+
+#[derive(Serialize, Schema)]
+#[serde(tag = "type", content = "data")]
+enum Event {
+    Click { x: i64 },
+    Noop,
+}
+
+#[test]
+fn adjacent_enum_records_tagging() {
+    let schema = schema_of::<Event>();
+    assert_eq!(schema.kind(), SchemaKind::Union);
+    assert_eq!(
+        schema.serde_tagging(),
+        Some(&SerdeTagging::Adjacent {
+            tag: "type".to_owned(),
+            content: "data".to_owned(),
+        })
+    );
+    assert_eq!(variant_keys::<Event>(), ["Click", "Noop"]);
+
+    // Oracle: serde adjacent wire is { "type": "Click", "data": { .. } }.
+    let wire = serde_json::to_value(Event::Click { x: 1 }).unwrap();
+    assert_eq!(wire["type"], json!("Click"));
+    assert!(wire["data"].get("x").is_some());
+    // Unit variant omits content: { "type": "Noop" }.
+    let noop = serde_json::to_value(Event::Noop).unwrap();
+    assert_eq!(noop["type"], json!("Noop"));
+    assert!(noop.get("data").is_none());
+}
+
+// ── #[serde(skip)] drops a variant from the union ────────────────────────────
+
+#[derive(Serialize, Schema)]
+enum WithSkip {
+    Kept {
+        n: i64,
+    },
+    #[serde(skip)]
+    #[allow(
+        dead_code,
+        reason = "exercises that #[serde(skip)] drops the union arm"
+    )]
+    Hidden,
+}
+
+#[test]
+fn serde_skip_drops_the_variant() {
+    assert_eq!(variant_keys::<WithSkip>(), ["Kept"]);
+    // The kept variant still round-trips through serde under its wire key.
+    let wire = serde_json::to_value(WithSkip::Kept { n: 1 }).unwrap();
+    assert_eq!(wire.as_object().unwrap().keys().next().unwrap(), "Kept");
+}
+
+// ── The union schema is a DESERIALIZATION contract ───────────────────────────
+
+#[derive(Serialize, Schema)]
+enum WithSkipDeser {
+    Kept {
+        n: i64,
+    },
+    #[serde(skip_deserializing)]
+    SerOnly {
+        m: i64,
+    },
+}
+
+#[test]
+fn skip_deserializing_variant_is_dropped_but_serde_still_serializes_it() {
+    // A `#[serde(skip_deserializing)]` variant is never produced by the
+    // deserializer, so it is dropped from the union schema (the schema is a
+    // deserialization contract — see `SchemaKind::Union`)...
+    assert_eq!(variant_keys::<WithSkipDeser>(), ["Kept"]);
+    let kept = serde_json::to_value(WithSkipDeser::Kept { n: 1 }).unwrap();
+    assert_eq!(kept.as_object().unwrap().keys().next().unwrap(), "Kept");
+    // ...even though serde STILL serializes the skipped variant. The schema is
+    // deliberately not an output/producer contract; this asymmetry is the
+    // documented scope.
+    let ser_only = serde_json::to_value(WithSkipDeser::SerOnly { m: 1 }).unwrap();
+    assert_eq!(
+        ser_only.as_object().unwrap().keys().next().unwrap(),
+        "SerOnly"
+    );
+}
+
+// ── Newtype payload must be a Record (fail-loud on union / Any) ───────────────
+
+#[derive(Serialize, Schema)]
+#[expect(
+    dead_code,
+    reason = "constructed only via schema_of, which panics by design"
+)]
+enum InnerUnion {
+    A { x: i64 },
+    B,
+}
+
+#[derive(Serialize, Schema)]
+#[expect(
+    dead_code,
+    reason = "constructed only via schema_of, which panics by design"
+)]
+enum OuterWrapsEnum {
+    Wrap(InnerUnion),
+}
+
+/// A newtype variant over another enum (a union payload) would splice the union's
+/// synthetic root key — a key serde never emits. The runtime guard rejects it at
+/// `schema()` init rather than producing a C1-broken schema.
+#[test]
+#[should_panic(expected = "not a record")]
+fn newtype_over_enum_panics_at_schema_init() {
+    let _ = schema_of::<OuterWrapsEnum>();
+}
+
+#[derive(Serialize, Schema)]
+#[expect(
+    dead_code,
+    reason = "constructed only via schema_of, which panics by design"
+)]
+enum OuterWrapsAny {
+    Raw(Value),
+}
+
+/// A newtype variant over `serde_json::Value` (the gradual `Any`, zero fields)
+/// would become a closed empty object that rejects every payload — the inverse of
+/// `Any`. The guard rejects it at `schema()` init.
+#[test]
+#[should_panic(expected = "not a record")]
+fn newtype_over_any_panics_at_schema_init() {
+    let _ = schema_of::<OuterWrapsAny>();
+}

--- a/crates/schema/tests/evolution_wire_snapshot.rs
+++ b/crates/schema/tests/evolution_wire_snapshot.rs
@@ -18,8 +18,8 @@
 //!   newer writer's field kind never fails to read on an older deployment.
 
 use nebula_schema::{
-    Field, FieldPath, FieldValue, FieldValues, Predicate, Rule, Schema, ValidationError,
-    ValidationReport, VisibilityMode, field_key,
+    Field, FieldPath, FieldValue, FieldValues, Predicate, Rule, Schema, SerdeTagging, ValidSchema,
+    ValidationError, ValidationReport, VisibilityMode, field_key,
 };
 use serde_json::json;
 
@@ -78,6 +78,42 @@ fn valid_schema_wire_format() {
         .build()
         .unwrap();
     insta::assert_json_snapshot!(schema);
+}
+
+/// A tagged-union (`SchemaKind::Union`) wire shape: `kind: "union"` +
+/// `serde_tagging` + the single root mode field carrying the variants. A change
+/// to the union envelope (or to how a mixed unit+data union is stored) diffs here.
+#[test]
+fn union_schema_wire_format() {
+    let external = ValidSchema::union(
+        Field::mode(field_key!("auth"))
+            .variant(
+                "oauth",
+                "OAuth",
+                Field::object(field_key!("oauth"))
+                    .add(Field::secret(field_key!("token")).required()),
+            )
+            .variant_empty("none", "None"),
+        SerdeTagging::External,
+    )
+    .unwrap();
+    insta::assert_json_snapshot!("union_schema_external_wire_format", external);
+
+    let adjacent = ValidSchema::union(
+        Field::mode(field_key!("event"))
+            .variant(
+                "click",
+                "Click",
+                Field::object(field_key!("click")).add(Field::number(field_key!("x")).required()),
+            )
+            .variant_empty("noop", "No-op"),
+        SerdeTagging::Adjacent {
+            tag: "type".to_owned(),
+            content: "data".to_owned(),
+        },
+    )
+    .unwrap();
+    insta::assert_json_snapshot!("union_schema_adjacent_wire_format", adjacent);
 }
 
 /// A `FieldValues` store covering every runtime-value shape (literal, nested

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__union_schema_adjacent_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__union_schema_adjacent_wire_format.snap
@@ -1,0 +1,60 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: adjacent
+---
+{
+  "kind": "union",
+  "serde_tagging": {
+    "adjacent": {
+      "tag": "type",
+      "content": "data"
+    }
+  },
+  "fields": [
+    {
+      "type": "mode",
+      "key": "event",
+      "required": {
+        "kind": "always"
+      },
+      "variants": [
+        {
+          "key": "click",
+          "label": "Click",
+          "field": {
+            "type": "object",
+            "key": "click",
+            "fields": [
+              {
+                "type": "number",
+                "key": "x",
+                "required": {
+                  "kind": "always"
+                },
+                "integer": false,
+                "widget": "plain",
+                "step": null
+              }
+            ],
+            "widget": "inline"
+          }
+        },
+        {
+          "key": "noop",
+          "label": "No-op",
+          "field": {
+            "type": "string",
+            "key": "_nebula_mode_empty",
+            "visible": {
+              "kind": "never"
+            },
+            "expression": "forbidden",
+            "hint": "text",
+            "widget": "plain"
+          }
+        }
+      ],
+      "default_variant": null
+    }
+  ]
+}

--- a/crates/schema/tests/snapshots/evolution_wire_snapshot__union_schema_external_wire_format.snap
+++ b/crates/schema/tests/snapshots/evolution_wire_snapshot__union_schema_external_wire_format.snap
@@ -1,0 +1,54 @@
+---
+source: crates/schema/tests/evolution_wire_snapshot.rs
+expression: external
+---
+{
+  "kind": "union",
+  "serde_tagging": "external",
+  "fields": [
+    {
+      "type": "mode",
+      "key": "auth",
+      "required": {
+        "kind": "always"
+      },
+      "variants": [
+        {
+          "key": "oauth",
+          "label": "OAuth",
+          "field": {
+            "type": "object",
+            "key": "oauth",
+            "fields": [
+              {
+                "type": "secret",
+                "key": "token",
+                "required": {
+                  "kind": "always"
+                },
+                "widget": "plain",
+                "reveal_last": null
+              }
+            ],
+            "widget": "inline"
+          }
+        },
+        {
+          "key": "none",
+          "label": "None",
+          "field": {
+            "type": "string",
+            "key": "_nebula_mode_empty",
+            "visible": {
+              "kind": "never"
+            },
+            "expression": "forbidden",
+            "hint": "text",
+            "widget": "plain"
+          }
+        }
+      ],
+      "default_variant": null
+    }
+  ]
+}

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -233,7 +233,7 @@ pub struct PortSchemaUndecidableDetails {
     pub to_port: Option<String>,
     /// Every reason the edge is undecidable, structured so a policy can route on
     /// them (e.g. suppress [`OpaqueProducer`](nebula_schema::UnknownReason::OpaqueProducer)
-    /// while blocking [`ModeVariance`](nebula_schema::UnknownReason::ModeVariance))
+    /// while blocking [`DynamicLoaderBacked`](nebula_schema::UnknownReason::DynamicLoaderBacked))
     /// without string-parsing. The `Display` impl joins their descriptions with `"; "`.
     pub reasons: Vec<nebula_schema::UnknownReason>,
 }


### PR DESCRIPTION
## Summary

Lands the **sum-type `SchemaKind::Union` keystone** that the unified-authoring arc (ADR-0109-B / ADR-0110) gates on — giving the type-DAG a faithful tagged-union edge — plus two independent, self-contained correctness fixes that surfaced while working in the same areas. Output of a multi-agent design planёrka and a follow-up adversarial C1 review; every confirmed review finding is fixed in this PR.

## Linked issue

None — the design + adversarial-review record lives in the maintainers' private design vault (`research/2026-06-24-schema-union-keystone-design.md`).

## Type of change

- [x] `feat` — new capability (sum-type union schema + payload-enum derive)
- [x] `fix` — bug fixes (idempotency key, `output_path` grammar, `Field::Mode` variance soundness)

## Affected crates / areas

- `nebula-schema` (+ `nebula-schema-macros`) — the keystone
- `nebula-execution` — idempotency key
- `nebula-engine` — `output_path` resolution
- `nebula-workflow` — coupled doc-link repoint

## Changes

- **`Field::Mode` variance**: replace the deliberately-unsound `Unknown(ModeVariance)` punt with a structural sum-type rule (the dual of record width-subtyping) — producer-variant containment (`SchemaIncompat::UnhandledVariant`) + covariant payloads; sound for edges and output-evolution. Removes the now-dead `UnknownReason::ModeVariance`.
- **`SchemaKind::Union`**: a marker over the schema's single root `Field::Mode` (not a parallel variant `Vec` — `validate()` iterates `fields` unconditionally, so a side-Vec would be fail-open). Adds `SerdeTagging {External, Adjacent}`, `ValidSchema::union()` (forces the root Mode required), fail-closed serde, `SchemaIncompat::KindMismatch`, union assignability via the one `collect_mode_variants` rule, and a C1-faithful `json_schema` export.
- **`#[derive(Schema)]` on enums** → a union, honoring serde tagging with serde-exact variant keys. Reject matrix (trybuild): untagged, internal, tuple>1, non-`FieldKey` variant key, newtype-over-primitive, variant `#[serde(alias)]`, and **generic type/const params** (one `OnceLock` shared across monomorphizations returns the wrong schema — fixed in both the struct and enum paths). Runtime guard rejects a newtype payload whose schema kind ≠ `Record`.
- **`nebula-execution`**: injective `IdempotencyKey` via length-prefixed framing + kind tag (closes a latent false-dedup / missed-payment footgun in `with_business_key`).
- **`nebula-engine`**: `navigate_path` strips an optional JSONPath root (`$.` / `$`) so the documented `output_path` grammar resolves instead of returning `Null` (ADR-0110 §6).

## Test plan

- `nebula-schema` unit + integration suites incl. a new `tests/derive_union.rs` whose C1 oracle compares schema variant/field keys against **serde's own wire output** (verbatim default, serde-exact `HTTPProxy → h_t_t_p_proxy`, variant rename, struct-variant field rename_all, adjacent tagging) + `should_panic` guards for newtype-over-enum / over-`Value`.
- trybuild reject matrix (9 fixtures) pins every rejected shape's compile error.
- insta golden snapshots for the union wire (external + adjacent).
- red→green regression tests for the idempotency-key and `output_path` fixes.

### Local verification

- [x] `cargo fmt` — formatted (lefthook fmt-check green)
- [x] `cargo clippy --workspace -- -D warnings` — clean (lefthook clippy-full green)
- [x] `cargo nextest run --workspace` — 1323 passed, 0 skipped (pre-push)
- [x] `cargo test -p nebula-schema --doc` — schema doctests pass
- [ ] `cargo deny check` — N/A (no `Cargo.toml` / dependency change)
- [x] `rustdoc -D warnings` (default features, all changed crates) — clean

## Breaking changes

Internal only — **no `nebula-sdk` (the sole public crate) surface change**. Within the workspace: `SchemaKind` and `SchemaIncompat` gain `#[non_exhaustive]` variants (`Union`, `KindMismatch`); `UnknownReason::ModeVariance` is removed (Mode-vs-Mode is now a real assignability verdict, not `Unknown`). `#[derive(Schema)]` on an enum changes from a hard error to producing a union schema. No persisted-data migration (no union instances exist yet).

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift; the union schema is documented as a deserialization contract and its value-layer ingress is explicitly deferred (honest scope on `SerdeTagging`)
- [x] Layer direction preserved (schema is a leaf; engine/execution/workflow unchanged in direction)
- [x] Crate `lib.rs //!` / public surface — `SerdeTagging` exported and documented
- [x] Plan/spec recorded in the private design vault (`research/2026-06-24-schema-union-keystone-design.md`)

## Safety / security impact

- [x] No new `unwrap()`/`expect()`/`panic!()` in library paths reachable on valid input (the newtype guard / union-build panics fire only on an author misuse the macro can't reject at expansion — fail-loud at `schema()` init, the established derive pattern)
- [x] No silent error suppression
- [x] No execution state transitions touched
- [x] No credential/secret paths touched
- [x] No new `unsafe`

## Notes for reviewers

- The two correctness fixes (idempotency, `output_path`) are deliberately **separate commits** for independent bisect/revert, bundled here as one session of work.
- **Deferred, by design** (documented on `SerdeTagging`): the value-layer ingress adapter (serde wire → `{mode,value}` envelope) — a derived union's C1 invariant today covers `json_schema` export + static assignability, not runtime value validation; the adapter lands with the engine dispatch boundary that will consume it (adding it now would be a caller-less orphan).
- **Known limitation** (flagged): a `#[serde(transparent)]` newtype payload is undetectable from the variant site (reports `kind == Record`).
- Verified correction to the design plan: the union dispatch in `explain_assignable_core` runs **after** all three gradual escapes, so `Any`-producer → union-consumer stays `Unknown`, not a false `KindMismatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deriving schemas from enums as tagged unions, including serde tagging styles.
  * JSON Schema export now includes union types with appropriate `oneOf` structures and discriminators.
  * Path navigation now accepts JSONPath-style roots like `$.foo.bar` and `$`.

* **Bug Fixes**
  * Improved idempotency key generation to avoid collisions in edge cases.
  * Tightened schema compatibility checks for union and enum evolution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->