### PR TITLE
fix(core): land nebula-core 10-model audit — full non-ADR fix set

### DIFF
--- a/crates/action/src/testing.rs
+++ b/crates/action/src/testing.rs
@@ -14,6 +14,7 @@ use nebula_core::{
     CoreError, CredentialKey, ResourceKey,
     accessor::{CredentialAccessor, Logger, ResourceAccessor},
     node_key,
+    scope::{Principal, Scope},
 };
 use nebula_credential::CredentialSnapshot;
 use tokio_util::sync::CancellationToken;
@@ -118,9 +119,11 @@ impl TestContextBuilder {
     pub fn build(self) -> crate::context::ActionRuntimeContext {
         use nebula_core::id::{ExecutionId, WorkflowId};
         let base = Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(Scope::default())
+                .principal(Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         );
         crate::context::ActionRuntimeContext::new(
             base,
@@ -150,9 +153,11 @@ impl TestContextBuilder {
         let emitter = Arc::new(SpyEmitter::new());
         let scheduler = Arc::new(SpyScheduler::new());
         let base = Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(Scope::default())
+                .principal(Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         );
         let ctx =
             crate::context::TriggerRuntimeContext::new(base, WorkflowId::new(), node_key!("test"))
@@ -286,8 +291,8 @@ impl CredentialAccessor for TestCredentialAccessor {
                 );
             }
         }
-        let key_owned = key_str.to_owned();
-        Box::pin(async move { Err(CoreError::CredentialNotFound { key: key_owned }) })
+        let missing_key = key.clone();
+        Box::pin(async move { Err(CoreError::credential_not_found(missing_key)) })
     }
 
     fn try_resolve_any(

--- a/crates/api/src/domain/org/membership.rs
+++ b/crates/api/src/domain/org/membership.rs
@@ -110,6 +110,8 @@ fn principal_key(p: &Principal) -> String {
             None => format!("wf:{workflow_id}"),
         },
         Principal::System => "system".to_owned(),
+        // Non-exhaustive: future principal kinds must be assigned a unique key prefix.
+        _ => "unknown".to_owned(),
     }
 }
 

--- a/crates/api/src/domain/resource/handler.rs
+++ b/crates/api/src/domain/resource/handler.rs
@@ -438,6 +438,8 @@ fn created_by_bytes(principal: &Principal) -> Vec<u8> {
         Principal::ServiceAccount(sid) => sid.as_bytes().to_vec(),
         Principal::Workflow { .. } => sentinel(CREATED_BY_CLASS_WORKFLOW),
         Principal::System => sentinel(CREATED_BY_CLASS_SYSTEM),
+        // Non-exhaustive: future principal kinds default to the system sentinel.
+        _ => sentinel(CREATED_BY_CLASS_SYSTEM),
     }
 }
 

--- a/crates/api/src/error/classify.rs
+++ b/crates/api/src/error/classify.rs
@@ -152,9 +152,26 @@ impl From<ValidationErrors> for ApiError {
 
 impl From<nebula_core::PermissionDenied> for ApiError {
     fn from(pd: nebula_core::PermissionDenied) -> Self {
+        let (required_role, current_role) = match &pd.denial {
+            nebula_core::PermissionDenial::Workspace { required, current } => (
+                required.to_string(),
+                current
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "none".to_owned()),
+            ),
+            nebula_core::PermissionDenial::Org { required, current } => (
+                required.to_string(),
+                current
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "none".to_owned()),
+            ),
+            // `PermissionDenial` is `#[non_exhaustive]`; future variants forward their
+            // human-readable Display output rather than hard-coding field access.
+            _ => (pd.denial.to_string(), String::new()),
+        };
         Self::InsufficientRole {
-            required_role: pd.required_role,
-            current_role: pd.current_role,
+            required_role,
+            current_role,
         }
     }
 }

--- a/crates/api/src/error/classify.rs
+++ b/crates/api/src/error/classify.rs
@@ -166,8 +166,12 @@ impl From<nebula_core::PermissionDenied> for ApiError {
                     .unwrap_or_else(|| "none".to_owned()),
             ),
             // `PermissionDenial` is `#[non_exhaustive]`; future variants forward their
-            // human-readable Display output rather than hard-coding field access.
-            _ => (pd.denial.to_string(), String::new()),
+            // human-readable Display output as `required_role`. `current_role` uses
+            // the same string so neither field is silently left blank/half-populated.
+            _ => {
+                let display = pd.denial.to_string();
+                (display.clone(), display)
+            },
         };
         Self::InsufficientRole {
             required_role,

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -261,6 +261,8 @@ fn principal_user_id(principal: &nebula_core::Principal) -> String {
         nebula_core::Principal::ServiceAccount(sid) => sid.to_string(),
         nebula_core::Principal::Workflow { workflow_id, .. } => workflow_id.to_string(),
         nebula_core::Principal::System => "system".to_string(),
+        // Non-exhaustive: future principal kinds fall back to a "system" sentinel.
+        _ => "system".to_string(),
     }
 }
 

--- a/crates/api/src/middleware/tenancy.rs
+++ b/crates/api/src/middleware/tenancy.rs
@@ -142,10 +142,8 @@ async fn resolve_webhook_path(
         return Ok(None);
     }
 
