### PR TITLE
docs(schema): SerdeTagging scope reflects the landed value-layer bridge

### DIFF
--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -102,16 +102,18 @@ pub enum SchemaKind {
 /// derive (they cannot satisfy C1: the former inlines the tag into the payload
 /// namespace, the latter has no discriminant key at all).
 ///
-/// # Scope (honest)
+/// # Scope
 ///
-/// Today `serde_tagging` is consumed by the `json_schema` export (feature
-/// `schemars`) and by the assignability lattice. There is **no value-layer
-/// ingress yet** that rewrites serde's external/adjacent wire
-/// (`{"Variant": payload}` / `{tag, content}`) into the internal `{mode, value}`
-/// envelope that [`validate`](ValidSchema::validate) consumes — so a derived union
-/// currently guarantees C1 for *contract export and static type-checking*, not for
-/// runtime value validation of a serialized enum. That ingress adapter lands with
-/// the engine dispatch boundary that needs it.
+/// `serde_tagging` is the single source of truth for a union's wire shape across
+/// all three consumers: the `json_schema` export (feature `schemars`), the
+/// assignability lattice, and the value-layer bridge —
+/// [`ValidSchema::values_from_wire`](ValidSchema::values_from_wire) folds serde's
+/// external/adjacent wire (`{"Variant": payload}` / the bare `"Variant"` /
+/// `{tag, content}`) into the internal `{mode, value}` envelope that
+/// [`validate`](ValidSchema::validate) consumes, and
+/// [`FieldValues::to_typed`](crate::FieldValues::to_typed) reconstructs that wire
+/// for the typed round-trip. So a derived union guarantees C1 for contract export,
+/// static type-checking, *and* runtime value validation of a serialized enum.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]


### PR DESCRIPTION
## Summary

The `SerdeTagging` "Scope (honest)" doc still claimed there was "no value-layer ingress yet" and that the adapter "lands with the engine dispatch boundary" — both false since the bridge landed in #907. Correct the doc: `serde_tagging` is now the single source of truth across the `json_schema` export, the assignability lattice, **and** the value-layer bridge (`ValidSchema::values_from_wire` + `FieldValues::to_typed`), so a derived union guarantees C1 for contract export, static type-checking, and runtime value validation of a serialized enum.

## Type of change

- [x] `docs` — documentation only

## Affected crates / areas

- `nebula-schema` (`SerdeTagging` doc comment)

## Breaking changes

None.

## Local verification

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p nebula-schema` — clean (new intra-doc links resolve)
- [x] `cargo fmt -p nebula-schema --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)