### PR TITLE
feat(workflow): forbid a parameter Reference without a coincident connection

### DIFF
--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -52,6 +52,28 @@ pub enum WorkflowError {
         source_node_key: NodeKey,
     },
 
+    /// A parameter `Reference` pulls a value from a node it has no connection
+    /// edge from. The dependency graph is built from connections only (it never
+    /// reads `parameters`), so a reference with no coincident connection leaves
+    /// the true data dependency invisible to the scheduler — the consumer can be
+    /// ordered before the producer and read stale or absent output. Adding the
+    /// connection makes the dependency visible (and type-checkable).
+    #[classify(
+        category = "validation",
+        code = "WORKFLOW:REFERENCE_WITHOUT_CONNECTION"
+    )]
+    #[error(
+        "node {node_key} references output of {source_node_key} via a parameter but has no \
+         connection edge from it — add a connection from {source_node_key} so the dependency is \
+         visible to the scheduler"
+    )]
+    ReferenceWithoutConnection {
+        /// The node containing the reference.
+        node_key: NodeKey,
+        /// The referenced producer node that is not connected.
+        source_node_key: NodeKey,
+    },
+
     /// Invalid action key format.
     #[classify(category = "validation", code = "WORKFLOW:INVALID_ACTION_KEY")]
     #[error("invalid action key `{key}`: {reason}")]

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -115,13 +115,33 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
         }
     }
 
-    // 5. Check parameter references
+    // 5. Check parameter references.
+    //
+    // A `Reference` must (a) point at a node that exists and (b) have a coincident
+    // connection edge from that node to the consumer. The dependency graph is built
+    // from connections only (`graph.rs` never reads `parameters`), so a reference
+    // with no connection leaves the data dependency invisible to the scheduler — the
+    // producer may be ordered after the consumer, which then reads stale or absent
+    // output. Making the connection mandatory keeps every data dependency visible on
+    // the graph (and type-checkable). Build the (from, to) endpoint set once for O(1)
+    // coincidence checks (O(E) build, O(params) loop — not O(params·E)).
+    let connected_pairs: HashSet<_> = definition
+        .connections
+        .iter()
+        .map(|conn| (&conn.from_node, &conn.to_node))
+        .collect();
     for node in &definition.nodes {
         for param in node.parameters.values() {
-            if let ParamValue::Reference { node_key, .. } = param
-                && !seen_ids.contains(node_key)
-            {
+            let ParamValue::Reference { node_key, .. } = param else {
+                continue;
+            };
+            if !seen_ids.contains(node_key) {
                 errors.push(WorkflowError::InvalidParameterReference {
+                    node_key: node.id.clone(),
+                    source_node_key: node_key.clone(),
+                });
+            } else if !connected_pairs.contains(&(node_key, &node.id)) {
+                errors.push(WorkflowError::ReferenceWithoutConnection {
                     node_key: node.id.clone(),
                     source_node_key: node_key.clone(),
                 });
@@ -575,6 +595,51 @@ mod tests {
             errors
                 .iter()
                 .any(|e| matches!(e, WorkflowError::InvalidParameterReference { .. }))
+        );
+    }
+
+    #[test]
+    fn reference_without_connection_is_rejected() {
+        // `a` pulls `b`'s output via a parameter Reference, but there is no
+        // connection edge b -> a, so the data dependency is invisible to the
+        // scheduler (graph.rs builds edges from connections only).
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let mut consumer = node(a);
+        consumer
+            .parameters
+            .insert("input".into(), ParamValue::reference(b.clone(), "$.data"));
+        let def = make_definition("ref-no-conn", vec![consumer, node(b)], vec![]);
+        let errors = validate_workflow(&def);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::ReferenceWithoutConnection { .. })),
+            "a Reference with no coincident connection must be rejected; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn reference_with_coincident_connection_passes() {
+        // Same Reference, now backed by a real b -> a connection edge: the
+        // dependency is visible to the scheduler, so it must not be flagged.
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let mut consumer = node(a.clone());
+        consumer
+            .parameters
+            .insert("input".into(), ParamValue::reference(b.clone(), "$.data"));
+        let def = make_definition(
+            "ref-with-conn",
+            vec![consumer, node(b.clone())],
+            vec![Connection::new(b, a)],
+        );
+        let errors = validate_workflow(&def);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::ReferenceWithoutConnection { .. })),
+            "a Reference WITH a coincident connection must not be flagged; got: {errors:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

First W0 on-ramp unit (ADR-0110-P0, part a) on the path to per-port edge typing. The dependency graph is built from connections only — `graph.rs` never reads node `parameters` — but a parameter can be a `ParamValue::Reference { node_key, .. }` pulling another node's output. Validation previously only checked that the referenced node *exists*, not that a connection edge from it exists. A `Reference` with no coincident connection left the true data dependency invisible to the scheduler: the consumer could be ordered before the producer and read stale/absent output (a latent ordering / data-integrity bug, and the prerequisite for typing per-field `Reference` edges in a later unit).

## Type of change

- [x] `feat` — new validation rule + error variant (closes a latent correctness gap)

## Affected crates / areas

- `nebula-workflow` (`validate.rs` step 5 + `WorkflowError`)

## Changes

- `validate_workflow` step 5: after the existing referenced-node-exists check, require a connection from the referenced producer to the consuming node, else `WorkflowError::ReferenceWithoutConnection`. The `(from, to)` endpoint set is built once (O(E)) so the parameter sweep stays O(params), not O(params·E).
- New typed `WorkflowError::ReferenceWithoutConnection { node_key, source_node_key }` (`#[classify]` + thiserror).

## Test plan

- `validate.rs` unit tests: a `Reference` with no connection is rejected; the same `Reference` backed by a coincident connection passes; a `Reference` to a non-existent node still surfaces `InvalidParameterReference` (unchanged path).
- Regression: `nebula-workflow` 128/128, `nebula-engine` 433/433 (the stricter rule breaks no existing fixture; api/server carry no `Reference` fixtures).

### Local verification

- [x] `cargo clippy -p nebula-workflow --all-features --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p nebula-workflow` (128) + `-p nebula-engine` (433) — pass
- [x] pre-push CI mirror (clippy-full + crate-diff rustdoc + workspace nextest) — green

## Breaking changes

None to the public API (additive `#[non_exhaustive]` error variant). Behavioral: a workflow whose parameter `Reference` lacks a coincident connection is now rejected at `/validate` — the intended illegal-by-construction tightening; no existing fixture relied on the permissive behavior.

## Safety / security impact

- [x] Closes the latent ordering / data-integrity gap (Reference-only dependency invisible to the scheduler)
- [x] Typed error variant; no secret/value leak in the message (names node keys only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow validation now catches parameter references that point to a node without a matching connection.
  * Error messages now clearly indicate when a missing connection needs to be added so the workflow can be scheduled correctly.
  * Validation continues to accept valid references when the proper connection is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->