### PR TITLE
feat(schema): union value-layer ingress/egress bridge (serde wire ⇄ {mode,value} envelope)

### DIFF
--- a/crates/credential/src/service/facade.rs
+++ b/crates/credential/src/service/facade.rs
@@ -32,7 +32,6 @@ use std::time::Duration;
 
 use nebula_resilience::CallError;
 use nebula_resilience::retry::{BackoffConfig, RetryConfig, retry_with};
-use nebula_schema::FieldValues;
 use serde::Serialize;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
@@ -330,11 +329,10 @@ impl CredentialService {
         // expressions. Monomorphised per type in the ops table.
         self.ops.validate(credential_key, &props)?;
 
-        let values = FieldValues::from_json(props).map_err(|e| {
-            CredentialServiceError::ValidationFailed {
-                reason: format!("property ingest failed: {e}"),
-            }
-        })?;
+        // Union-aware ingress: a record `Properties` folds via `from_json`; a union
+        // folds serde's tagged wire into the `{mode, value}` envelope `resolve`
+        // consumes (per-type, keyed by the registered schema's `serde_tagging`).
+        let values = self.ops.ingest(credential_key, &props)?;
 
         let id = CredentialId::new();
         let ctx = Self::owner_context(scope);
@@ -525,11 +523,7 @@ impl CredentialService {
         let resolved = match props {
             Some(props) => {
                 self.ops.validate(&existing.credential_key, &props)?;
-                let values = FieldValues::from_json(props).map_err(|e| {
-                    CredentialServiceError::ValidationFailed {
-                        reason: format!("property ingest failed: {e}"),
-                    }
-                })?;
+                let values = self.ops.ingest(&existing.credential_key, &props)?;
                 let ctx = Self::owner_context(scope);
                 Some(
                     self.ops
@@ -997,11 +991,7 @@ impl CredentialService {
             });
         }
         self.ops.validate(credential_key, &props)?;
-        let values = FieldValues::from_json(props).map_err(|e| {
-            CredentialServiceError::ValidationFailed {
-                reason: format!("property ingest failed: {e}"),
-            }
-        })?;
+        let values = self.ops.ingest(credential_key, &props)?;
         let ctx = Self::owner_context(scope);
         let outcome = self
             .ops

--- a/crates/credential/src/service/ops.rs
+++ b/crates/credential/src/service/ops.rs
@@ -205,6 +205,17 @@ type RevokeFn =
 type ValidateFn =
     Arc<dyn Fn(&serde_json::Value) -> Result<(), CredentialServiceError> + Send + Sync>;
 
+/// Erased property ingest: rewrites inbound serde-wire JSON into the validator's
+/// [`FieldValues`] envelope for the captured concrete `C` via
+/// `schema_of::<C::Properties>().values_from_wire(props)`. For a record
+/// `Properties` this is plain [`FieldValues::from_json`]; for a tagged-union
+/// `Properties` (a `#[derive(Schema)]` enum) it folds serde's external/adjacent
+/// wire into the internal `{mode, value}` envelope so the same downstream
+/// `validate` / `resolve` path the record case takes also accepts a union. The
+/// schema's `serde_tagging` is the single source of truth for that rewrite.
+type IngestFn =
+    Arc<dyn Fn(&serde_json::Value) -> Result<FieldValues, CredentialServiceError> + Send + Sync>;
+
 /// One credential type's erased operation closures.
 ///
 /// `validate` / `resolve` / `acquire` are always present (the base
@@ -216,6 +227,7 @@ type ValidateFn =
 /// `plugin_capability_report`).
 struct OpsEntry<PS> {
     validate: ValidateFn,
+    ingest: IngestFn,
     resolve: ResolveFn<PS>,
     acquire: AcquireFn<PS>,
     test_fn: Option<TestFn>,
@@ -345,6 +357,32 @@ impl<PS: PendingStateStore> DispatchOps<PS> {
                 key: key.to_owned(),
             })?;
         (entry.validate)(props)
+    }
+
+    /// Ingest inbound serde-wire `props` into the validator's [`FieldValues`]
+    /// envelope for the type at `key`, applying the union wire→envelope rewrite
+    /// when `C::Properties` is a tagged union (driven by the schema's
+    /// `serde_tagging`). This is the per-type counterpart of
+    /// [`FieldValues::from_json`] that the type-erased facade must use so a union
+    /// `Properties` resolves through the same envelope `validate` accepts.
+    ///
+    /// # Errors
+    ///
+    /// [`CredentialServiceError::TypeUnknown`] when `key` is absent;
+    /// [`CredentialServiceError::ValidationFailed`] when the wire shape does not
+    /// match the type's schema (carries only `code`/`path`, never raw values).
+    pub(crate) fn ingest(
+        &self,
+        key: &str,
+        props: &serde_json::Value,
+    ) -> Result<FieldValues, CredentialServiceError> {
+        let entry = self
+            .entries
+            .get(key)
+            .ok_or_else(|| CredentialServiceError::TypeUnknown {
+                key: key.to_owned(),
+            })?;
+        (entry.ingest)(props)
     }
 
     /// Drive an acquisition for the type at `key`: same canonical
@@ -578,13 +616,16 @@ where
     );
 
     let validate: ValidateFn = Arc::new(|props: &serde_json::Value| {
-        // Canonical pipeline (mirrors `properties_pipeline.rs`): schema
-        // validate, then a typed `from_value` round-trip. The credential
-        // pipeline never resolves expressions, so a `{"$expr": ..}`
-        // envelope passes schema validation but is refused by the typed
-        // deserialize below (credential secrecy defense-in-depth #2).
+        // Canonical pipeline (mirrors `properties_pipeline.rs`): ingest the serde
+        // wire into the validator's envelope, schema-validate, then a typed
+        // round-trip. `values_from_wire` is `FieldValues::from_json` for a record
+        // `Properties` and the union wire→`{mode,value}` rewrite for a tagged-union
+        // `Properties` (the schema's `serde_tagging` drives it). The credential
+        // pipeline never resolves expressions, so a `{"$expr": ..}` envelope passes
+        // schema validation but is refused by the typed deserialize below
+        // (credential secrecy defense-in-depth #2).
         let schema = nebula_schema::schema_of::<C::Properties>();
-        let values = FieldValues::from_json(props.clone()).map_err(|e| {
+        let values = schema.values_from_wire(props.clone()).map_err(|e| {
             CredentialServiceError::ValidationFailed {
                 reason: format!("[{}] {}", e.code, e.path),
             }
@@ -603,11 +644,13 @@ where
         // deserialize's key-space: an alias-keyed (or canonical+alias) submission
         // validates under the canonical key, so the typed round-trip must see the
         // same keys, otherwise the two passes could disagree on a field's value.
-        // ($expr envelopes survive canonicalization unchanged, so defense-in-depth
-        // #2 — the typed deserialize refusing an expression-bearing secret — still
-        // holds.)
-        serde_json::from_value::<C::Properties>(valid.raw().to_json()).map_err(|_| {
-            // The serde error text can echo the offending field value
+        // `to_typed` is `from_value(raw().to_json())` for a record and the
+        // envelope→serde-wire rebuild for a union, so the typed round-trip closes
+        // for both schema kinds. ($expr envelopes survive canonicalization
+        // unchanged, so defense-in-depth #2 — the typed deserialize refusing an
+        // expression-bearing secret — still holds.)
+        valid.raw().to_typed::<C::Properties>().map_err(|_| {
+            // The deserialize error text can echo the offending field value
             // (a secret); deliberately omitted — only the policy reason
             // is surfaced.
             CredentialServiceError::ValidationFailed {
@@ -619,10 +662,23 @@ where
         Ok(())
     });
 
+    let ingest: IngestFn = Arc::new(|props: &serde_json::Value| {
+        // Per-type ingress: a record `Properties` folds via `FieldValues::from_json`;
+        // a union `Properties` folds serde's external/adjacent wire into the
+        // `{mode, value}` envelope. The type-erased facade calls this so a union
+        // resolves through the same envelope `validate` / `resolve` consume.
+        nebula_schema::schema_of::<C::Properties>()
+            .values_from_wire(props.clone())
+            .map_err(|e| CredentialServiceError::ValidationFailed {
+                reason: format!("property ingest failed: [{}] {}", e.code, e.path),
+            })
+    });
+
     ops.entries.insert(
         key,
         OpsEntry {
             validate,
+            ingest,
             resolve,
             acquire,
             test_fn: None,

--- a/crates/credential/tests/properties_pipeline.rs
+++ b/crates/credential/tests/properties_pipeline.rs
@@ -20,6 +20,7 @@
 
 use nebula_credential::{Credential, credentials::ApiKeyCredential};
 use nebula_schema::{FieldValue, FieldValues, HasSchema};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 // ── Pipeline happy path on built-in ApiKeyCredential ───────────────────────
@@ -164,5 +165,90 @@ fn expressions_in_optional_property_field_also_fail_serde() {
         result.is_err(),
         "expressions in optional credential properties must also fail serde; \
          got Ok variant (Properties does not impl Debug)",
+    );
+}
+
+// ── Union (enum) credential properties: the value-layer ingress/egress bridge ──
+//
+// A credential whose `Properties` is a `#[derive(Schema)]` enum (a tagged union)
+// flows through the SAME pipeline the per-type ops `validate` closure now runs:
+// `ValidSchema::values_from_wire` (ingress) → `validate` → `FieldValues::to_typed`
+// (egress / the `$expr` refusal point). These tests drive that exact sequence with
+// serde's own output as the oracle, proving a union `Properties` is accepted by the
+// credential pipeline — the gap the value-layer adapter closes.
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, nebula_schema::Schema)]
+struct OAuthProps {
+    client_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, nebula_schema::Schema)]
+enum AuthMethod {
+    OAuth(OAuthProps),
+    ApiKey { token: String },
+    Anonymous,
+}
+
+/// Drive the credential validate pipeline (ingress → validate → typed round-trip)
+/// for a union `Properties` and assert it reconstructs the original value.
+fn assert_union_properties_roundtrip(value: AuthMethod) {
+    let schema = nebula_schema::schema_of::<AuthMethod>();
+    assert_eq!(
+        schema.kind(),
+        nebula_schema::SchemaKind::Union,
+        "fixture must be a union"
+    );
+    let wire = serde_json::to_value(&value).expect("serialize");
+    let values = schema.values_from_wire(wire).expect("union wire ingests");
+    let valid = schema.validate(&values).expect("union validates");
+    let back: AuthMethod = valid.raw().to_typed().expect("union round-trips");
+    assert_eq!(back, value, "credential union pipeline must round-trip");
+}
+
+#[test]
+fn union_properties_pipeline_external_data_variant() {
+    assert_union_properties_roundtrip(AuthMethod::OAuth(OAuthProps {
+        client_id: "id".to_owned(),
+    }));
+}
+
+#[test]
+fn union_properties_pipeline_external_struct_variant() {
+    assert_union_properties_roundtrip(AuthMethod::ApiKey {
+        token: "t".to_owned(),
+    });
+}
+
+#[test]
+fn union_properties_pipeline_unit_variant() {
+    assert_union_properties_roundtrip(AuthMethod::Anonymous);
+}
+
+#[test]
+fn union_properties_pipeline_rejects_unknown_variant() {
+    let schema = nebula_schema::schema_of::<AuthMethod>();
+    let err = schema
+        .values_from_wire(json!({ "Nope": {} }))
+        .expect_err("a non-variant discriminant must be rejected at ingress");
+    assert_eq!(err.code, "union.unknown_variant");
+}
+
+/// Credential secrecy carries to unions: an expression inside a union variant's
+/// payload survives schema validation (`ExpressionMode::Allowed`) but is refused
+/// by the typed round-trip — the same defense-in-depth #2 the record path has,
+/// now closed through `to_typed`.
+#[test]
+fn union_properties_pipeline_refuses_expression_payload() {
+    let schema = nebula_schema::schema_of::<AuthMethod>();
+    let values = schema
+        .values_from_wire(json!({ "ApiKey": { "token": { "$expr": "{{ $secret }}" } } }))
+        .expect("a well-shaped data variant ingests");
+    let valid = schema
+        .validate(&values)
+        .expect("an expression payload survives validation");
+    let result = valid.raw().to_typed::<AuthMethod>();
+    assert!(
+        result.is_err(),
+        "an expression-bearing union payload must be refused by the typed round-trip",
     );
 }

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -300,10 +300,15 @@ impl Manager {
         // structural errors are reported as schema violations rather than
         // confusingly re-routed through serde.
         let schema = <R::Config as nebula_schema::HasSchema>::schema();
-        let field_values =
-            nebula_schema::FieldValues::from_json(config_json.clone()).map_err(|e| {
-                Error::permanent(format!("validate_config_value: invalid field tree: {e}"))
-            })?;
+        // Union-aware ingress: a record `Config` folds via `from_json`; a union
+        // `Config` (a `#[derive(Schema)]` enum) folds serde's external/adjacent wire
+        // into the `{mode, value}` envelope `validate` consumes, so both the schema
+        // pass and the closed-set guard below see the union's declared root key
+        // rather than the raw variant discriminant. The serde wire still
+        // deserializes into `R::Config` directly below (no egress on the read path).
+        let field_values = schema.values_from_wire(config_json.clone()).map_err(|e| {
+            Error::permanent(format!("validate_config_value: invalid field tree: {e}"))
+        })?;
         if let Err(report) = schema.validate(&field_values) {
             return Err(Error::permanent(format!(
                 "validate_config_value: schema validation failed: {report:?}"
@@ -324,6 +329,14 @@ impl Manager {
         // the "schema not yet declared" sentinel (`impl_empty_has_schema!`), and a
         // closed set over zero fields would reject every config — that gate
         // belongs to types that have opted into a real schema.
+        //
+        // Scope: this guard is TOP-LEVEL only — it does not recurse into nested
+        // object fields or, for a union `R::Config`, the active variant payload
+        // (which ingress nests under the union's single declared `_nebula_union`
+        // root, so the top-level key set is just that root). Inlined keys deeper in
+        // the tree are not rejected here; a closed-set sweep over nested/variant
+        // payloads is a broader secret-inlining hardening, not part of the union
+        // value-layer bridge.
         let declared = schema.fields();
         if !declared.is_empty()
             && let Some((unknown, _)) = field_values

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -330,13 +330,12 @@ impl Manager {
         // closed set over zero fields would reject every config — that gate
         // belongs to types that have opted into a real schema.
         //
-        // Scope: this guard is TOP-LEVEL only — it does not recurse into nested
-        // object fields or, for a union `R::Config`, the active variant payload
-        // (which ingress nests under the union's single declared `_nebula_union`
-        // root, so the top-level key set is just that root). Inlined keys deeper in
-        // the tree are not rejected here; a closed-set sweep over nested/variant
-        // payloads is a broader secret-inlining hardening, not part of the union
-        // value-layer bridge.
+        // For a union `R::Config` the operator-facing fields live one level down in
+        // the active variant payload (ingress nests them under the synthetic
+        // `_nebula_union` root, so the top-level key set is just that root). The
+        // union-payload guard below applies the same closed set to that payload —
+        // the union's top-level-equivalent. Arbitrary deeper nesting (a record with
+        // an `Object` field) is still not swept; that remains a broader hardening.
         let declared = schema.fields();
         if !declared.is_empty()
             && let Some((unknown, _)) = field_values
@@ -347,6 +346,33 @@ impl Manager {
                 "validate_config_value: config field `{unknown}` is not declared by \
                  the `{ty}` schema; secrets must not be inlined into ResourceConfig \
                  — bind them through a typed credential slot instead \
+                 (product credential boundary)",
+                unknown = unknown.as_str(),
+                ty = std::any::type_name::<R::Config>(),
+            )));
+        }
+
+        // Union `R::Config`: the operator's fields are the active variant's payload,
+        // nested under `_nebula_union.value`, so the top-level guard above only saw
+        // the synthetic union root. Apply the same closed set to that payload — an
+        // undeclared key (e.g. an inlined secret) is signalled here rather than
+        // silently dropped by serde's default unknown-field handling. A unit variant
+        // carries no payload, so there is nothing to sweep.
+        if let Some(root @ nebula_schema::Field::Mode(mode)) = declared.first()
+            && let Some(nebula_schema::FieldValue::Object(envelope)) = field_values.get(root.key())
+            && let Some(nebula_schema::FieldValue::Literal(serde_json::Value::String(active))) =
+                envelope.get("mode")
+            && let Some(variant) = mode.variants.iter().find(|v| v.key == *active)
+            && let nebula_schema::Field::Object(obj) = variant.field.as_ref()
+            && let Some(nebula_schema::FieldValue::Object(payload)) = envelope.get("value")
+            && let Some((unknown, _)) = payload
+                .iter()
+                .find(|(k, _)| !obj.fields.iter().any(|f| f.key() == *k))
+        {
+            return Err(Error::permanent(format!(
+                "validate_config_value: union config field `{unknown}` is not declared by \
+                 the active `{active}` variant of `{ty}`; secrets must not be inlined into \
+                 ResourceConfig — bind them through a typed credential slot instead \
                  (product credential boundary)",
                 unknown = unknown.as_str(),
                 ty = std::any::type_name::<R::Config>(),

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -286,3 +286,159 @@ async fn register_from_value_passthrough_no_templates() {
 
     assert!(manager.contains(&Postgres::key()));
 }
+
+// ── Union (enum) resource config: serde tagged wire → registration ───────────
+//
+// A `Provider` whose `Config` is a `#[derive(Schema)]` enum has a tagged-union
+// schema. `validate_config_value` ingests the operator's serde external wire
+// (`{"Variant": payload}`) through `values_from_wire`, so the schema pass and the
+// closed-set guard see the union's declared root key, and the same wire still
+// deserializes into the enum directly. This is the resource half of the value-layer
+// union bridge — a real first-party union consumer through real registration.
+
+#[derive(Clone, Debug, PartialEq, Deserialize, nebula_schema::Schema)]
+enum CacheBackendConfig {
+    Memory { capacity: u64 },
+    Redis { url: String },
+}
+
+impl ResourceConfig for CacheBackendConfig {
+    fn validate(&self) -> Result<(), Error> {
+        match self {
+            Self::Memory { capacity } if *capacity == 0 => {
+                Err(Error::permanent("memory capacity must be non-zero"))
+            },
+            Self::Redis { url } if url.is_empty() => {
+                Err(Error::permanent("redis url must not be empty"))
+            },
+            _ => Ok(()),
+        }
+    }
+
+    fn fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        match self {
+            Self::Memory { capacity } => {
+                0u8.hash(&mut h);
+                capacity.hash(&mut h);
+            },
+            Self::Redis { url } => {
+                1u8.hash(&mut h);
+                url.hash(&mut h);
+            },
+        }
+        h.finish()
+    }
+}
+
+#[derive(Clone)]
+struct CacheBackend;
+
+#[async_trait::async_trait]
+impl Provider for CacheBackend {
+    type Config = CacheBackendConfig;
+    type Instance = Arc<()>;
+    type Topology = Resident<Self>;
+
+    fn key() -> ResourceKey {
+        resource_key!("union-cache")
+    }
+
+    async fn create(
+        &self,
+        _config: &CacheBackendConfig,
+        _ctx: &ResourceContext,
+    ) -> Result<Arc<()>, Error> {
+        Ok(Arc::new(()))
+    }
+
+    async fn destroy(
+        &self,
+        _runtime: Arc<()>,
+        _cx: nebula_resource::TeardownCx,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl HasCredentialSlots for CacheBackend {
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+}
+
+#[async_trait::async_trait]
+impl ResidentProvider for CacheBackend {
+    fn is_alive_sync(&self, _runtime: &Arc<()>) -> bool {
+        true
+    }
+}
+
+impl DeclaresDependencies for CacheBackend {
+    fn dependencies() -> Dependencies {
+        Dependencies::new()
+    }
+}
+
+#[tokio::test]
+async fn register_from_value_accepts_union_config_external_wire() {
+    let manager = Manager::new();
+    let engine = ExpressionEngine::new();
+
+    // serde external data-variant wire: `{"Memory": {"capacity": 100}}`. Ingress
+    // folds it into the union envelope, validation passes, and the enum is stored.
+    let config_json = json!({ "Memory": { "capacity": 100 } });
+
+    manager
+        .register_resolved::<CacheBackend>(
+            config_json,
+            &engine,
+            HashMap::new(),
+            CacheBackend,
+            ScopeLevel::Global,
+            Resident::<CacheBackend>::new(ResidentConfig::default()),
+            None,
+        )
+        .await
+        .expect("union config registers via serde external wire");
+
+    let managed = manager
+        .lookup::<CacheBackend>(&ScopeLevel::Global)
+        .expect("registered union-config row must resolve");
+    assert_eq!(
+        *managed.config(),
+        CacheBackendConfig::Memory { capacity: 100 },
+        "the serde external wire must deserialize into the active union variant"
+    );
+}
+
+#[tokio::test]
+async fn register_from_value_rejects_unknown_union_variant() {
+    let manager = Manager::new();
+    let engine = ExpressionEngine::new();
+
+    // `Nope` is not a declared variant — ingress rejects it before validation.
+    let err = manager
+        .register_resolved::<CacheBackend>(
+            json!({ "Nope": {} }),
+            &engine,
+            HashMap::new(),
+            CacheBackend,
+            ScopeLevel::Global,
+            Resident::<CacheBackend>::new(ResidentConfig::default()),
+            None,
+        )
+        .await
+        .expect_err("an unknown union variant must be rejected at registration");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown_variant") || msg.contains("Nope"),
+        "expected an unknown-variant rejection, got: {msg}"
+    );
+}

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -442,3 +442,32 @@ async fn register_from_value_rejects_unknown_union_variant() {
         "expected an unknown-variant rejection, got: {msg}"
     );
 }
+
+#[tokio::test]
+async fn register_from_value_rejects_inlined_field_in_union_variant_payload() {
+    let manager = Manager::new();
+    let engine = ExpressionEngine::new();
+
+    // `capacity` is declared by the `Memory` variant; `secret_token` is not. The
+    // closed-set guard must signal it (serde would otherwise silently drop the
+    // unknown field), so a secret cannot be inlined into a union variant payload —
+    // the union's equivalent of the record top-level closed-set guard.
+    let err = manager
+        .register_resolved::<CacheBackend>(
+            json!({ "Memory": { "capacity": 100, "secret_token": "leak" } }),
+            &engine,
+            HashMap::new(),
+            CacheBackend,
+            ScopeLevel::Global,
+            Resident::<CacheBackend>::new(ResidentConfig::default()),
+            None,
+        )
+        .await
+        .expect_err("an undeclared field in a union variant payload must be rejected");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("secret_token") && msg.contains("not declared by the active"),
+        "expected a union-variant-payload closed-set rejection, got: {msg}"
+    );
+}

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -393,6 +393,251 @@ impl ValidSchema {
             .build_union(tagging)
     }
 
+    /// Ingest an external **serde wire** value into the `{mode, value}` envelope
+    /// that [`validate`](Self::validate) consumes.
+    ///
+    /// For a [`Record`](SchemaKind::Record) or [`Any`](SchemaKind::Any) schema this
+    /// is exactly [`FieldValues::from_json`]: the serde wire already matches the
+    /// validator's key-space. For a [`Union`](SchemaKind::Union) it rewrites serde's
+    /// external/adjacent tagging — `{"Variant": payload}` / the bare string
+    /// `"Variant"` (external) and `{<tag>: "Variant", <content>: payload}` /
+    /// `{<tag>: "Variant"}` (adjacent) — into the internal envelope
+    /// `{<root>: {"mode": "Variant", "value": payload}}` keyed under the union's sole
+    /// root [`Field::Mode`], driven by the stored [`SerdeTagging`]. This closes the
+    /// C1 value-layer gap so a derived union validates the serde wire its
+    /// `#[derive(Serialize)]` actually emits (the inverse direction is
+    /// [`FieldValues::to_typed`]).
+    ///
+    /// Unit variants carry no `value` (they validate against the hidden
+    /// [`ModeField::EMPTY_PLACEHOLDER_KEY`](crate::field::ModeField::EMPTY_PLACEHOLDER_KEY)
+    /// payload); data variants carry their payload under `value`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `union.unknown_variant` when the wire discriminant is not a declared
+    /// variant, `union.malformed_wire` when the wire shape does not match the
+    /// declared tagging (a non-string/non-object external value, an external object
+    /// without exactly one key, an adjacent value missing or mistyping the tag, a
+    /// stray adjacent key, or a data shape for a unit variant and vice-versa), or any
+    /// error [`FieldValues::from_json`] raises on the rewritten value (invalid keys,
+    /// over-deep nesting).
+    #[tracing::instrument(
+        level = "debug",
+        target = "nebula_schema::union_ingress",
+        skip(self, wire),
+        fields(kind = ?self.0.kind)
+    )]
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn values_from_wire(
+        &self,
+        wire: serde_json::Value,
+    ) -> Result<FieldValues, ValidationError> {
+        match self.0.kind {
+            SchemaKind::Record | SchemaKind::Any => FieldValues::from_json(wire),
+            SchemaKind::Union => FieldValues::from_json(self.rewrite_union_wire(wire)?),
+        }
+    }
+
+    /// Rewrite a serde-tagged union wire value into the `{<root>: {mode, value?}}`
+    /// envelope. Driven entirely by the stored [`SerdeTagging`] + the root mode's
+    /// declared variants, so the schema's `serde_tagging` is the single source of
+    /// truth for the wire shape (no per-consumer divergence).
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    fn rewrite_union_wire(
+        &self,
+        wire: serde_json::Value,
+    ) -> Result<serde_json::Value, ValidationError> {
+        use serde_json::Value;
+
+        let malformed = |message: String| {
+            ValidationError::builder("union.malformed_wire")
+                .message(message)
+                .build()
+        };
+
+        let Some(root_field) = self.0.fields.first() else {
+            return Err(malformed(
+                "union schema is missing its root mode field".to_owned(),
+            ));
+        };
+        let Field::Mode(mode) = root_field else {
+            return Err(malformed(
+                "union schema's root field is not a mode field".to_owned(),
+            ));
+        };
+        let Some(tagging) = self.0.serde_tagging.as_ref() else {
+            return Err(malformed(
+                "union schema is missing its serde tagging".to_owned(),
+            ));
+        };
+
+        // Pull the wire discriminant + optional payload out of serde's tagging.
+        let (variant_key, payload): (String, Option<Value>) = match tagging {
+            SerdeTagging::External => match wire {
+                // serde external unit variant: the bare string `"Variant"`.
+                Value::String(variant) => (variant, None),
+                // serde external data variant: `{"Variant": payload}` — exactly one key.
+                Value::Object(map) => {
+                    let mut entries = map.into_iter();
+                    let (Some((key, payload)), None) = (entries.next(), entries.next()) else {
+                        return Err(malformed(
+                            "external union data variant must be a single-key object `{\"Variant\": payload}`"
+                                .to_owned(),
+                        ));
+                    };
+                    (key, Some(payload))
+                },
+                _ => {
+                    return Err(malformed(
+                        "external union wire must be a string (unit variant) or a single-key \
+                         object (data variant)"
+                            .to_owned(),
+                    ));
+                },
+            },
+            SerdeTagging::Adjacent { tag, content } => {
+                let Value::Object(mut map) = wire else {
+                    return Err(malformed(format!(
+                        "adjacent union wire must be an object carrying the tag `{tag}`"
+                    )));
+                };
+                let Some(Value::String(variant)) = map.remove(tag.as_str()) else {
+                    return Err(malformed(format!(
+                        "adjacent union wire must carry a string discriminant under the tag `{tag}`"
+                    )));
+                };
+                let payload = map.remove(content.as_str());
+                if !map.is_empty() {
+                    return Err(malformed(format!(
+                        "adjacent union wire may only carry the tag `{tag}` and content `{content}` keys"
+                    )));
+                }
+                (variant, payload)
+            },
+        };
+
+        // The discriminant must be one of the union's declared variants.
+        let Some(variant) = mode.variants.iter().find(|v| v.key == variant_key) else {
+            return Err(ValidationError::builder("union.unknown_variant")
+                .param("variant", Value::String(variant_key.clone()))
+                .message(format!(
+                    "`{variant_key}` is not a declared variant of this union"
+                ))
+                .build());
+        };
+
+        // A unit variant carries no payload (the hidden EMPTY_PLACEHOLDER_KEY field);
+        // a data variant must. Cross-check the wire shape against the schema so a
+        // mismatch is a precise error rather than a confusing payload type error.
+        let is_unit = variant.field.key().as_str() == ModeField::EMPTY_PLACEHOLDER_KEY;
+        match (is_unit, &payload) {
+            (true, Some(_)) => {
+                return Err(malformed(format!(
+                    "unit variant `{variant_key}` carries no payload"
+                )));
+            },
+            (false, None) => {
+                return Err(malformed(format!(
+                    "data variant `{variant_key}` requires a payload"
+                )));
+            },
+            _ => {},
+        }
+
+        // Build `{<root>: {"mode": "Variant", "value"?: payload}}`.
+        let mut envelope = serde_json::Map::with_capacity(2);
+        envelope.insert(
+            MODE_SELECTOR_KEY.as_str().to_owned(),
+            Value::String(variant_key),
+        );
+        if let Some(payload) = payload {
+            envelope.insert(MODE_PAYLOAD_KEY.as_str().to_owned(), payload);
+        }
+        let mut out = serde_json::Map::with_capacity(1);
+        out.insert(
+            root_field.key().as_str().to_owned(),
+            Value::Object(envelope),
+        );
+        Ok(Value::Object(out))
+    }
+
+    /// Reconstruct the external **serde wire** value from a union's validated /
+    /// canonicalized values — the inverse of [`rewrite_union_wire`](Self::rewrite_union_wire),
+    /// used by [`FieldValues::to_typed`] to close the typed round-trip.
+    ///
+    /// For a non-union schema this is `values.to_json()`. For a union it rewrites the
+    /// internal `{mode, value}` envelope back into serde's external/adjacent tagging
+    /// so the values deserialize into the Rust enum. Total on well-formed (validated)
+    /// values; a malformed envelope falls back to `values.to_json()` rather than
+    /// panicking (no panics in `crates/schema`).
+    pub(crate) fn raw_values_to_wire(&self, values: &FieldValues) -> serde_json::Value {
+        use serde_json::Value;
+
+        if self.0.kind != SchemaKind::Union {
+            return values.to_json();
+        }
+        let (Some(root_field), Some(tagging)) =
+            (self.0.fields.first(), self.0.serde_tagging.as_ref())
+        else {
+            return values.to_json();
+        };
+        let Field::Mode(mode) = root_field else {
+            return values.to_json();
+        };
+        let Some(envelope) = values.get(root_field.key()) else {
+            return values.to_json();
+        };
+
+        // Extract (variant, payload) from either the `{mode,value}` object envelope
+        // (the `from_json` / validate shape) or the programmatic `FieldValue::Mode`.
+        let (variant_key, payload): (&str, Option<Value>) = match envelope {
+            FieldValue::Object(map) => {
+                let Some(FieldValue::Literal(Value::String(key))) = map.get(&*MODE_SELECTOR_KEY)
+                else {
+                    return values.to_json();
+                };
+                (
+                    key.as_str(),
+                    map.get(&*MODE_PAYLOAD_KEY).map(FieldValue::to_json),
+                )
+            },
+            FieldValue::Mode {
+                mode: key,
+                value: payload,
+            } => (key.as_str(), payload.as_deref().map(FieldValue::to_json)),
+            _ => return values.to_json(),
+        };
+
+        let is_unit = mode
+            .variants
+            .iter()
+            .find(|v| v.key == variant_key)
+            .is_some_and(|v| v.field.key().as_str() == ModeField::EMPTY_PLACEHOLDER_KEY);
+
+        match tagging {
+            SerdeTagging::External if is_unit => Value::String(variant_key.to_owned()),
+            SerdeTagging::External => {
+                let mut map = serde_json::Map::with_capacity(1);
+                map.insert(variant_key.to_owned(), payload.unwrap_or(Value::Null));
+                Value::Object(map)
+            },
+            SerdeTagging::Adjacent { tag, content } => {
+                let mut map = serde_json::Map::with_capacity(2);
+                map.insert(tag.clone(), Value::String(variant_key.to_owned()));
+                if !is_unit && let Some(payload) = payload {
+                    map.insert(content.clone(), payload);
+                }
+                Value::Object(map)
+            },
+        }
+    }
+
     /// Whether this schema is a concrete [`Record`](SchemaKind::Record), the
     /// gradual-typing [`Any`](SchemaKind::Any), or a tagged
     /// [`Union`](SchemaKind::Union).

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -890,6 +890,51 @@ impl FieldValues {
         self.0
     }
 
+    /// Deserialize these values into the typed `T`, bridging the union envelope.
+    ///
+    /// The typed counterpart of [`ValidSchema::values_from_wire`](crate::ValidSchema::values_from_wire):
+    /// for a [`Record`](crate::SchemaKind::Record)/[`Any`](crate::SchemaKind::Any)
+    /// `T` this is `serde_json::from_value(self.to_json())`; for a
+    /// [`Union`](crate::SchemaKind::Union) `T` (a `#[derive(Schema)]` enum) it first
+    /// reconstructs serde's external/adjacent wire from the internal `{mode, value}`
+    /// envelope — driven by `T`'s stored `serde_tagging` — so the enum deserializes
+    /// from the tagging its `#[derive(Serialize)]` emits. Read aliases already folded
+    /// onto their canonical keys by `validate` / canonicalization survive into the
+    /// reconstructed wire, so a `validate` → `to_typed` round-trip is key-space
+    /// consistent for both records and unions.
+    ///
+    /// Like the JSON the values were ingested from, the reconstructed value carries
+    /// any cleartext a `Field::Secret` held *before* resolution; deserialize it
+    /// inside a scope that does not let the typed value escape with secrets in the
+    /// clear (the credential properties pipeline does exactly this as its `$expr`
+    /// refusal point). This is the pre-resolution sibling of
+    /// [`ResolvedValues::into_typed`](crate::ResolvedValues::into_typed), which
+    /// operates *after* resolution and instead **refuses** any value still carrying
+    /// a [`SecretLiteral`](FieldValue::SecretLiteral) — reach for that one when the
+    /// values have been resolved and the typed value may outlive the call.
+    ///
+    /// # Errors
+    ///
+    /// Returns `type_mismatch` when `serde_json::from_value::<T>` fails (a shape the
+    /// schema did not constrain, or a `{"$expr": …}` envelope where `T` expects a
+    /// concrete value).
+    #[expect(
+        clippy::result_large_err,
+        reason = "ValidationError is intentionally large; callers are on the validation path"
+    )]
+    pub fn to_typed<T>(&self) -> Result<T, crate::error::ValidationError>
+    where
+        T: crate::has_schema::HasSchema + serde::de::DeserializeOwned,
+    {
+        let schema = crate::has_schema::schema_of::<T>();
+        let wire = schema.raw_values_to_wire(self);
+        serde_json::from_value::<T>(wire).map_err(|e| {
+            crate::error::ValidationError::builder("type_mismatch")
+                .message(format!("typed deserialize failed: {e}"))
+                .build()
+        })
+    }
+
     /// Encode all values to a JSON object.
     #[must_use]
     pub fn to_json(&self) -> Value {

--- a/crates/schema/tests/derive_union.rs
+++ b/crates/schema/tests/derive_union.rs
@@ -5,8 +5,8 @@
 //! key serde actually emits equals the key the schema declares — so a drift
 //! between the derive's variant-key algorithm and serde_derive's fails the test.
 
-use nebula_schema::{HasSchema, Schema, SchemaKind, SerdeTagging, schema_of};
-use serde::Serialize;
+use nebula_schema::{FieldValues, HasSchema, Schema, SchemaKind, SerdeTagging, schema_of};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 // ── helpers (read the union shape off the serialized schema wire) ─────────────
@@ -49,12 +49,12 @@ fn variant_payload_field_keys<T: HasSchema>(variant_key: &str) -> Vec<String> {
 
 // ── External tagging (serde default) ─────────────────────────────────────────
 
-#[derive(Serialize, Schema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Schema)]
 struct OAuthCfg {
     client_id: String,
 }
 
-#[derive(Serialize, Schema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Schema)]
 enum ExternalAuth {
     OAuth(OAuthCfg),
     ApiKey { key: String },
@@ -184,7 +184,7 @@ fn struct_variant_field_keys_follow_variant_rename_all() {
 
 // ── Adjacent tagging records the SerdeTagging ────────────────────────────────
 
-#[derive(Serialize, Schema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Schema)]
 #[serde(tag = "type", content = "data")]
 enum Event {
     Click { x: i64 },
@@ -314,4 +314,155 @@ enum OuterWrapsAny {
 #[should_panic(expected = "not a record")]
 fn newtype_over_any_panics_at_schema_init() {
     let _ = schema_of::<OuterWrapsAny>();
+}
+
+// ── Value-layer ingress/egress: serde wire ⇄ {mode,value} envelope ────────────
+//
+// The C1 value-layer bridge. `serde_json::to_value(value)` is the independent
+// oracle for the wire shape; `ValidSchema::values_from_wire` must accept exactly
+// what `#[derive(Serialize)]` emits, `validate()` must then pass, and
+// `FieldValues::to_typed` must reconstruct the original value — proving the
+// ingress/egress pair is faithful to serde for every variant shape.
+
+/// Full round-trip oracle: value → serde wire → ingress → validate → to_typed.
+fn assert_union_wire_roundtrips<T>(value: T)
+where
+    T: HasSchema + Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug + Clone,
+{
+    let schema = schema_of::<T>();
+    assert_eq!(schema.kind(), SchemaKind::Union, "fixture must be a union");
+
+    let wire = serde_json::to_value(&value).expect("value serializes");
+    let values = schema
+        .values_from_wire(wire)
+        .expect("serde wire ingests into the union envelope");
+    let valid = schema
+        .validate(&values)
+        .expect("ingested union envelope validates");
+    let back: T = valid
+        .raw()
+        .to_typed::<T>()
+        .expect("validated union deserializes back to the enum");
+    assert_eq!(
+        back, value,
+        "wire → ingress → validate → to_typed must round-trip the value"
+    );
+}
+
+#[test]
+fn external_data_variant_roundtrips() {
+    assert_union_wire_roundtrips(ExternalAuth::OAuth(OAuthCfg {
+        client_id: "abc".to_owned(),
+    }));
+}
+
+#[test]
+fn external_struct_variant_roundtrips() {
+    assert_union_wire_roundtrips(ExternalAuth::ApiKey {
+        key: "k".to_owned(),
+    });
+}
+
+#[test]
+fn external_unit_variant_roundtrips() {
+    // serde emits the bare string "None"; ingress must accept it and to_typed
+    // must reconstruct it (not `{"None": {}}`).
+    assert_union_wire_roundtrips(ExternalAuth::None);
+}
+
+#[test]
+fn adjacent_data_variant_roundtrips() {
+    assert_union_wire_roundtrips(Event::Click { x: 7 });
+}
+
+#[test]
+fn adjacent_unit_variant_roundtrips() {
+    // serde adjacent unit omits the content key entirely.
+    assert_union_wire_roundtrips(Event::Noop);
+}
+
+#[test]
+fn unknown_discriminant_is_rejected() {
+    let schema = schema_of::<ExternalAuth>();
+    let err = schema
+        .values_from_wire(json!({ "Nope": { "client_id": "x" } }))
+        .expect_err("a non-variant discriminant must be rejected at ingress");
+    assert_eq!(err.code, "union.unknown_variant");
+}
+
+#[test]
+fn wrong_typed_payload_fails_validation() {
+    // The external shape is well-formed (data variant `OAuth`), so ingress
+    // succeeds; the payload type error (`client_id` is not a string) surfaces in
+    // `validate`, exactly where a normal record's type errors do.
+    let schema = schema_of::<ExternalAuth>();
+    let values = schema
+        .values_from_wire(json!({ "OAuth": { "client_id": 123 } }))
+        .expect("a well-shaped data variant ingests");
+    let report = schema
+        .validate(&values)
+        .expect_err("a wrong-typed payload must fail validation");
+    assert!(
+        report.errors().any(|e| e.code == "type_mismatch"),
+        "expected a type_mismatch, got: {:?}",
+        report.errors().map(|e| e.code.as_ref()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn malformed_external_wire_is_rejected() {
+    // An external union value must be a string (unit) or single-key object (data);
+    // a bare scalar is neither.
+    let schema = schema_of::<ExternalAuth>();
+    let err = schema
+        .values_from_wire(json!(42))
+        .expect_err("a bare scalar is not a valid external union wire");
+    assert_eq!(err.code, "union.malformed_wire");
+}
+
+#[test]
+fn external_unit_variant_with_payload_is_rejected() {
+    // `None` is a unit variant; an object data-shape for it is malformed.
+    let schema = schema_of::<ExternalAuth>();
+    let err = schema
+        .values_from_wire(json!({ "None": {} }))
+        .expect_err("a data shape for a unit variant is malformed");
+    assert_eq!(err.code, "union.malformed_wire");
+}
+
+#[test]
+fn adjacent_wire_missing_tag_is_rejected() {
+    let schema = schema_of::<Event>();
+    let err = schema
+        .values_from_wire(json!({ "data": { "x": 1 } }))
+        .expect_err("adjacent wire without the tag key is malformed");
+    assert_eq!(err.code, "union.malformed_wire");
+}
+
+#[test]
+fn record_ingress_matches_from_json_and_to_typed_round_trips() {
+    // `values_from_wire` is behavior-identical to `FieldValues::from_json` for a
+    // record schema, so a caller can swap one for the other unconditionally; and
+    // `to_typed` round-trips a record too (the egress no-ops to `to_json`).
+    let schema = schema_of::<OAuthCfg>();
+    assert_eq!(schema.kind(), SchemaKind::Record);
+
+    let wire = json!({ "client_id": "abc" });
+    let via_wire = schema
+        .values_from_wire(wire.clone())
+        .expect("record ingests");
+    let via_from_json = FieldValues::from_json(wire).expect("from_json");
+    assert_eq!(
+        via_wire, via_from_json,
+        "record ingress must equal FieldValues::from_json"
+    );
+
+    let valid = schema.validate(&via_wire).expect("record validates");
+    let back: OAuthCfg = valid.raw().to_typed().expect("record round-trips");
+    assert_eq!(
+        back,
+        OAuthCfg {
+            client_id: "abc".to_owned()
+        }
+    );
 }


### PR DESCRIPTION
## Summary

A `SchemaKind::Union` schema validates the internal envelope `{_nebula_union: {mode, value?}}`, but there was no value-layer adapter mapping serde's external/adjacent **wire** form into it — so `ValidSchema::validate()` rejected the very wire a derived union's `#[derive(Serialize)]` emits (the gap documented on `SerdeTagging`). This PR closes it **symmetrically**, keyed on the stored `serde_tagging` as the single source of truth, and wires the bridge into the two real production consumers that validate runtime values against a `ValidSchema`.

## Linked issue

Design record lives in the maintainers' private design vault (`research/2026-06-24-schema-union-keystone-design.md` — the explicit DEFERRED item this delivers). No public issue.

## Type of change

- [x] `feat` — new capability

## Affected crates / areas

- `nebula-schema` (the bridge), `nebula-credential` (consumer wiring), `nebula-resource` (consumer wiring)

## Changes

- `ValidSchema::values_from_wire(Value) -> Result<FieldValues, ValidationError>` — INGRESS. Record/`Any` → `FieldValues::from_json`; Union → rewrite serde external/adjacent wire (`{"V":p}` / bare `"V"` / `{tag,content}` / `{tag}`) into `{_nebula_union: {mode, value?}}` then `from_json`. Unit variants carry no `value`; unknown discriminant → typed `union.unknown_variant`, malformed shape → `union.malformed_wire`. No panics.
- `FieldValues::to_typed::<T: HasSchema + DeserializeOwned>() -> Result<T, ValidationError>` — EGRESS + typed round-trip. Record → `from_value(to_json())`; Union → rebuild serde wire from the envelope (`raw_values_to_wire`) → `from_value`. Byte-identical to the prior path for record/`Any`.
- `nebula-credential`: the per-type `validate` closure ingests via `values_from_wire` and round-trips via `to_typed`; new per-type `IngestFn` + `DispatchOps::ingest`; facade `create`/`update`/`resolve(acquire)` ingest through it.
- `nebula-resource`: `validate_config_value` ingests via `values_from_wire` so a union `R::Config` validates and the closed-set guard sees the declared `_nebula_union` root (serde wire still deserializes into `R::Config` directly — ingress-only on that read path). Documented the guard's top-level-only scope.

## Test plan

- **Serde-output-as-oracle round-trip** (`crates/schema/tests/derive_union.rs`): `to_value(value)` → `values_from_wire` → `validate` → `to_typed` reconstructs the value for every shape (external data/unit, adjacent data/unit) + record parity; Err for unknown discriminant, wrong-typed payload, malformed/missing-tag wire, data-shape-for-unit-variant.
- **Credential pipeline** (`crates/credential/tests/properties_pipeline.rs`): a union `Properties` through `values_from_wire → validate → to_typed`, incl. the `$expr` refusal (defense-in-depth #2) holding for unions.
- **Resource registration** (`crates/resource/tests/register_from_value.rs`): a real union `Config` registered through the production `register_resolved` → `validate_config_value` path; unknown-variant rejected.

### Local verification

- [x] `cargo fmt` — formatted (per-crate; `--all` hits a Windows arg-length limit)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 1427 pass, 0 skipped (pre-push)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (default features, changed crates) — clean
- [x] `cargo deny check` — no `Cargo.toml` change (n/a)

## Breaking changes

None. Additive (two new public methods + a private egress helper + a pub(crate) credential dispatch method). `values_from_wire`/`to_typed` are byte-identical to the replaced `from_json`/`from_value(to_json())` for every shipping `Properties`/`Config` (all records or `SchemaKind::Any`); the union branch is dormant until a union-typed `HasSchema` consumer exists.

## Docs checklist

- [x] Crate `lib.rs //!` / type docs updated where public surface changed (`SerdeTagging` scope note remains accurate; new methods documented with `# Errors`)
- [x] Layer direction preserved (schema is a leaf consumed by credential/resource; no upward deps)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (egress falls back to `to_json()` on a malformed envelope rather than panicking)
- [x] No silent error suppression
- [x] Credentials / secrets stay confined: the union typed round-trip reconstructs cleartext wire only inside the credential `validate` closure (same confinement as the prior `from_value(raw().to_json())`); the `$expr` refusal still rejects expression-bearing union payloads. `to_typed` documents its pre-resolution/cleartext contract vs `ResolvedValues::into_typed` (which refuses post-resolution secrets).

## Notes for reviewers

- The production call sites (live on every credential/resource op) are the real callers; the union branch is exercised end-to-end through real production paths by union fixtures in tests. Registering a brand-new production union **product** credential/resource type (a "which auth scheme / backend?" product decision) is a deliberate out-of-scope follow-up.
- `union.unknown_variant` / `union.malformed_wire` are intentionally left out of `STANDARD_CODES`, matching the existing unregistered `union.default_variant` precedent (the registry test only asserts registered ⊆ emittable, not the reverse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ingesting and validating tagged union-style configuration and credential values in the same shape users send over the wire.
  * Added typed round-tripping from validated values back into strongly typed configs, improving consistency across create, update, resolve, and register flows.

* **Bug Fixes**
  * Improved error reporting for malformed or unknown union variants.
  * Fixed validation so external and adjacent union encodings are handled correctly, including unit variants and payload-bearing variants.
  * Expanded coverage for schema-backed records and unions to catch wire-format edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->