-    let mut ids = ResolvedIds {
-        org_id: Some(resolve_org(state, segments[3]).await?),
-        ..Default::default()
-    };
+    let mut ids = ResolvedIds::default();
+    ids.org_id = Some(resolve_org(state, segments[3]).await?);
 
     if segments.len() >= 6 {
         let org_id = ids.org_id.expect("org_id just resolved");

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -848,7 +848,9 @@ mod tests {
         TriggerEventOutcome, TriggerHandler, WebhookAction, WebhookConfig, WebhookRequest,
         WebhookResponse, WebhookTriggerAdapter, hmac_sha256_compute,
     };
-    use nebula_core::{BaseContext, Dependencies, NodeKey, WorkflowId, action_key, node_key};
+    use nebula_core::{
+        BaseContext, Dependencies, NodeKey, WorkflowId, action_key, node_key, scope::Principal,
+    };
     use nebula_storage::inmem::{
         InMemoryExecutionStore, InMemoryTriggerDedupInbox, InMemoryWebhookActivationStore,
         InMemoryWorkflowVersionStore,
@@ -1241,9 +1243,11 @@ mod tests {
     ) -> nebula_action::TriggerRuntimeContext {
         nebula_action::TriggerRuntimeContext::new(
             Arc::new(
-                BaseContext::builder()
+                BaseContext::builder(nebula_core::scope::Scope::default())
+                    .principal(Principal::System)
                     .cancellation(CancellationToken::new())
-                    .build(),
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
             ),
             workflow_id,
             node_key,

--- a/crates/api/src/transport/webhook/routing.rs
+++ b/crates/api/src/transport/webhook/routing.rs
@@ -131,9 +131,11 @@ mod tests {
         });
         let ctx = TriggerRuntimeContext::new(
             Arc::new(
-                nebula_core::BaseContext::builder()
+                nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                    .principal(nebula_core::scope::Principal::System)
                     .cancellation(CancellationToken::new())
-                    .build(),
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
             ),
             nebula_core::WorkflowId::new(),
             nebula_core::node_key!("test"),

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -717,7 +717,7 @@ mod tests {
     use std::sync::Arc;
 
     use nebula_action::{TriggerContext, TriggerHandler, WebhookConfig};
-    use nebula_core::BaseContext;
+    use nebula_core::{BaseContext, scope::Principal};
     use nebula_storage::inmem::InMemoryWebhookActivationStore;
     use nebula_storage_port::Scope;
     use nebula_storage_port::dto::WebhookMode;
@@ -759,9 +759,11 @@ mod tests {
     fn ctx_template() -> TriggerRuntimeContext {
         TriggerRuntimeContext::new(
             Arc::new(
-                BaseContext::builder()
+                BaseContext::builder(nebula_core::scope::Scope::default())
+                    .principal(Principal::System)
                     .cancellation(CancellationToken::new())
-                    .build(),
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
             ),
             nebula_core::WorkflowId::new(),
             nebula_core::node_key!("test"),

--- a/crates/api/tests/trace_w3c_smoke.rs
+++ b/crates/api/tests/trace_w3c_smoke.rs
@@ -61,8 +61,12 @@ async fn init_api_telemetry_emits_traceparent_on_response() {
 
     let parsed =
         parse_traceparent(traceparent).expect("response traceparent must be structurally valid");
-    assert_ne!(parsed.trace_id.0, 0, "trace_id must not be all-zero");
-    assert_ne!(parsed.parent_span_id.0, 0, "parent_id must not be all-zero");
+    assert_ne!(parsed.trace_id.get(), 0, "trace_id must not be all-zero");
+    assert_ne!(
+        parsed.parent_span_id.get(),
+        0,
+        "parent_id must not be all-zero"
+    );
 }
 
 /// End-to-end: an inbound `traceparent` is extracted, attached as parent of the per-request
@@ -149,7 +153,7 @@ async fn inbound_traceparent_round_trips_with_same_trace_id() {
         .expect("ASCII");
 
     let parsed = parse_traceparent(returned).expect("structurally valid");
-    let returned_trace_id_hex = format!("{:032x}", parsed.trace_id.0);
+    let returned_trace_id_hex = format!("{:032x}", parsed.trace_id.get());
     assert_eq!(
         returned_trace_id_hex, INBOUND_TRACE_ID,
         "response traceparent must carry the inbound trace id — propagation broken (W3C trace propagation)"

--- a/crates/api/tests/webhook_bootstrap_restart_durability.rs
+++ b/crates/api/tests/webhook_bootstrap_restart_durability.rs
@@ -110,9 +110,11 @@ impl WebhookActivationContextFactory for NoopCtxFactory {
     fn build(&self, _record: &WebhookActivationRecord) -> TriggerRuntimeContext {
         TriggerRuntimeContext::new(
             Arc::new(
-                nebula_core::BaseContext::builder()
+                nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                    .principal(nebula_core::scope::Principal::System)
                     .cancellation(CancellationToken::new())
-                    .build(),
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
             ),
             nebula_core::WorkflowId::new(),
             nebula_core::node_key!("bootstrap-restart-test"),

--- a/crates/api/tests/webhook_register_e2e.rs
+++ b/crates/api/tests/webhook_register_e2e.rs
@@ -158,9 +158,11 @@ impl WebhookActivationContextFactory for NoopCtxFactory {
     fn build(&self, _record: &WebhookActivationRecord) -> TriggerRuntimeContext {
         TriggerRuntimeContext::new(
             Arc::new(
-                nebula_core::BaseContext::builder()
+                nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                    .principal(Principal::System)
                     .cancellation(CancellationToken::new())
-                    .build(),
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
             ),
             WorkflowId::new(),
             node_key!("webhook-register-e2e"),

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -197,9 +197,11 @@ async fn register_webhook(
 
     let ctx_template = TriggerRuntimeContext::new(
         Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                .principal(nebula_core::scope::Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         ),
         nebula_core::WorkflowId::new(),
         nebula_core::node_key!("test"),
@@ -472,9 +474,11 @@ async fn handler_timeout_returns_504() {
     let adapter: Arc<dyn TriggerHandler> = Arc::new(hanging_adapter);
     let ctx_template = TriggerRuntimeContext::new(
         Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                .principal(nebula_core::scope::Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         ),
         nebula_core::WorkflowId::new(),
         nebula_core::node_key!("test"),
@@ -717,9 +721,11 @@ async fn register_typed<A: WebhookAction>(
     let adapter: Arc<dyn TriggerHandler> = Arc::new(adapter);
     let ctx_template = TriggerRuntimeContext::new(
         Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                .principal(nebula_core::scope::Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         ),
         nebula_core::WorkflowId::new(),
         nebula_core::node_key!("test"),
@@ -990,9 +996,11 @@ fn test_scope() -> Scope {
 fn noop_ctx_template() -> TriggerRuntimeContext {
     TriggerRuntimeContext::new(
         Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                .principal(nebula_core::scope::Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         ),
         nebula_core::WorkflowId::new(),
         nebula_core::node_key!("test"),

--- a/crates/core/AGENTS.md
+++ b/crates/core/AGENTS.md
@@ -12,7 +12,7 @@
 ## Key files
 - `src/lib.rs` — module wiring, re-exports, `prelude`, compile-time key macros (`plugin_key!` etc.)
 - `src/id/` — prefixed-ULID identifiers (`ExecutionId` `exe_…`, `WorkflowId` `wf_…`, …) via `domain-key`; all `Copy`, `new/nil/parse`, serde
-- `src/keys.rs` — normalized validated string keys; `SecretString` credential wrapper lives here (Debug MUST stay redacted)
+- `src/keys.rs` — normalized validated string keys (no secret material here — credential wrappers live in `nebula-credential`)
 - `src/scope.rs` — `ScopeLevel`/`Scope`/`Principal`/`ScopeResolver` (Global → … → Action)
 - `src/context/` — `Context` trait, `BaseContext(Builder)`, capability traits (`HasCredentials`, `HasResources`, …)
 - `src/auth.rs` — canonical `AuthScheme` trait + `AuthPattern` enum (re-exported by `nebula-credential`)
@@ -23,7 +23,7 @@
 - Identifiers/keys are stable opaque handles ([L1-§3.10]); changing their representation cascades — extend deliberately, never casually rename or re-encode.
 - `SecretString` and credential-related key types must keep `Debug` redacted ([L2-§12.5]) — no secret material in logs or error strings. Use `debug_redacted`/`debug_typed` from `guard`.
 - ID types use `domain-key` (prefixed ULIDs) — never add a direct `uuid` dependency or invent a per-type newtype.
-- `CredentialId`/`CredentialEvent` vocabulary lives in `nebula-credential`; `AuthScheme`/`AuthPattern` are canonical *here* and re-exported there.
+- `CredentialId` is defined in this crate (`src/id/types.rs`); `CredentialEvent` vocabulary lives in `nebula-credential`. `AuthScheme`/`AuthPattern` are canonical *here* and re-exported there.
 - Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
 - Library code uses typed `thiserror`/`CoreError`; no panicking unwrap/expect/panic in lib code.
 

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -27,9 +27,9 @@ workspace — extend `nebula-core` deliberately (canon §3.10).
 
 ## Public API
 
-- `ExecutionId`, `WorkflowId`, `NodeId`, `UserId`, `TenantId`, `ProjectId`, `OrganizationId`, `ResourceId`, `RoleId` — prefixed ULID typed identifiers. (`CredentialId` lives in `nebula-credential`.)
+- `ExecutionId`, `WorkflowId`, `WorkflowVersionId`, `OrgId`, `WorkspaceId`, `UserId`, `ServiceAccountId`, `ResourceId`, `CredentialId`, `TriggerId`, `TriggerEventId`, `AttemptId`, `InstanceId`, `SessionId` — prefixed ULID typed identifiers, all defined in this crate.
 - `PluginKey`, `ActionKey`, `CredentialKey`, `ParameterKey`, `ResourceKey`, `NodeKey` — normalized string keys with validation.
-- `ScopeLevel`, `Scope`, `Principal`, `ScopeResolver` — hierarchical scope system (Global → Organization → Project → Workflow → Execution → Action).
+- `ScopeLevel`, `Scope`, `Principal`, `ScopeResolver` — hierarchical scope system (Global → Organization → Workspace → Workflow → Execution).
 - `Context` trait, `BaseContext`, `BaseContextBuilder` — base context with capability traits (`HasCredentials`, `HasResources`, `HasMetrics`, `HasEventBus`, `HasLogger`).
 - `ResourceAccessor`, `CredentialAccessor`, `Logger`, `MetricsEmitter`, `EventEmitter`, `Clock` — capability accessor traits injected through context.
 - `Guard`, `TypedGuard` — RAII guard traits for scoped resource/credential wrappers (module `guard`). Debug helpers: `debug_redacted`, `debug_typed`.
@@ -38,16 +38,16 @@ workspace — extend `nebula-core` deliberately (canon §3.10).
 - `TraceId`, `SpanId` — observability identity types.
 - `CoreError` — typed error for this crate (thiserror, no anyhow).
 - `OrgRole`, `WorkspaceRole`, `effective_workspace_role` — organization and workspace role enums for RBAC (module `role`).
-- `Permission`, `PermissionDenied` — granular permission definitions (module `permission`).
+- `Permission` — granular permission definitions (module `permission`). `PermissionDenied` — access-control error type (module `tenancy`).
 - `TenantContext`, `ResolvedIds` — multi-tenant context and resolved organization/workspace IDs (module `tenancy`).
 - `Slug`, `SlugKind`, `SlugError`, `is_prefixed_ulid()` — validated slug strings for human-readable identifiers (module `slug`).
 
-Credential-specific vocabulary (`CredentialEvent`, `CredentialId`) lives in `nebula-credential`. The `AuthScheme` trait and `AuthPattern` enum are canonical in this crate (module `auth`); `nebula-credential` re-exports them for discoverability.
+Credential-specific vocabulary (`CredentialEvent`) lives in `nebula-credential`. `CredentialId` is defined in this crate (module `id`). The `AuthScheme` trait and `AuthPattern` enum are canonical in this crate (module `auth`); `nebula-credential` re-exports them for discoverability.
 
 ## Contract
 
 - **[L1-§3.10]** Identifiers and keys in this crate are the stable, opaque handles shared by every other crate. Changing their representation cascades across the workspace.
-- **[L2-§12.5]** `SecretString` (credential material wrapper) must keep its `Debug` implementation redacted. No secret material may appear in log output or error strings. Seam: credential-related key types in `crates/core/src/keys.rs`. Test coverage: see `docs/MATURITY.md`.
+- **[L2-§12.5]** No secret material may appear in log output or error strings. Credential material (`SecretString` and related wrappers) lives in `nebula-credential`, not here. Test coverage: see `docs/MATURITY.md`.
 
 ## Non-goals
 
@@ -74,7 +74,7 @@ See `docs/MATURITY.md` row for `nebula-core`.
 
 All ID types use prefixed ULIDs via the `domain-key` crate (no direct `uuid` dependency).
 All ID types are `Copy`, support `new()`, `nil()`, `parse(&str)`, serde, and re-export
-`UuidParseError` for parse error handling.
+`UlidParseError` for parse error handling.
 
 Prefix examples: `ExecutionId` → `exe_01J9…`, `WorkflowId` → `wf_01J9…`.
 

--- a/crates/core/src/accessor.rs
+++ b/crates/core/src/accessor.rs
@@ -112,8 +112,35 @@ pub trait RefreshCoordinator: Send + Sync {
 
 /// Token returned by [`RefreshCoordinator`].
 ///
-/// The token is an opaque handle. TTL / timeout semantics (e.g., how long
-/// a refresh lock is held before auto-release) are deferred to the concrete
-/// `RefreshCoordinator` implementation.
+/// The token is an opaque handle minted exclusively by a [`RefreshCoordinator`]
+/// implementation.  Callers must pass it back to [`RefreshCoordinator::release_refresh`]
+/// to release the lock.  TTL / timeout semantics are delegated to the concrete
+/// implementation.
 #[derive(Debug)]
-pub struct RefreshToken(pub u64);
+pub struct RefreshToken(u64);
+
+impl RefreshToken {
+    /// Mint a new token from a coordinator-assigned value.
+    #[must_use = "dropping a RefreshToken without calling release_refresh leaks the refresh lock"]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the raw coordinator-assigned value.
+    #[must_use]
+    pub const fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RefreshToken;
+
+    #[test]
+    fn refresh_token_round_trips() {
+        assert_eq!(RefreshToken::new(42).get(), 42);
+        assert_eq!(RefreshToken::new(99).get(), 99);
+        assert_ne!(RefreshToken::new(1).get(), RefreshToken::new(2).get());
+    }
+}

--- a/crates/core/src/accessor.rs
+++ b/crates/core/src/accessor.rs
@@ -101,10 +101,14 @@ impl Clock for SystemClock {
 
 /// Single-flight refresh coordination (spec 22).
 pub trait RefreshCoordinator: Send + Sync {
-    /// Acquire a refresh lock.
+    /// Acquire a refresh lock for the given credential.
+    ///
+    /// Takes a typed [`crate::id::CredentialId`] rather than a raw `&str` so the
+    /// compiler enforces that callers pass an actual credential identifier — not an
+    /// arbitrary string — at every call site.
     fn acquire_refresh(
         &self,
-        credential_id: &str,
+        credential_id: &crate::id::CredentialId,
     ) -> BoxFuture<'_, Result<RefreshToken, crate::CoreError>>;
     /// Release a refresh lock.
     fn release_refresh(&self, token: RefreshToken) -> BoxFuture<'_, Result<(), crate::CoreError>>;

--- a/crates/core/src/auth.rs
+++ b/crates/core/src/auth.rs
@@ -37,8 +37,10 @@ use zeroize::ZeroizeOnDrop;
 
 /// Classification of authentication patterns.
 ///
-/// 10 built-in patterns cover common integration auth mechanisms.
-/// `Custom` handles everything else.
+/// 11 variants: `NoAuth`, 9 named auth-mechanism patterns
+/// (secret-token, password, OAuth2, key-pair, certificate, request-signing,
+/// connection-URI, instance-identity, shared-secret), and `Custom` for
+/// plugin-defined patterns not covered by the named set.
 ///
 /// **Pruned 2026-04-24** (zero consumers, Plane-A territory):
 /// `FederatedIdentity` (SAML/JWT → `nebula-auth`, not integration credentials),

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -46,9 +46,26 @@ pub struct BaseContext {
 }
 
 impl BaseContext {
-    /// Create a builder for BaseContext.
-    pub fn builder() -> BaseContextBuilder {
-        BaseContextBuilder::default()
+    /// Create a builder for `BaseContext`.
+    ///
+    /// `scope` is required at construction time — every context must declare
+    /// the tenancy scope it operates within. Background tasks and system
+    /// operations should pass `Scope::default()` explicitly.
+    ///
+    /// # Required fields
+    ///
+    /// - `scope` — provided here.
+    /// - `principal` — set via [`.principal()`](BaseContextBuilder::principal) before calling
+    ///   [`.build()`](BaseContextBuilder::build). Use [`Principal::System`] for background tasks.
+    pub fn builder(scope: Scope) -> BaseContextBuilder {
+        BaseContextBuilder {
+            scope,
+            principal: None,
+            cancellation: None,
+            clock: None,
+            trace_id: None,
+            span_id: None,
+        }
     }
 }
 
@@ -73,10 +90,14 @@ impl Context for BaseContext {
     }
 }
 
-/// Builder for BaseContext.
-#[derive(Default)]
+/// Builder for [`BaseContext`].
+///
+/// Constructed via [`BaseContext::builder(scope)`](BaseContext::builder).
+/// `scope` is fixed at construction; `principal` must be set before calling
+/// [`build`](Self::build). All other fields are optional with sensible defaults.
+#[must_use = "call .build() to construct the BaseContext"]
 pub struct BaseContextBuilder {
-    scope: Option<Scope>,
+    scope: Scope,
     principal: Option<Principal>,
     cancellation: Option<CancellationToken>,
     clock: Option<Box<dyn Clock>>,
@@ -85,48 +106,100 @@ pub struct BaseContextBuilder {
 }
 
 impl BaseContextBuilder {
-    /// Set the scope.
-    pub fn scope(mut self, scope: Scope) -> Self {
-        self.scope = Some(scope);
-        self
-    }
-    /// Set the principal.
+    /// Set the principal (who is acting).
+    ///
+    /// Required. Use [`Principal::System`] for background / daemon contexts.
     pub fn principal(mut self, p: Principal) -> Self {
         self.principal = Some(p);
         self
     }
+
     /// Set the cancellation token.
+    ///
+    /// Defaults to a fresh [`CancellationToken`] if not provided.
     pub fn cancellation(mut self, t: CancellationToken) -> Self {
         self.cancellation = Some(t);
         self
     }
-    /// Set the clock.
+
+    /// Set the clock implementation.
+    ///
+    /// Defaults to [`SystemClock`](crate::accessor::SystemClock) if not provided.
     pub fn clock(mut self, c: impl Clock + 'static) -> Self {
         self.clock = Some(Box::new(c));
         self
     }
-    /// Set the trace ID.
+
+    /// Set the trace ID for distributed tracing correlation.
     pub fn trace_id(mut self, t: TraceId) -> Self {
         self.trace_id = Some(t);
         self
     }
-    /// Set the span ID.
+
+    /// Set the span ID for distributed tracing correlation.
     pub fn span_id(mut self, s: SpanId) -> Self {
         self.span_id = Some(s);
         self
     }
 
-    /// Build the BaseContext.
-    pub fn build(self) -> BaseContext {
-        BaseContext {
-            scope: self.scope.unwrap_or_default(),
-            principal: self.principal.unwrap_or(Principal::System),
+    /// Build the [`BaseContext`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::CoreError::RegistryInvariant`] if `principal` was not set.
+    /// Pass [`Principal::System`] explicitly for background tasks.
+    pub fn build(self) -> Result<BaseContext, crate::error::CoreError> {
+        let principal = self
+            .principal
+            .ok_or(crate::error::CoreError::RegistryInvariant(
+                "BaseContext requires a principal; use Principal::System for background tasks",
+            ))?;
+        Ok(BaseContext {
+            scope: self.scope,
+            principal,
             cancellation: self.cancellation.unwrap_or_default(),
             clock: self
                 .clock
                 .unwrap_or_else(|| Box::new(crate::accessor::SystemClock)),
             trace_id: self.trace_id,
             span_id: self.span_id,
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{error::CoreError, scope::Principal};
+
+    #[test]
+    fn build_without_principal_returns_registry_invariant_error() {
+        let result = BaseContext::builder(Scope::default()).build();
+        assert!(
+            matches!(result, Err(CoreError::RegistryInvariant(_))),
+            "missing principal must yield RegistryInvariant",
+        );
+    }
+
+    #[test]
+    fn build_with_scope_and_principal_succeeds_and_carries_both() {
+        use crate::id::{OrgId, WorkspaceId};
+
+        let org_id = OrgId::new();
+        let ws_id = WorkspaceId::new();
+        let scope = Scope {
+            org_id: Some(org_id),
+            workspace_id: Some(ws_id),
+            ..Scope::default()
+        };
+
+        let ctx = BaseContext::builder(scope)
+            .principal(Principal::System)
+            .build()
+            .expect("scope + principal must produce a valid BaseContext");
+
+        assert_eq!(ctx.scope().org_id, Some(org_id));
+        assert_eq!(ctx.scope().workspace_id, Some(ws_id));
+        assert!(matches!(ctx.principal(), Principal::System));
     }
 }

--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -200,6 +200,29 @@ mod tests {
 
         assert_eq!(ctx.scope().org_id, Some(org_id));
         assert_eq!(ctx.scope().workspace_id, Some(ws_id));
-        assert!(matches!(ctx.principal(), Principal::System));
+        assert_eq!(ctx.principal(), &Principal::System);
+    }
+
+    #[test]
+    fn build_with_user_principal_stores_and_returns_it() {
+        use crate::id::UserId;
+
+        let user_id = UserId::new();
+
+        let ctx = BaseContext::builder(Scope::default())
+            .principal(Principal::User(user_id))
+            .build()
+            .expect("user principal must produce a valid BaseContext");
+
+        assert_eq!(
+            ctx.principal(),
+            &Principal::User(user_id),
+            "stored principal must match the one supplied to the builder"
+        );
+        assert_ne!(
+            ctx.principal(),
+            &Principal::System,
+            "user principal must not compare equal to Principal::System"
+        );
     }
 }

--- a/crates/core/src/dependencies.rs
+++ b/crates/core/src/dependencies.rs
@@ -145,19 +145,37 @@ pub struct ResourceRequirement {
 }
 
 impl ResourceRequirement {
-    /// Create a required resource requirement.
+    /// Create a required resource requirement from a pre-validated [`ResourceKey`].
     ///
-    /// `key` must be a valid [`ResourceKey`] string (lowercase, underscores).
-    /// Panics at runtime if the key is invalid — prefer compile-time
-    /// validated keys when possible.
-    pub fn new(key: &str, type_id: TypeId, type_name: &'static str) -> Self {
+    /// Prefer the compile-time [`resource_key!`](crate::resource_key) macro to
+    /// construct the key argument — that rejects invalid literals at compile time
+    /// and makes this constructor infallible.
+    pub fn new(key: ResourceKey, type_id: TypeId, type_name: &'static str) -> Self {
         Self {
-            key: ResourceKey::new(key).unwrap_or_else(|_| panic!("invalid resource key: {key}")),
+            key,
             type_id,
             type_name,
             required: true,
             purpose: None,
         }
+    }
+
+    /// Create a required resource requirement, validating `key` at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError::InvalidKey`] when `key` fails [`ResourceKey`]
+    /// validation (not lowercase-underscore-alphanumeric).  Prefer the compile-time
+    /// [`resource_key!`](crate::resource_key) macro + [`Self::new`] when the key
+    /// is a string literal.
+    pub fn try_from_str(
+        key: &str,
+        type_id: TypeId,
+        type_name: &'static str,
+    ) -> Result<Self, crate::CoreError> {
+        let validated_key =
+            ResourceKey::new(key).map_err(|_| crate::CoreError::invalid_key(key, "resource"))?;
+        Ok(Self::new(validated_key, type_id, type_name))
     }
 
     /// Set the purpose description (builder-style).
@@ -174,20 +192,37 @@ impl ResourceRequirement {
 }
 
 impl CredentialRequirement {
-    /// Create a required credential requirement.
+    /// Create a required credential requirement from a pre-validated [`CredentialKey`].
     ///
-    /// `key` must be a valid [`CredentialKey`] string (lowercase, underscores).
-    /// Panics at runtime if the key is invalid — prefer compile-time
-    /// validated keys when possible.
-    pub fn new(key: &str, type_id: TypeId, type_name: &'static str) -> Self {
+    /// Prefer the compile-time [`credential_key!`](crate::credential_key) macro to
+    /// construct the key argument — that rejects invalid literals at compile time
+    /// and makes this constructor infallible.
+    pub fn new(key: CredentialKey, type_id: TypeId, type_name: &'static str) -> Self {
         Self {
-            key: CredentialKey::new(key)
-                .unwrap_or_else(|_| panic!("invalid credential key: {key}")),
+            key,
             type_id,
             type_name,
             required: true,
             purpose: None,
         }
+    }
+
+    /// Create a required credential requirement, validating `key` at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError::InvalidKey`] when `key` fails [`CredentialKey`]
+    /// validation (not lowercase-underscore-alphanumeric).  Prefer the compile-time
+    /// [`credential_key!`](crate::credential_key) macro + [`Self::new`] when the
+    /// key is a string literal.
+    pub fn try_from_str(
+        key: &str,
+        type_id: TypeId,
+        type_name: &'static str,
+    ) -> Result<Self, crate::CoreError> {
+        let validated_key = CredentialKey::new(key)
+            .map_err(|_| crate::CoreError::invalid_key(key, "credential"))?;
+        Ok(Self::new(validated_key, type_id, type_name))
     }
 
     /// Set the purpose description (builder-style).
@@ -252,10 +287,7 @@ impl From<DependencyError> for crate::CoreError {
                 crate::CoreError::DependencyMissing { name, required_by }
             },
             DependencyError::Cycle { path } => crate::CoreError::DependencyCycle { path },
-            DependencyError::RegistryInvariant(msg) => crate::CoreError::DependencyMissing {
-                name: msg,
-                required_by: "registry",
-            },
+            DependencyError::RegistryInvariant(msg) => crate::CoreError::RegistryInvariant(msg),
         }
     }
 }
@@ -263,13 +295,29 @@ impl From<DependencyError> for crate::CoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource_key;
 
     struct FakeResource;
 
     #[test]
+    fn resource_requirement_try_from_str_rejects_invalid_key() {
+        // Headline acceptance test — must be red before try_from_str exists.
+        let result = ResourceRequirement::try_from_str("bad key!", TypeId::of::<()>(), "X");
+        assert!(
+            result.is_err(),
+            "try_from_str must reject keys with spaces/special chars"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, crate::CoreError::InvalidKey { .. }),
+            "expected InvalidKey, got: {err:?}"
+        );
+    }
+
+    #[test]
     fn resource_requirement_builder() {
         let req = ResourceRequirement::new(
-            "fake_resource",
+            resource_key!("fake_resource"),
             TypeId::of::<FakeResource>(),
             "FakeResource",
         )
@@ -284,8 +332,11 @@ mod tests {
 
     #[test]
     fn resource_requirement_defaults() {
-        let req =
-            ResourceRequirement::new("test_res", TypeId::of::<FakeResource>(), "FakeResource");
+        let req = ResourceRequirement::new(
+            resource_key!("test_res"),
+            TypeId::of::<FakeResource>(),
+            "FakeResource",
+        );
 
         assert!(req.required);
         assert_eq!(req.purpose, None);
@@ -295,7 +346,7 @@ mod tests {
     fn dependencies_builder() {
         let deps = Dependencies::new().resource(
             ResourceRequirement::new(
-                "http_resource",
+                resource_key!("http_resource"),
                 TypeId::of::<FakeResource>(),
                 "HttpResource",
             )
@@ -305,6 +356,20 @@ mod tests {
         assert_eq!(deps.resources().len(), 1);
         assert_eq!(deps.resources()[0].type_name, "HttpResource");
         assert!(deps.credentials().is_empty());
+    }
+
+    #[test]
+    fn credential_requirement_try_from_str_rejects_invalid_key() {
+        let result = CredentialRequirement::try_from_str("bad key!", TypeId::of::<()>(), "X");
+        assert!(
+            result.is_err(),
+            "try_from_str must reject keys with spaces/special chars"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, crate::CoreError::InvalidKey { domain, .. } if domain == "credential"),
+            "expected InvalidKey with domain=credential, got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/core/src/dependencies.rs
+++ b/crates/core/src/dependencies.rs
@@ -30,8 +30,9 @@ impl Dependencies {
         self
     }
 
-    /// Declare a slot-binding field (`#[resource]` / `#[credential]`) per
-    ///. The default id (the slot key) supplies the binding when
+    /// Declare a slot-binding field (`#[resource]` / `#[credential]`).
+    ///
+    /// The default id (the slot key) supplies the binding when
     /// the workflow node does not override it via `slot_bindings`.
     pub fn slot_field(mut self, field: SlotField) -> Self {
         self.slot_fields.push(field);
@@ -58,13 +59,13 @@ impl Dependencies {
 ///
 /// Slot fields capture the `(slot_key, default_id, kind, required, lazy)`
 /// tuple that `#[derive(Action)]` reads off `#[resource(...)]` /
-/// `#[credential(...)]` field-level attributes (). The
-/// engine uses this declaration to resolve the slot at dispatch time,
-/// applying the workflow's `slot_bindings` override when one
-/// is supplied for `slot_key`, falling back to `default_id` otherwise.
+/// `#[credential(...)]` field-level attributes. The engine uses this
+/// declaration to resolve the slot at dispatch time, applying the
+/// workflow's `slot_bindings` override when one is supplied for
+/// `slot_key`, falling back to `default_id` otherwise.
 #[derive(Debug, Clone)]
 pub struct SlotField {
-    /// The struct-field name (and default binding key, ).
+    /// The struct-field name (also used as the default binding key).
     pub slot_key: &'static str,
     /// Default id used when the workflow node does not override.
     /// By convention this is `slot_key` itself.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+use crate::keys::CredentialKey;
+
 /// Core error -- only errors that core vocabulary operations produce.
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
@@ -63,8 +65,8 @@ pub enum CoreError {
     /// Credential not found by key.
     #[error("credential not found: {key}")]
     CredentialNotFound {
-        /// The key that was not found.
-        key: String,
+        /// The validated credential key that was not found.
+        key: CredentialKey,
     },
 
     /// Credential access denied (action not authorized for this key).
@@ -133,6 +135,11 @@ impl CoreError {
     /// Create a missing dependency error.
     pub fn dependency_missing(name: &'static str, required_by: &'static str) -> Self {
         Self::DependencyMissing { name, required_by }
+    }
+
+    /// Create a credential-not-found error for the given validated key.
+    pub fn credential_not_found(key: CredentialKey) -> Self {
+        Self::CredentialNotFound { key }
     }
 
     /// Create a resource-acquire failure surfaced through the accessor seam.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -91,6 +91,13 @@ pub enum CoreError {
         /// Optional retry delay hint from the resource layer.
         retry_after: Option<Duration>,
     },
+
+    /// An internal registry invariant was violated (e.g., duplicate registration
+    /// or a lookup that contradicts a prior guarantee).
+    ///
+    /// This is a programming-error category; it is never retryable.
+    #[error("registry invariant violated: {0}")]
+    RegistryInvariant(&'static str),
 }
 
 impl CoreError {
@@ -161,12 +168,8 @@ impl nebula_error::Classify for CoreError {
                 nebula_error::ErrorCategory::NotFound
             },
             Self::CredentialAccessDenied { .. } => nebula_error::ErrorCategory::Authorization,
-            Self::ResourceUnavailable {
-                retryable: true, ..
-            } => nebula_error::ErrorCategory::Unavailable,
-            Self::ResourceUnavailable {
-                retryable: false, ..
-            } => nebula_error::ErrorCategory::Cancelled,
+            Self::ResourceUnavailable { .. } => nebula_error::ErrorCategory::Unavailable,
+            Self::RegistryInvariant(_) => nebula_error::ErrorCategory::Internal,
         }
     }
 
@@ -181,6 +184,7 @@ impl nebula_error::Classify for CoreError {
             Self::CredentialNotFound { .. } => "CORE:CREDENTIAL_NOT_FOUND",
             Self::CredentialAccessDenied { .. } => "CORE:CREDENTIAL_ACCESS_DENIED",
             Self::ResourceUnavailable { .. } => "CORE:RESOURCE_UNAVAILABLE",
+            Self::RegistryInvariant(_) => "CORE:REGISTRY_INVARIANT",
         })
     }
 
@@ -245,5 +249,46 @@ mod tests {
             CoreError::dependency_missing("dep", "owner"),
             CoreError::DependencyMissing { .. }
         ));
+    }
+
+    #[test]
+    fn registry_invariant_from_dependency_error_maps_correctly() {
+        use crate::dependencies::DependencyError;
+        use nebula_error::Classify;
+
+        let dep_err = DependencyError::RegistryInvariant("duplicate registration");
+        let core_err = CoreError::from(dep_err);
+
+        assert!(
+            matches!(core_err, CoreError::RegistryInvariant(_)),
+            "RegistryInvariant DependencyError must map to CoreError::RegistryInvariant"
+        );
+        assert_eq!(core_err.code().as_str(), "CORE:REGISTRY_INVARIANT");
+        assert_eq!(core_err.category(), nebula_error::ErrorCategory::Internal);
+        assert!(!core_err.is_retryable());
+    }
+
+    #[test]
+    fn resource_unavailable_category_is_unavailable_regardless_of_retryable() {
+        use nebula_error::Classify;
+
+        let retryable = CoreError::resource_unavailable("db", "timeout", true, None);
+        assert_eq!(
+            retryable.category(),
+            nebula_error::ErrorCategory::Unavailable,
+            "retryable=true must be Unavailable"
+        );
+        assert!(retryable.is_retryable(), "retryable=true must be retryable");
+
+        let non_retryable = CoreError::resource_unavailable("db", "gone", false, None);
+        assert_eq!(
+            non_retryable.category(),
+            nebula_error::ErrorCategory::Unavailable,
+            "retryable=false must also be Unavailable"
+        );
+        assert!(
+            !non_retryable.is_retryable(),
+            "retryable=false must not be retryable"
+        );
     }
 }

--- a/crates/core/src/id/types.rs
+++ b/crates/core/src/id/types.rs
@@ -20,9 +20,6 @@ define_ulid!(pub ServiceAccountIdDomain => ServiceAccountId, prefix = "svc");
 define_ulid!(pub ResourceIdDomain => ResourceId, prefix = "res");
 define_ulid!(pub CredentialIdDomain => CredentialId, prefix = "cred");
 define_ulid!(pub SessionIdDomain => SessionId, prefix = "sess");
-// OrganizationId duplicates OrgId with the same "org" prefix.
-#[deprecated(note = "Use OrgId instead")]
-pub type OrganizationId = OrgId;
 
 #[cfg(test)]
 mod tests {
@@ -108,10 +105,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        deprecated,
-        reason = "test exercises OrganizationId which is deprecated but still supported"
-    )]
     fn all_id_types_create_successfully() {
         let _ = OrgId::new();
         let _ = WorkspaceId::new();
@@ -127,6 +120,5 @@ mod tests {
         let _ = ResourceId::new();
         let _ = CredentialId::new();
         let _ = SessionId::new();
-        let _ = OrganizationId::new();
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,11 +13,14 @@
 //!
 //! ## Public API
 //!
-//! - **Identifiers** — `ExecutionId` (`exe_…`), `WorkflowId` (`wf_…`), `NodeId`, `UserId`,
-//!   `TenantId`, `ProjectId`, `OrganizationId`, `ResourceId`, `CredentialId` (`cred_…`), `RoleId`.
+//! - **Identifiers** — `ExecutionId` (`exe_…`), `WorkflowId` (`wf_…`), `WorkflowVersionId`
+//!   (`wfv_…`), `OrgId` (`org_…`), `WorkspaceId` (`ws_…`), `UserId` (`usr_…`),
+//!   `ServiceAccountId` (`svc_…`), `ResourceId` (`res_…`), `CredentialId` (`cred_…`),
+//!   `TriggerId` (`trg_…`), `TriggerEventId` (`evt_…`), `AttemptId` (`att_…`),
+//!   `InstanceId` (`nbl_…`), `SessionId` (`sess_…`) — all defined in this crate.
 //! - **Keys** — `PluginKey`, `ActionKey`, `CredentialKey`, `ParameterKey`, `ResourceKey`, `NodeKey`
 //!   — normalized string keys with validation.
-//! - **Scope** — `ScopeLevel`, `Scope`, `Principal`, `ScopeResolver` (Global → … → Action).
+//! - **Scope** — `ScopeLevel`, `Scope`, `Principal`, `ScopeResolver` (Global → Organization → Workspace → Workflow → Execution).
 //! - **Context** — `Context` trait, `BaseContext`, `BaseContextBuilder`, capability traits
 //!   (`HasCredentials`, `HasResources`, `HasMetrics`, `HasEventBus`, `HasLogger`).
 //! - **Accessors** — `ResourceAccessor`, `CredentialAccessor`, `Logger`, `MetricsEmitter`,
@@ -29,7 +32,7 @@
 //! - **Observability** — `TraceId`, `SpanId`, `W3cTraceContext`, W3C trace parsing.
 //! - **Errors** — `CoreError` (typed, thiserror; no anyhow).
 //! - **Roles** — `OrgRole`, `WorkspaceRole`, `effective_workspace_role` (module `role`).
-//! - **Permissions** — `Permission`, `PermissionDenied` (module `permission`).
+//! - **Permissions** — `Permission` (module `permission`). `PermissionDenied` (module `tenancy`).
 //! - **Tenancy** — `TenantContext`, `ResolvedIds` (module `tenancy`).
 //! - **Slugs** — `Slug`, `SlugKind`, `SlugError`, `is_prefixed_ulid()` (module `slug`).
 
@@ -79,7 +82,6 @@ pub use context::{
 pub use dependencies::*;
 pub use error::*;
 pub use guard::{Guard, TypedGuard, debug_redacted, debug_typed};
-#[allow(deprecated)] // OrganizationId re-exported for migration period
 pub use id::*;
 pub use keys::*;
 pub use lifecycle::{LayerLifecycle, ShutdownOutcome};
@@ -111,11 +113,9 @@ pub mod prelude {
     pub use crate::dependencies::DependencyError;
     pub use crate::error::{CoreError, CoreResult};
     // Identifiers (ULID-backed)
-    #[expect(deprecated, reason = "OrganizationId re-exported for migration period")]
     pub use crate::id::{
-        AttemptId, CredentialId, ExecutionId, InstanceId, OrgId, OrganizationId, ResourceId,
-        ServiceAccountId, SessionId, TriggerEventId, TriggerId, UserId, WorkflowId,
-        WorkflowVersionId, WorkspaceId,
+        AttemptId, CredentialId, ExecutionId, InstanceId, OrgId, ResourceId, ServiceAccountId,
+        SessionId, TriggerEventId, TriggerId, UserId, WorkflowId, WorkflowVersionId, WorkspaceId,
     };
     // Domain keys (normalized string keys)
     pub use crate::keys::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -94,7 +94,7 @@ pub use role::{OrgRole, WorkspaceRole, effective_workspace_role};
 pub use scope::*;
 pub use slug::{Slug, SlugError, SlugKind, is_prefixed_ulid};
 pub use sync::Lazy;
-pub use tenancy::{PermissionDenied, ResolvedIds, TenantContext};
+pub use tenancy::{PermissionDenial, PermissionDenied, ResolvedIds, TenantContext};
 
 /// Named parse-error type for [`PluginKey`] — `<PluginKey as std::str::FromStr>::Err`.
 ///

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -43,6 +43,7 @@ impl LayerLifecycle {
 /// Result of a graceful shutdown attempt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
+#[must_use = "a ShutdownOutcome carries the grace-exceeded signal; dropping it discards whether shutdown completed within grace"]
 pub enum ShutdownOutcome {
     /// All children completed within grace period.
     Graceful,

--- a/crates/core/src/obs.rs
+++ b/crates/core/src/obs.rs
@@ -6,13 +6,75 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// W3C Trace Context trace-id (128-bit).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct TraceId(pub u128);
+/// W3C Trace Context trace-id (128-bit, always non-zero).
+///
+/// The W3C spec forbids an all-zero trace id; this type makes that invariant
+/// unrepresentable by construction. Use [`TraceId::new`] to construct one from
+/// a parsed value, and [`TraceId::get`] to read the raw integer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TraceId(core::num::NonZeroU128);
 
-/// W3C Trace Context parent-id (64-bit).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SpanId(pub u64);
+impl TraceId {
+    /// Wrap `value` in a `TraceId`. Returns `None` if `value` is zero.
+    #[must_use]
+    pub fn new(value: u128) -> Option<Self> {
+        core::num::NonZeroU128::new(value).map(Self)
+    }
+
+    /// Return the raw 128-bit trace id value (guaranteed non-zero).
+    #[must_use]
+    pub const fn get(&self) -> u128 {
+        self.0.get()
+    }
+}
+
+impl Serialize for TraceId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.get().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TraceId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = u128::deserialize(deserializer)?;
+        Self::new(raw).ok_or_else(|| serde::de::Error::custom("trace_id must not be all zeros"))
+    }
+}
+
+/// W3C Trace Context parent-id (64-bit, always non-zero).
+///
+/// The W3C spec forbids an all-zero parent id; this type makes that invariant
+/// unrepresentable by construction. Use [`SpanId::new`] to construct one from
+/// a parsed value, and [`SpanId::get`] to read the raw integer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SpanId(core::num::NonZeroU64);
+
+impl SpanId {
+    /// Wrap `value` in a `SpanId`. Returns `None` if `value` is zero.
+    #[must_use]
+    pub fn new(value: u64) -> Option<Self> {
+        core::num::NonZeroU64::new(value).map(Self)
+    }
+
+    /// Return the raw 64-bit span id value (guaranteed non-zero).
+    #[must_use]
+    pub const fn get(&self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl Serialize for SpanId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.get().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SpanId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = u64::deserialize(deserializer)?;
+        Self::new(raw).ok_or_else(|| serde::de::Error::custom("span_id must not be all zeros"))
+    }
+}
 
 /// Lowercase W3C `traceparent` HTTP header field-name.
 pub const W3C_TRACEPARENT: &str = "traceparent";
@@ -95,25 +157,20 @@ impl W3cTraceContext {
         })
     }
 
-    /// Build from decoded identifiers (version `00` only). Rejects all-zero trace or parent id.
+    /// Build from decoded identifiers (version `00` only).
+    ///
+    /// Both `trace_id` and `parent_span_id` are [`TraceId`] / [`SpanId`] which are
+    /// non-zero by construction, so no runtime rejection is needed here.
     pub fn from_trace_ids(
         trace_id: TraceId,
         parent_span_id: SpanId,
         trace_flags: u8,
     ) -> Result<Self, W3cTraceContextError> {
-        if trace_id.0 == 0 {
-            return Err(W3cTraceContextError::InvalidTraceparent {
-                reason: "trace_id must not be all zeros",
-            });
-        }
-        if parent_span_id.0 == 0 {
-            return Err(W3cTraceContextError::InvalidTraceparent {
-                reason: "parent_id must not be all zeros",
-            });
-        }
         let traceparent = format!(
             "00-{:032x}-{:016x}-{:02x}",
-            trace_id.0, parent_span_id.0, trace_flags
+            trace_id.get(),
+            parent_span_id.get(),
+            trace_flags
         );
         Ok(Self {
             traceparent,
@@ -179,7 +236,9 @@ fn parse_and_canonicalize_traceparent(s: &str) -> Result<String, W3cTraceContext
     let parsed = parse_traceparent_parts(s)?;
     Ok(format!(
         "00-{:032x}-{:016x}-{:02x}",
-        parsed.trace_id.0, parsed.parent_span_id.0, parsed.trace_flags
+        parsed.trace_id.get(),
+        parsed.parent_span_id.get(),
+        parsed.trace_flags
     ))
 }
 
@@ -267,9 +326,16 @@ fn parse_traceparent_parts(s: &str) -> Result<ParsedTraceparent, W3cTraceContext
         }
     })?;
 
+    // Both values were checked for zero above, so `new` is guaranteed to return `Some`.
+    let trace_id = TraceId::new(trace_id).ok_or(W3cTraceContextError::InvalidTraceparent {
+        reason: "trace_id must not be all zeros",
+    })?;
+    let parent_span_id = SpanId::new(parent).ok_or(W3cTraceContextError::InvalidTraceparent {
+        reason: "parent_id must not be all zeros",
+    })?;
     Ok(ParsedTraceparent {
-        trace_id: TraceId(trace_id),
-        parent_span_id: SpanId(parent),
+        trace_id,
+        parent_span_id,
         trace_flags,
     })
 }
@@ -284,8 +350,11 @@ mod tests {
         let ctx = W3cTraceContext::from_traceparent_str(tp).expect("valid");
         assert_eq!(ctx.traceparent(), tp);
         let parsed = parse_traceparent(tp).expect("parse");
-        assert_eq!(parsed.trace_id.0, 0x0af7_6519_16cd_43dd_8448_eb21_1c80_319c);
-        assert_eq!(parsed.parent_span_id.0, 0xb7ad_6b71_6920_3331_u64);
+        assert_eq!(
+            parsed.trace_id.get(),
+            0x0af7_6519_16cd_43dd_8448_eb21_1c80_319c
+        );
+        assert_eq!(parsed.parent_span_id.get(), 0xb7ad_6b71_6920_3331_u64);
         assert_eq!(parsed.trace_flags, 0x01);
     }
 
@@ -325,16 +394,60 @@ mod tests {
 
     #[test]
     fn from_trace_ids_builds_expected_string() {
-        let ctx = W3cTraceContext::from_trace_ids(
-            TraceId(0x0af7_6519_16cd_43dd_8448_eb21_1c80_319c),
-            SpanId(0xb7ad_6b71_6920_3331),
-            1,
-        )
-        .expect("build");
+        let trace_id =
+            TraceId::new(0x0af7_6519_16cd_43dd_8448_eb21_1c80_319c).expect("non-zero trace id");
+        let span_id = SpanId::new(0xb7ad_6b71_6920_3331).expect("non-zero span id");
+        let ctx = W3cTraceContext::from_trace_ids(trace_id, span_id, 1).expect("build");
         assert_eq!(
             ctx.traceparent(),
             "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
         );
+    }
+
+    #[test]
+    fn trace_id_zero_is_unrepresentable() {
+        assert!(
+            TraceId::new(0).is_none(),
+            "all-zero TraceId must be rejected"
+        );
+        assert_eq!(
+            TraceId::new(5).expect("non-zero").get(),
+            5,
+            "TraceId::get must round-trip"
+        );
+    }
+
+    #[test]
+    fn span_id_zero_is_unrepresentable() {
+        assert!(SpanId::new(0).is_none(), "all-zero SpanId must be rejected");
+        assert_eq!(
+            SpanId::new(7).expect("non-zero").get(),
+            7,
+            "SpanId::get must round-trip"
+        );
+    }
+
+    #[test]
+    fn trace_id_serde_round_trip_non_zero() {
+        let original =
+            TraceId::new(0x0af7_6519_16cd_43dd_8448_eb21_1c80_319c).expect("non-zero trace id");
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: TraceId = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized, original);
+    }
+
+    #[test]
+    fn trace_id_serde_rejects_zero() {
+        let json = serde_json::to_string(&0_u128).expect("serialize zero");
+        let result: Result<TraceId, _> = serde_json::from_str(&json);
+        assert!(result.is_err(), "deserializing zero as TraceId must fail");
+    }
+
+    #[test]
+    fn span_id_serde_rejects_zero() {
+        let json = serde_json::to_string(&0_u64).expect("serialize zero");
+        let result: Result<SpanId, _> = serde_json::from_str(&json);
+        assert!(result.is_err(), "deserializing zero as SpanId must fail");
     }
 
     #[test]

--- a/crates/core/src/scope.rs
+++ b/crates/core/src/scope.rs
@@ -212,7 +212,17 @@ pub struct Scope {
 impl Scope {
     /// Check whether this scope can access a resource registered at the given level.
     ///
-    /// Strict containment: resource scope must be broader-or-equal to caller scope.
+    /// Exact-match semantics per level:
+    /// - `Global` — always accessible.
+    /// - `Organization(id)` — caller must carry that exact organization ID.
+    /// - `Workspace(id)` — caller must carry that exact workspace ID.
+    /// - `Workflow(id)` — caller must carry that exact workflow ID.
+    /// - `Execution(id)` — caller must carry that exact execution ID.
+    ///
+    /// A caller carrying only a deeper-level ID (e.g. `execution_id` only) does
+    /// **not** thereby gain access to a resource registered at a shallower level
+    /// (e.g. workspace): each level is checked independently against the
+    /// corresponding field of this `Scope`.
     pub fn can_access(&self, registered: &ScopeLevel) -> bool {
         match registered {
             ScopeLevel::Global => true,

--- a/crates/core/src/scope.rs
+++ b/crates/core/src/scope.rs
@@ -235,7 +235,11 @@ impl Scope {
 }
 
 /// Actor identity within the system.
+///
+/// This enum is `#[non_exhaustive]`: future principal kinds may be added
+/// without a semver break. External `match` arms must include a `_` wildcard.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum Principal {
     /// Human user.
     User(crate::id::UserId),

--- a/crates/core/src/slug.rs
+++ b/crates/core/src/slug.rs
@@ -60,12 +60,6 @@ impl Slug {
         Ok(Self(value.to_owned()))
     }
 
-    /// Create without validation (for trusted internal use only).
-    #[must_use]
-    pub fn new_unchecked(value: String) -> Self {
-        Self(value)
-    }
-
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/crates/core/src/slug.rs
+++ b/crates/core/src/slug.rs
@@ -176,8 +176,7 @@ fn validate_slug(value: &str, kind: SlugKind) -> Result<(), SlugError> {
 }
 
 /// Check if a slug matches a reserved word.
-/// Uses a hardcoded set of common reserved words.
-/// In production this would load from `reserved_slugs.txt`.
+/// Uses a hardcoded set of reserved words (see `RESERVED_SLUGS` in this module).
 #[must_use]
 pub fn is_reserved(slug: &str) -> bool {
     // Case-insensitive check (slugs are already lowercase, but be safe)
@@ -185,7 +184,7 @@ pub fn is_reserved(slug: &str) -> bool {
     RESERVED_SLUGS.contains(&lower.as_str())
 }
 
-/// Core reserved slugs. Extended list loaded at runtime from `reserved_slugs.txt`.
+/// Reserved slugs that may not be used as org/workspace/workflow slugs.
 const RESERVED_SLUGS: &[&str] = &[
     "admin",
     "api",
@@ -265,4 +264,256 @@ pub fn is_prefixed_ulid(segment: &str) -> bool {
         "res_", "cred_", "sess_", "pat_",
     ];
     PREFIXES.iter().any(|prefix| segment.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Slug::new valid ──────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_valid_org() {
+        let slug = Slug::new("my-org", SlugKind::Org).unwrap();
+        assert_eq!(slug.as_str(), "my-org");
+    }
+
+    #[test]
+    fn slug_new_valid_workflow() {
+        let slug = Slug::new("a", SlugKind::Workflow).unwrap();
+        assert_eq!(slug.as_str(), "a");
+    }
+
+    #[test]
+    fn slug_new_valid_digits_and_hyphens() {
+        let slug = Slug::new("abc-123-def", SlugKind::Workflow).unwrap();
+        assert_eq!(slug.as_str(), "abc-123-def");
+    }
+
+    // ── TooShort ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_too_short_org() {
+        // Org min is 3; "ab" is only 2 chars.
+        let err = Slug::new("ab", SlugKind::Org).unwrap_err();
+        assert!(
+            matches!(err, SlugError::TooShort { min: 3, actual: 2 }),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn slug_new_too_short_service_account() {
+        // ServiceAccount min is 3; "a" is only 1 char.
+        let err = Slug::new("a", SlugKind::ServiceAccount).unwrap_err();
+        assert!(
+            matches!(err, SlugError::TooShort { min: 3, .. }),
+            "unexpected: {err:?}"
+        );
+    }
+
+    // ── TooLong ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_too_long_org() {
+        // Org max is 39 chars.
+        let long = "a".repeat(40);
+        let err = Slug::new(&long, SlugKind::Org).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SlugError::TooLong {
+                    max: 39,
+                    actual: 40
+                }
+            ),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn slug_new_too_long_workspace() {
+        // Workspace max is 50 chars.
+        let long = "a".repeat(51);
+        let err = Slug::new(&long, SlugKind::Workspace).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SlugError::TooLong {
+                    max: 50,
+                    actual: 51
+                }
+            ),
+            "unexpected: {err:?}"
+        );
+    }
+
+    // ── InvalidCharacter ────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_invalid_char_uppercase() {
+        // Uppercase at position 0 is caught by the start-character check first,
+        // which produces InvalidStart rather than InvalidCharacter.
+        let err = Slug::new("My-Org", SlugKind::Workflow).unwrap_err();
+        assert!(
+            matches!(err, SlugError::InvalidStart),
+            "unexpected: {err:?}"
+        );
+        // Uppercase at a non-start position reaches the per-char loop.
+        let err2 = Slug::new("my-Org", SlugKind::Workflow).unwrap_err();
+        assert!(
+            matches!(
+                err2,
+                SlugError::InvalidCharacter {
+                    ch: 'O',
+                    position: 3
+                }
+            ),
+            "unexpected: {err2:?}"
+        );
+    }
+
+    #[test]
+    fn slug_new_invalid_char_underscore() {
+        let err = Slug::new("my_org", SlugKind::Workflow).unwrap_err();
+        assert!(
+            matches!(err, SlugError::InvalidCharacter { ch: '_', .. }),
+            "unexpected: {err:?}"
+        );
+    }
+
+    // ── InvalidStart ────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_invalid_start_hyphen() {
+        let err = Slug::new("-my-org", SlugKind::Workflow).unwrap_err();
+        assert!(
+            matches!(err, SlugError::InvalidStart),
+            "unexpected: {err:?}"
+        );
+    }
+
+    // ── InvalidEnd ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_invalid_end_hyphen() {
+        let err = Slug::new("my-org-", SlugKind::Workflow).unwrap_err();
+        assert!(matches!(err, SlugError::InvalidEnd), "unexpected: {err:?}");
+    }
+
+    // ── ConsecutiveHyphens ──────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_consecutive_hyphens() {
+        let err = Slug::new("my--org", SlugKind::Workflow).unwrap_err();
+        assert!(
+            matches!(err, SlugError::ConsecutiveHyphens),
+            "unexpected: {err:?}"
+        );
+    }
+
+    // ── Reserved ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn slug_new_reserved_word() {
+        let err = Slug::new("admin", SlugKind::Workflow).unwrap_err();
+        assert!(matches!(err, SlugError::Reserved), "unexpected: {err:?}");
+    }
+
+    #[test]
+    fn slug_new_reserved_word_api() {
+        let err = Slug::new("api", SlugKind::Org).unwrap_err();
+        assert!(matches!(err, SlugError::Reserved), "unexpected: {err:?}");
+    }
+
+    // ── is_reserved ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_reserved_returns_true_for_reserved_word() {
+        assert!(is_reserved("admin"));
+        assert!(is_reserved("api"));
+        assert!(is_reserved("webhook"));
+    }
+
+    #[test]
+    fn is_reserved_returns_false_for_ordinary_slug() {
+        assert!(!is_reserved("my-cool-workflow"));
+        assert!(!is_reserved("acme-corp"));
+    }
+
+    // ── is_prefixed_ulid ────────────────────────────────────────────────────
+
+    #[test]
+    fn is_prefixed_ulid_true_for_each_known_prefix() {
+        // One representative value per recognized prefix — format doesn't matter for the
+        // prefix-existence check (is_prefixed_ulid only checks starts_with).
+        let samples = [
+            "org_01ABC",
+            "ws_01ABC",
+            "wf_01ABC",
+            "wfv_01ABC",
+            "exe_01ABC",
+            "att_01ABC",
+            "nbl_01ABC",
+            "trg_01ABC",
+            "evt_01ABC",
+            "usr_01ABC",
+            "svc_01ABC",
+            "res_01ABC",
+            "cred_01ABC",
+            "sess_01ABC",
+            "pat_01ABC",
+        ];
+        for sample in samples {
+            assert!(
+                is_prefixed_ulid(sample),
+                "expected is_prefixed_ulid({sample:?}) == true"
+            );
+        }
+    }
+
+    #[test]
+    fn is_prefixed_ulid_false_for_plain_slug() {
+        assert!(!is_prefixed_ulid("my-workflow"));
+        assert!(!is_prefixed_ulid("acme-corp"));
+        assert!(!is_prefixed_ulid(""));
+    }
+
+    // ── B6: drift-guard — prefix list matches live ID types ─────────────────
+
+    #[test]
+    fn prefixed_ulid_recognizes_live_id_type_strings() {
+        use crate::id::{
+            AttemptId, CredentialId, ExecutionId, InstanceId, OrgId, ResourceId, ServiceAccountId,
+            SessionId, TriggerEventId, TriggerId, UserId, WorkflowId, WorkflowVersionId,
+            WorkspaceId,
+        };
+
+        macro_rules! assert_recognized {
+            ($id_type:ident) => {{
+                let id = $id_type::new();
+                let as_string = id.to_string();
+                assert!(
+                    is_prefixed_ulid(&as_string),
+                    "is_prefixed_ulid should recognize a freshly-constructed {}: {as_string}",
+                    stringify!($id_type)
+                );
+            }};
+        }
+
+        assert_recognized!(OrgId);
+        assert_recognized!(WorkspaceId);
+        assert_recognized!(WorkflowId);
+        assert_recognized!(WorkflowVersionId);
+        assert_recognized!(ExecutionId);
+        assert_recognized!(AttemptId);
+        assert_recognized!(InstanceId);
+        assert_recognized!(TriggerId);
+        assert_recognized!(TriggerEventId);
+        assert_recognized!(UserId);
+        assert_recognized!(ServiceAccountId);
+        assert_recognized!(ResourceId);
+        assert_recognized!(CredentialId);
+        assert_recognized!(SessionId);
+    }
 }

--- a/crates/core/src/tenancy.rs
+++ b/crates/core/src/tenancy.rs
@@ -160,7 +160,11 @@ impl std::error::Error for PermissionDenied {}
 
 /// IDs resolved by the tenancy middleware from path segments.
 /// Inserted into request extensions so handlers and RBAC middleware can use them.
+///
+/// This struct is `#[non_exhaustive]`: additional resolved IDs may be added
+/// in future versions. External struct literals must use `..Default::default()`.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct ResolvedIds {
     pub org_id: Option<OrgId>,
     pub workspace_id: Option<WorkspaceId>,

--- a/crates/core/src/tenancy.rs
+++ b/crates/core/src/tenancy.rs
@@ -30,13 +30,17 @@ impl TenantContext {
                 Some(actual) if actual >= required_ws_role => Ok(()),
                 Some(actual) => Err(PermissionDenied {
                     permission,
-                    required_role: required_ws_role.to_string(),
-                    current_role: actual.to_string(),
+                    denial: PermissionDenial::Workspace {
+                        required: required_ws_role,
+                        current: Some(actual),
+                    },
                 }),
                 None => Err(PermissionDenied {
                     permission,
-                    required_role: required_ws_role.to_string(),
-                    current_role: "none".to_string(),
+                    denial: PermissionDenial::Workspace {
+                        required: required_ws_role,
+                        current: None,
+                    },
                 }),
             }
         } else {
@@ -70,13 +74,17 @@ impl TenantContext {
                 Some(actual) if actual >= required => Ok(()),
                 Some(actual) => Err(PermissionDenied {
                     permission,
-                    required_role: required.to_string(),
-                    current_role: actual.to_string(),
+                    denial: PermissionDenial::Org {
+                        required,
+                        current: Some(actual),
+                    },
                 }),
                 None => Err(PermissionDenied {
                     permission,
-                    required_role: required.to_string(),
-                    current_role: "none".to_string(),
+                    denial: PermissionDenial::Org {
+                        required,
+                        current: None,
+                    },
                 }),
             }
         }
@@ -89,21 +97,62 @@ impl TenantContext {
     }
 }
 
+/// The specific role-level mismatch that caused a permission check to fail.
+///
+/// Carries the required and actual (caller's) role at the level that was checked.
+/// `current` is `None` when the caller has no role at that level at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PermissionDenial {
+    /// A workspace-scoped permission was required but the caller's workspace role was
+    /// absent or below the minimum.
+    Workspace {
+        /// The minimum workspace role required by the permission.
+        required: WorkspaceRole,
+        /// The caller's workspace role, or `None` if no workspace role is present.
+        current: Option<WorkspaceRole>,
+    },
+    /// An org-scoped permission was required but the caller's org role was absent or
+    /// below the minimum.
+    Org {
+        /// The minimum org role required by the permission.
+        required: OrgRole,
+        /// The caller's org role, or `None` if no org role is present.
+        current: Option<OrgRole>,
+    },
+}
+
+impl fmt::Display for PermissionDenial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Workspace { required, current } => {
+                let current_display = current
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "none".to_owned());
+                write!(f, "{required} required, current role {current_display}")
+            },
+            Self::Org { required, current } => {
+                let current_display = current
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "none".to_owned());
+                write!(f, "{required} required, current role {current_display}")
+            },
+        }
+    }
+}
+
 /// Returned when a permission check fails.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PermissionDenied {
+    /// The permission that was required.
     pub permission: Permission,
-    pub required_role: String,
-    pub current_role: String,
+    /// The role-level mismatch that caused the denial.
+    pub denial: PermissionDenial,
 }
 
 impl fmt::Display for PermissionDenied {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{} required, current role {}",
-            self.required_role, self.current_role
-        )
+        fmt::Display::fmt(&self.denial, f)
     }
 }
 
@@ -155,13 +204,16 @@ mod tests {
             Permission::MemberRemove,
             Permission::ServiceAccountManage,
         ] {
+            let err = ctx
+                .require(permission)
+                .expect_err("OrgMember must be denied");
             assert_eq!(
-                ctx.require(permission)
-                    .map_err(|err| (err.required_role, err.current_role)),
-                Err((
-                    OrgRole::OrgAdmin.to_string(),
-                    OrgRole::OrgMember.to_string()
-                ))
+                err.denial,
+                PermissionDenial::Org {
+                    required: OrgRole::OrgAdmin,
+                    current: Some(OrgRole::OrgMember),
+                },
+                "wrong denial shape for {permission:?}"
             );
         }
     }
@@ -171,11 +223,15 @@ mod tests {
         let admin = context_with_org_role(Some(OrgRole::OrgAdmin));
         let owner = context_with_org_role(Some(OrgRole::OrgOwner));
 
+        let err = admin
+            .require(Permission::OrgDelete)
+            .expect_err("OrgAdmin must be denied OrgDelete");
         assert_eq!(
-            admin
-                .require(Permission::OrgDelete)
-                .map_err(|err| (err.required_role, err.current_role)),
-            Err((OrgRole::OrgOwner.to_string(), OrgRole::OrgAdmin.to_string()))
+            err.denial,
+            PermissionDenial::Org {
+                required: OrgRole::OrgOwner,
+                current: Some(OrgRole::OrgAdmin),
+            }
         );
         assert!(owner.require(Permission::OrgDelete).is_ok());
     }

--- a/crates/core/src/tenancy.rs
+++ b/crates/core/src/tenancy.rs
@@ -129,13 +129,16 @@ impl fmt::Display for PermissionDenial {
                 let current_display = current
                     .map(|r| r.to_string())
                     .unwrap_or_else(|| "none".to_owned());
-                write!(f, "{required} required, current role {current_display}")
+                write!(
+                    f,
+                    "workspace role {required} required, current {current_display}"
+                )
             },
             Self::Org { required, current } => {
                 let current_display = current
                     .map(|r| r.to_string())
                     .unwrap_or_else(|| "none".to_owned());
-                write!(f, "{required} required, current role {current_display}")
+                write!(f, "org role {required} required, current {current_display}")
             },
         }
     }
@@ -238,5 +241,35 @@ mod tests {
             }
         );
         assert!(owner.require(Permission::OrgDelete).is_ok());
+    }
+
+    #[test]
+    fn permission_denial_display_discriminates_workspace_vs_org() {
+        use crate::role::{OrgRole, WorkspaceRole};
+
+        let ws_denial = PermissionDenial::Workspace {
+            required: WorkspaceRole::WorkspaceViewer,
+            current: None,
+        };
+        let org_denial = PermissionDenial::Org {
+            required: OrgRole::OrgAdmin,
+            current: Some(OrgRole::OrgMember),
+        };
+
+        let ws_str = ws_denial.to_string();
+        let org_str = org_denial.to_string();
+
+        assert!(
+            ws_str.contains("workspace"),
+            "workspace denial Display must contain 'workspace', got: {ws_str:?}"
+        );
+        assert!(
+            org_str.contains("org"),
+            "org denial Display must contain 'org', got: {org_str:?}"
+        );
+        assert_ne!(
+            ws_str, org_str,
+            "workspace and org denial Display strings must differ"
+        );
     }
 }

--- a/crates/core/tests/schema_contracts.rs
+++ b/crates/core/tests/schema_contracts.rs
@@ -72,6 +72,10 @@ fn core_error_code_stability() {
             CoreError::dependency_missing("x", "y"),
             "CORE:DEPENDENCY_MISSING",
         ),
+        (
+            CoreError::RegistryInvariant("duplicate registration"),
+            "CORE:REGISTRY_INVARIANT",
+        ),
     ];
     for (err, expected_code) in errors {
         assert_eq!(err.code().as_str(), expected_code, "CoreError code changed");

--- a/crates/credential/macros/src/credential.rs
+++ b/crates/credential/macros/src/credential.rs
@@ -433,7 +433,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 quote! {
                     .resource(
                         ::nebula_core::ResourceRequirement::new(
-                            #key_str,
+                            ::nebula_core::resource_key!(#key_str),
                             ::std::any::TypeId::of::<#ty>(),
                             #type_name_str,
                         ).purpose(#purpose)
@@ -443,7 +443,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 quote! {
                     .resource(
                         ::nebula_core::ResourceRequirement::new(
-                            #key_str,
+                            ::nebula_core::resource_key!(#key_str),
                             ::std::any::TypeId::of::<#ty>(),
                             #type_name_str,
                         )

--- a/crates/credential/src/context.rs
+++ b/crates/credential/src/context.rs
@@ -84,7 +84,10 @@ fn default_resource_accessor() -> Arc<dyn ResourceAccessor> {
 /// use nebula_credential::CredentialContextBuilder;
 /// use nebula_core::BaseContext;
 ///
-/// let base = BaseContext::builder().build();
+/// let base = BaseContext::builder(nebula_core::scope::Scope::default())
+///     .principal(nebula_core::scope::Principal::System)
+///     .build()
+///     .expect("scope + principal must produce a valid BaseContext");
 /// let ctx = CredentialContextBuilder::new(base, credentials, resources)
 ///     .callback_url("https://app/callback".to_owned())
 ///     .build();
@@ -245,7 +248,10 @@ impl CredentialContext {
     /// default scope, system clock) and noop accessors. The `owner_id` is
     /// stored as an override for backward-compatible pending-store binding.
     pub fn for_test(owner_id: impl Into<String>) -> Self {
-        let base = BaseContext::builder().build();
+        let base = BaseContext::builder(Scope::default())
+            .principal(Principal::System)
+            .build()
+            .expect("scope + principal must produce a valid BaseContext");
         let cancel = base.cancellation().child_token();
         Self {
             base: Arc::new(base),
@@ -403,7 +409,10 @@ mod tests {
 
     #[test]
     fn builder_creates_context_with_all_fields() {
-        let base = BaseContext::builder().build();
+        let base = BaseContext::builder(Scope::default())
+            .principal(Principal::System)
+            .build()
+            .expect("scope + principal must produce a valid BaseContext");
         let ctx = CredentialContextBuilder::new(
             base,
             default_credential_accessor(),

--- a/crates/credential/src/runtime/scoped_accessor.rs
+++ b/crates/credential/src/runtime/scoped_accessor.rs
@@ -144,8 +144,8 @@ mod tests {
                     Box::new(format!("resolved:{}", key.as_str()));
                 Box::pin(async move { Ok(val) })
             } else {
-                let key_str = key.as_str().to_owned();
-                Box::pin(async move { Err(CoreError::CredentialNotFound { key: key_str }) })
+                let missing_key = key.clone();
+                Box::pin(async move { Err(CoreError::credential_not_found(missing_key)) })
             }
         }
 

--- a/crates/credential/tests/context_cancel_probe.rs
+++ b/crates/credential/tests/context_cancel_probe.rs
@@ -5,7 +5,11 @@
 
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 
-use nebula_core::{BaseContext, CoreError, ResourceKey, accessor::ResourceAccessor};
+use nebula_core::{
+    BaseContext, CoreError, ResourceKey,
+    accessor::ResourceAccessor,
+    scope::{Principal, Scope},
+};
 use nebula_credential::{CredentialContextBuilder, NoopCredentialAccessor};
 use tokio_util::sync::CancellationToken;
 
@@ -42,7 +46,10 @@ impl ResourceAccessor for NoopResourceAccessor {
 fn child_token_derivable_and_cascades_from_parent() {
     let parent = CancellationToken::new();
     let ctx = CredentialContextBuilder::new(
-        BaseContext::builder().build(),
+        BaseContext::builder(Scope::default())
+            .principal(Principal::System)
+            .build()
+            .expect("scope + principal must produce a valid BaseContext"),
         Arc::new(NoopCredentialAccessor),
         Arc::new(NoopResourceAccessor),
     )

--- a/crates/engine/src/credential_accessor.rs
+++ b/crates/engine/src/credential_accessor.rs
@@ -82,8 +82,11 @@ type ResolveFn = Arc<
 ///         let resolver = Arc::clone(&resolver);
 ///         let id = id.to_owned();
 ///         Box::pin(async move {
+///             let credential_key = nebula_core::CredentialKey::new(&id)
+///                 .expect("id passed through allowlist must be a valid CredentialKey");
 ///             resolver.resolve_snapshot(&id).await
-///                 .map_err(|e| CoreError::CredentialNotFound { key: e.to_string() })
+///                 .map(|snap| snap)
+///                 .map_err(|_| CoreError::credential_not_found(credential_key))
 ///         })
 ///     }
 /// });
@@ -297,9 +300,9 @@ mod tests {
         let accessor = EngineCredentialAccessor::new(
             allowed_keys,
             |_id: &str| async {
-                Err(CoreError::CredentialNotFound {
-                    key: "resolver reached".to_owned(),
-                })
+                Err(CoreError::credential_not_found(credential_key!(
+                    "resolver_reached"
+                )))
             },
             "test_action".to_owned(),
         );
@@ -347,9 +350,7 @@ mod tests {
     async fn resolver_error_propagates_for_allowed_key() {
         let accessor = make_failing_accessor(
             ["my_key"],
-            CoreError::CredentialNotFound {
-                key: "transient failure".to_owned(),
-            },
+            CoreError::credential_not_found(credential_key!("transient_failure")),
         );
         let result = accessor.resolve_any(&credential_key!("my_key")).await;
         assert!(
@@ -377,9 +378,9 @@ mod tests {
                 let calls = calls_inner.clone();
                 async move {
                     calls.fetch_add(1, AOrdering::Relaxed);
-                    Err(CoreError::CredentialNotFound {
-                        key: "resolver should not be called".to_owned(),
-                    })
+                    Err(CoreError::credential_not_found(credential_key!(
+                        "resolver_not_called"
+                    )))
                 }
             },
             "test_action".to_owned(),

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -23,7 +23,7 @@ use nebula_action::{
     ActionError, ActionResult, capability::default_resource_accessor, result::WaitCondition,
 };
 use nebula_core::{
-    ActionKey, NodeKey, ResourceKey,
+    ActionKey, CredentialKey, NodeKey, ResourceKey,
     accessor::{CredentialAccessor, ResourceAccessor},
     id::{ExecutionId, InstanceId, WorkflowId},
     node_key,
@@ -5355,26 +5355,36 @@ impl WorkflowEngine {
             .get(&node_def.action_key)
             .cloned()
             .unwrap_or_default();
-        let credentials: Arc<dyn CredentialAccessor> =
-            if let Some(resolver_fn) = &self.credential_resolver {
-                let resolver_fn = Arc::clone(resolver_fn);
-                Arc::new(EngineCredentialAccessor::new(
-                    allowed_keys,
-                    move |id: &str| {
-                        let resolver_fn = Arc::clone(&resolver_fn);
-                        let id = id.to_owned();
-                        async move {
-                            let snapshot = (resolver_fn)(&id).await.map_err(|e| {
-                                nebula_core::CoreError::CredentialNotFound { key: e.to_string() }
-                            })?;
-                            Ok(Box::new(snapshot) as Box<dyn std::any::Any + Send + Sync>)
-                        }
-                    },
-                    node_def.action_key.as_str().to_owned(),
-                ))
-            } else {
-                default_credential_accessor()
-            };
+        let credentials: Arc<dyn CredentialAccessor> = if let Some(resolver_fn) =
+            &self.credential_resolver
+        {
+            let resolver_fn = Arc::clone(resolver_fn);
+            Arc::new(EngineCredentialAccessor::new(
+                allowed_keys,
+                move |id: &str| {
+                    let resolver_fn = Arc::clone(&resolver_fn);
+                    let credential_key_str = id.to_owned();
+                    async move {
+                        let snapshot = (resolver_fn)(&credential_key_str).await.map_err(|e| {
+                            tracing::debug!(
+                                credential_key = %credential_key_str,
+                                error = %e,
+                                "credential resolution failed"
+                            );
+                            nebula_core::CoreError::credential_not_found(
+                                CredentialKey::new(&credential_key_str).expect(
+                                    "credential key passed through allowlist must be valid",
+                                ),
+                            )
+                        })?;
+                        Ok(Box::new(snapshot) as Box<dyn std::any::Any + Send + Sync>)
+                    }
+                },
+                node_def.action_key.as_str().to_owned(),
+            ))
+        } else {
+            default_credential_accessor()
+        };
 
         // Build resource accessor: wrap the manager-backed global accessor in
         // a LayeredResourceAccessor (M6.1 — Phase 6). Phase 6 plugs in the
@@ -6251,9 +6261,15 @@ impl NodeTask {
         }
 
         let base = Arc::new(
-            nebula_core::BaseContext::builder()
-                .cancellation(self.cancel.child_token())
-                .build(),
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope {
+                execution_id: Some(self.execution_id),
+                workflow_id: Some(self.workflow_id),
+                ..nebula_core::scope::Scope::default()
+            })
+            .principal(nebula_core::scope::Principal::System)
+            .cancellation(self.cancel.child_token())
+            .build()
+            .expect("scope + principal must produce a valid BaseContext"),
         );
         let action_ctx = nebula_action::ActionRuntimeContext::new(
             base,
@@ -7747,7 +7763,7 @@ mod tests {
         ActionError, action::Action, context::CredentialContextExt, metadata::ActionMetadata,
         result::ActionResult, stateless::StatelessAction,
     };
-    use nebula_core::{Dependencies, action_key};
+    use nebula_core::{Dependencies, action_key, scope::Principal};
     use nebula_storage_port::StorageError;
     use nebula_storage_port::store::{ExecutionStore, NodeResultStore, WorkflowVersionStore};
     use nebula_workflow::{
@@ -8425,9 +8441,11 @@ mod tests {
     #[tokio::test]
     async fn trigger_context_construction_is_usable_in_engine() {
         let base = Arc::new(
-            nebula_core::BaseContext::builder()
+            nebula_core::BaseContext::builder(nebula_core::scope::Scope::default())
+                .principal(Principal::System)
                 .cancellation(CancellationToken::new())
-                .build(),
+                .build()
+                .expect("scope + principal must produce a valid BaseContext"),
         );
         let ctx =
             nebula_action::TriggerRuntimeContext::new(base, WorkflowId::new(), node_key!("test"));

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -5371,11 +5371,13 @@ impl WorkflowEngine {
                                 error = %e,
                                 "credential resolution failed"
                             );
-                            nebula_core::CoreError::credential_not_found(
-                                CredentialKey::new(&credential_key_str).expect(
-                                    "credential key passed through allowlist must be valid",
+                            match CredentialKey::new(&credential_key_str) {
+                                Ok(key) => nebula_core::CoreError::credential_not_found(key),
+                                Err(_) => nebula_core::CoreError::invalid_key(
+                                    credential_key_str.clone(),
+                                    "credential",
                                 ),
-                            )
+                            }
                         })?;
                         Ok(Box::new(snapshot) as Box<dyn std::any::Any + Send + Sync>)
                     }
@@ -6260,17 +6262,23 @@ impl NodeTask {
             }
         }
 
-        let base = Arc::new(
-            nebula_core::BaseContext::builder(nebula_core::scope::Scope {
-                execution_id: Some(self.execution_id),
-                workflow_id: Some(self.workflow_id),
-                ..nebula_core::scope::Scope::default()
-            })
-            .principal(nebula_core::scope::Principal::System)
-            .cancellation(self.cancel.child_token())
-            .build()
-            .expect("scope + principal must produce a valid BaseContext"),
-        );
+        let base = match nebula_core::BaseContext::builder(nebula_core::scope::Scope {
+            execution_id: Some(self.execution_id),
+            workflow_id: Some(self.workflow_id),
+            ..nebula_core::scope::Scope::default()
+        })
+        .principal(nebula_core::scope::Principal::System)
+        .cancellation(self.cancel.child_token())
+        .build()
+        {
+            Ok(ctx) => Arc::new(ctx),
+            Err(e) => {
+                return (
+                    self.node_key,
+                    Err(EngineError::PlanningFailed(e.to_string())),
+                );
+            },
+        };
         let action_ctx = nebula_action::ActionRuntimeContext::new(
             base,
             self.execution_id,

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -1218,6 +1218,7 @@ mod tests {
         context::Context,
         id::{ExecutionId, WorkflowId},
         node_key,
+        scope::{Principal, Scope},
     };
 
     use crate::runtime::runner::{ActionExecutor, InProcessRunner};
@@ -1280,7 +1281,12 @@ mod tests {
 
     fn test_context() -> ActionRuntimeContext {
         ActionRuntimeContext::new(
-            Arc::new(BaseContext::builder().build()),
+            Arc::new(
+                BaseContext::builder(Scope::default())
+                    .principal(Principal::System)
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
+            ),
             ExecutionId::new(),
             node_key!("test"),
             WorkflowId::new(),
@@ -1289,7 +1295,12 @@ mod tests {
 
     fn test_trigger_context() -> TriggerRuntimeContext {
         TriggerRuntimeContext::new(
-            Arc::new(BaseContext::builder().build()),
+            Arc::new(
+                BaseContext::builder(Scope::default())
+                    .principal(Principal::System)
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
+            ),
             WorkflowId::new(),
             node_key!("test"),
         )
@@ -1353,7 +1364,12 @@ mod tests {
 
         let eid = ExecutionId::new();
         let ctx = ActionRuntimeContext::new(
-            Arc::new(BaseContext::builder().build()),
+            Arc::new(
+                BaseContext::builder(Scope::default())
+                    .principal(Principal::System)
+                    .build()
+                    .expect("scope + principal must produce a valid BaseContext"),
+            ),
             eid,
             node_key!("test"),
             WorkflowId::new(),

--- a/crates/engine/src/scoped_resources.rs
+++ b/crates/engine/src/scoped_resources.rs
@@ -761,7 +761,7 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
 
-    use nebula_core::NodeKey;
+    use nebula_core::{CredentialKey, NodeKey};
 
     use super::*;
 
@@ -841,9 +841,10 @@ mod tests {
                     self.hits.fetch_add(1, Ordering::SeqCst);
                     Ok(Box::new(self.payload_marker) as ScopedLookup)
                 } else {
-                    Err(CoreError::CredentialNotFound {
-                        key: key_owned.as_str().to_owned(),
-                    })
+                    Err(CoreError::credential_not_found(
+                        CredentialKey::new(key_owned.as_str())
+                            .expect("ResourceKey format is CredentialKey-compatible"),
+                    ))
                 }
             })
         }

--- a/crates/engine/tests/scoped_resources.rs
+++ b/crates/engine/tests/scoped_resources.rs
@@ -31,7 +31,7 @@ use std::{
 
 use dashmap::DashMap;
 use nebula_core::{
-    CoreError, NodeKey, ResourceKey,
+    CoreError, CredentialKey, NodeKey, ResourceKey,
     accessor::ResourceAccessor,
     id::{ExecutionId, WorkflowId},
 };
@@ -92,8 +92,11 @@ impl ResourceAccessor for FakeGlobalAccessor {
             self.table
                 .get(&key)
                 .map(|v| Box::new(*v.value()) as Box<dyn std::any::Any + Send + Sync>)
-                .ok_or_else(|| CoreError::CredentialNotFound {
-                    key: key.as_str().to_owned(),
+                .ok_or_else(|| {
+                    CoreError::credential_not_found(
+                        CredentialKey::new(key.as_str())
+                            .expect("ResourceKey format is CredentialKey-compatible"),
+                    )
                 })
         })
     }

--- a/crates/resource/src/context.rs
+++ b/crates/resource/src/context.rs
@@ -123,11 +123,12 @@ impl ResourceContext {
     /// Creates a minimal context for cases that only need scope + cancellation
     /// (e.g., daemon loops, warmup). Uses no-op accessors internally.
     pub fn minimal(scope: Scope, cancellation: CancellationToken) -> Self {
-        let base = BaseContext::builder()
-            .scope(scope)
+        let base = BaseContext::builder(scope)
+            .principal(Principal::System)
             .cancellation(cancellation)
             .clock(SystemClock)
-            .build();
+            .build()
+            .expect("scope + principal must produce a valid BaseContext");
         Self {
             base,
             resources: Arc::new(NoopResourceAccessor),

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -279,10 +279,10 @@ impl Error {
             .unwrap_or_else(|| "resource".to_owned());
         let detail = self.to_string();
         match self.kind() {
-            ErrorKind::NotFound => nebula_core::CoreError::credential_not_found(
-                CredentialKey::new(&key_label)
-                    .expect("ResourceKey format is CredentialKey-compatible"),
-            ),
+            ErrorKind::NotFound => match CredentialKey::new(&key_label) {
+                Ok(key) => nebula_core::CoreError::credential_not_found(key),
+                Err(_) => nebula_core::CoreError::invalid_key(key_label, "credential"),
+            },
             ErrorKind::Ambiguous => nebula_core::CoreError::scope_violation(key_label, detail),
             ErrorKind::Cancelled => {
                 nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -7,7 +7,7 @@
 
 use std::{fmt, time::Duration};
 
-use nebula_core::ResourceKey;
+use nebula_core::{CredentialKey, ResourceKey};
 
 /// How the framework should handle this error.
 #[non_exhaustive]
@@ -279,7 +279,10 @@ impl Error {
             .unwrap_or_else(|| "resource".to_owned());
         let detail = self.to_string();
         match self.kind() {
-            ErrorKind::NotFound => nebula_core::CoreError::CredentialNotFound { key: detail },
+            ErrorKind::NotFound => nebula_core::CoreError::credential_not_found(
+                CredentialKey::new(&key_label)
+                    .expect("ResourceKey format is CredentialKey-compatible"),
+            ),
             ErrorKind::Ambiguous => nebula_core::CoreError::scope_violation(key_label, detail),
             ErrorKind::Cancelled => {
                 nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)

--- a/typos.toml
+++ b/typos.toml
@@ -24,6 +24,9 @@ extend-exclude = [
   "targets",
   # Local agent bundle / vendored patches (not Nebula sources).
   "openswarm",
+  # Multi-model audit-campaign reports — LLM-generated reference prose with
+  # their own vocabulary (abbreviations like `ser-Err`), not production code.
+  "audits",
 ]
 
 [default]


### PR DESCRIPTION
## Summary

Lands every actionable finding from the 10-model blind audit of `nebula-core` (`crates/core/audits/`) that does **not** require an architecture ADR. Six commits, gated green at each step; cross-crate ripple finished in-pass (no shims). Pre-1.0, breaking changes accepted where spec-correct.

## What's in it

- **Batch 1 — safe consensus** (`07ba6507`): fallible `Resource/CredentialRequirement` constructors (no more `panic!` in lib; derive macro emits compile-time `resource_key!`); `ResourceUnavailable{retryable:false}` category `Cancelled`→`Unavailable`; `Slug::new_unchecked` deleted (zero callers); `RefreshToken` field encapsulated; typed `CoreError::RegistryInvariant` (no longer lossily mapped to `DependencyMissing`).
- **typos config** (`13e47dcc`): exclude generated `audits/` reports from the spell-check hook.
- **Batch 2a — non-breaking** (`3e4aba79`): doc-drift fixed across README/lib.rs/AGENTS (CredentialId is defined here; dropped phantom `NodeId/TenantId/ProjectId/RoleId`; correct scope levels; `UlidParseError`; `PermissionDenied` in `tenancy`; no `SecretString` phantom); deleted deprecated `OrganizationId`; slug.rs gains a `#[cfg(test)]` module incl. an `is_prefixed_ulid` drift-guard; `ShutdownOutcome` `#[must_use]`; `AuthPattern` doc count fixed; `Scope::can_access` doc aligned to the actual exact-match-per-level semantics (behavior unchanged).
- **Batch 2b — typed tightening** (`44a2ceaf`): `RefreshCoordinator::acquire_refresh(&CredentialId)`; `PermissionDenied` carries a typed `PermissionDenial` enum (Workspace/Org, `#[non_exhaustive]`); `TraceId`/`SpanId` wrap private `NonZeroU128`/`NonZeroU64` (zero unrepresentable, serde rejects zero).
- **Batch 2c — fail-closed + typed errors** (`7b983c72`): `BaseContext::builder(scope)` requires scope and `build()` returns `Result` (missing principal is a typed error, not a silent `Principal::System`); `CredentialNotFound.key` is `CredentialKey`; `#[non_exhaustive]` on `Principal`+`ResolvedIds`. This surfaced and fixed two latent key-corruption bugs where the `key` field stored an error *message* (engine credential resolver; resource error mapping).
- **Review fixes** (`7bc6194f`): removed three reachable `.expect()` panics the typed-key/builder changes introduced (resolver, resource mapping, `NodeTask` build) — all now `match`-fallible to a typed `CoreError`; `PermissionDenial` Display now distinguishes workspace vs org; api error-classify fallback no longer half-populates; added builder tests.

## ⚠️ Breaking changes (internal crates only; `nebula-sdk` is the sole public surface)

`Resource/CredentialRequirement::new` signatures, `RefreshCoordinator::acquire_refresh`, `PermissionDenied` shape, `TraceId`/`SpanId` fields, `BaseContext::builder`/`build`, `CredentialNotFound.key`, and `#[non_exhaustive]` on `Principal`/`ResolvedIds`. All in-workspace call sites migrated.

## Deferred (need their own ADR/decision — intentionally not here)

- `Scope::can_access` hierarchical-vs-exact-match contract (security decision; doc aligned to exact-match for now).
- `Scope` typestate collapse + `#[non_exhaustive]` on `Scope` (would need a throwaway builder the typestate ADR replaces).
- `Box<dyn Any>` accessor erasure → typed ports (ADR-0109/0110).
- Typed `action_id` in credential errors (ADR-0106).

## Gate / test evidence

`cargo clippy --all-targets -- -D warnings` (core+engine+api+credential+resource), `cargo nextest run` (1860 across those 5 crates locally; 2313 across 140 binaries in the pre-push gate), `cargo check --workspace --all-targets`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo fmt --all` — all green. Pre-push `clippy-full` + `crate-diff-gate` (rustdoc -D warnings per changed crate) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved context handling across the app with stricter, more explicit runtime setup.
  * Added safer, typed handling for identifiers and trace context values.

* **Bug Fixes**
  * Fixed permission and access errors to show clearer, more structured details.
  * Improved fallback behavior for future or unknown identity types.
  * Strengthened validation for keys, slugs, and trace identifiers.

* **Documentation**
  * Updated public docs and examples to match current identifier and scope terminology.

* **Tests**
  * Expanded test coverage for context creation, error mapping, and trace parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->