### PR TITLE
fix(action): close audit findings (HMAC secret leak, derive attrs, dead validation, typed bounds)

### DIFF
--- a/crates/action/macros/src/field_slots.rs
+++ b/crates/action/macros/src/field_slots.rs
@@ -298,6 +298,15 @@ pub(crate) fn emit_slot_resolution_block(slots: &[ParsedSlotField]) -> (TokenStr
 
         // Build the per-slot resolution block. Each shape produces a
         // value of the field's declared type.
+        //
+        // Optional-slot discipline: `None` means "binding absent" — no
+        // explicit binding AND the default-id resolution also returned
+        // nothing. A binding that is present but fails resolution (e.g.
+        // the resource/credential id is invalid or inaccessible) is a
+        // hard error and must propagate, not silently become `None`.
+        // The `binding_present` variable captures whether an explicit
+        // binding was configured so the error arm can distinguish the
+        // two cases.
         let stmt = match (optional, lazy) {
             (false, false) => quote! {
                 let #field = {
@@ -317,10 +326,26 @@ pub(crate) fn emit_slot_resolution_block(slots: &[ParsedSlotField]) -> (TokenStr
             },
             (true, false) => quote! {
                 let #field = {
-                    let slot_id = #binding_call.unwrap_or(#slot_key_lit);
+                    let explicit_binding = #binding_call;
+                    let slot_id = explicit_binding.unwrap_or(#slot_key_lit);
                     match #resolve_call {
                         Ok(guard) => Some(guard),
-                        Err(_) => None,
+                        Err(e) => {
+                            if explicit_binding.is_some() {
+                                // Binding was configured but resolution failed —
+                                // propagate as a hard error, not a silent None.
+                                return Err(::nebula_action::ActionError::fatal(
+                                    format!(
+                                        "failed to resolve explicitly-bound {} slot `{}` (id `{}`): {}",
+                                        #kind_word, #slot_key_lit, slot_id, e,
+                                    )
+                                ));
+                            }
+                            // No explicit binding; default-id resolution returned
+                            // nothing — treat as absent.
+                            let _ = e;
+                            None
+                        }
                     }
                 };
             },
@@ -342,10 +367,22 @@ pub(crate) fn emit_slot_resolution_block(slots: &[ParsedSlotField]) -> (TokenStr
             },
             (true, true) => quote! {
                 let #field = {
-                    let slot_id = #binding_call.unwrap_or(#slot_key_lit);
+                    let explicit_binding = #binding_call;
+                    let slot_id = explicit_binding.unwrap_or(#slot_key_lit);
                     match #resolve_call {
                         Ok(guard) => Some(::nebula_core::sync::Lazy::with_value(guard)),
-                        Err(_) => None,
+                        Err(e) => {
+                            if explicit_binding.is_some() {
+                                return Err(::nebula_action::ActionError::fatal(
+                                    format!(
+                                        "failed to resolve explicitly-bound {} slot `{}` (id `{}`): {}",
+                                        #kind_word, #slot_key_lit, slot_id, e,
+                                    )
+                                ));
+                            }
+                            let _ = e;
+                            None
+                        }
                     }
                 };
             },

--- a/crates/action/macros/src/lib.rs
+++ b/crates/action/macros/src/lib.rs
@@ -60,7 +60,7 @@ mod field_slots;
 /// )]
 /// pub struct SlackSendAction;
 /// ```
-#[proc_macro_derive(Action, attributes(action, nebula))]
+#[proc_macro_derive(Action, attributes(action, nebula, resource, credential))]
 pub fn derive_action(input: TokenStream) -> TokenStream {
     action::derive(input)
 }

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -47,7 +47,31 @@ use crate::{
     stateless::StatelessAction,
     stream::StreamAction,
     trigger::{TriggerAction, TriggerEvent, TriggerEventOutcome},
+    validation::validate_action_package,
 };
+
+/// Validate action metadata at the start of `instantiate` — fail-closed.
+///
+/// Called once per dispatch by all `Generic*Factory` instantiate implementations.
+/// Because `ActionFactory::metadata()` is cached via `OnceLock`, the
+/// `validate_action_package` cost (a few allocations and comparisons) is paid
+/// every dispatch. The check is cheap relative to the I/O that follows. If a
+/// factory's action has structurally invalid metadata (empty key, duplicate
+/// ports, invalid support-port declarations) the engine never executes it,
+/// preventing silent data-integrity issues.
+///
+/// Callers that need to suppress validation for tests (e.g., deliberately
+/// invalid metadata fixtures) should call the underlying action directly
+/// rather than going through an `ActionFactory`.
+fn check_metadata_or_fatal(meta: &ActionMetadata) -> Result<(), ActionError> {
+    validate_action_package(meta).map_err(|validation_errors| {
+        ActionError::fatal(format!(
+            "action `{}` has invalid metadata; registration should have been rejected: {}",
+            meta.base.key.as_str(),
+            validation_errors,
+        ))
+    })
+}
 
 /// Object-safe factory trait — engine registry stores `Arc<dyn ActionFactory>`.
 ///
@@ -58,7 +82,8 @@ use crate::{
 ///
 /// # Errors
 ///
-/// Returns [`ActionError::Fatal`] if slot resolution fails or the factory
+/// Returns [`ActionError::Fatal`] if slot resolution fails, if action metadata
+/// validation fails (duplicate ports, empty key, etc.), or the factory
 /// otherwise cannot construct an executable action for this dispatch.
 pub trait ActionFactory: Send + Sync + 'static {
     /// Static metadata describing the action this factory produces.
@@ -119,6 +144,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = StatelessHandleImpl::<A>::new(action, meta);
@@ -331,6 +357,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = StatefulHandleImpl::<A>::new(action, meta);
@@ -470,6 +497,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = TriggerHandleImpl::<A>::new(action, meta);
@@ -577,6 +605,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = ResourceHandleImpl::<A>::new(action, meta);
@@ -674,6 +703,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = ControlHandleImpl::<A>::new(action, meta);
@@ -766,6 +796,7 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let inner = StreamHandleImpl::<A>::new(action, meta);
@@ -886,10 +917,119 @@ where
         ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
+            check_metadata_or_fatal(self.metadata())?;
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
             let adapter = crate::agent::AgentActionAdapter::<A>::new(action, meta);
             Ok(ActionHandle::Agent(Box::new(adapter)))
         })
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use nebula_core::{Dependencies, action_key, node_key};
+    use nebula_workflow::NodeDefinition;
+    use serde_json::Value;
+
+    use super::*;
+    use crate::{
+        StatelessAction, action::Action, metadata::ActionMetadata, result::ActionResult,
+        testing::TestContextBuilder,
+    };
+
+    // ── InvalidMetadataAction ────────────────────────────────────────────────
+    //
+    // A stateless action whose `metadata()` returns deliberately invalid
+    // data (empty name + empty description). The factory must refuse to
+    // instantiate it with `ActionError::Fatal` — fail-closed per FIX 3.
+
+    struct InvalidMetadataAction;
+
+    impl Action for InvalidMetadataAction {
+        type Input = Value;
+        type Output = Value;
+
+        fn metadata() -> ActionMetadata {
+            // Empty name and description trigger `MissingMetadataField`
+            // validation failures in `validate_action_package`.
+            ActionMetadata::new(action_key!("test.invalid_meta"), "", "")
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static DEPS: OnceLock<Dependencies> = OnceLock::new();
+            DEPS.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl StatelessAction for InvalidMetadataAction {
+        async fn execute(
+            &self,
+            _input: Value,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> Result<ActionResult<Value>, ActionError> {
+            Ok(ActionResult::success(Value::Null))
+        }
+    }
+
+    impl FromWorkflowNode for InvalidMetadataAction {
+        type Error = ActionError;
+
+        async fn from_workflow_node(
+            _node: &NodeDefinition,
+            _ctx: &dyn ActionContext,
+        ) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+    }
+
+    fn stub_node() -> NodeDefinition {
+        NodeDefinition::new(
+            node_key!("test_node"),
+            "Test Node",
+            "nebula.test",
+            "test.invalid_meta",
+        )
+        .expect("stub node key is valid")
+    }
+
+    /// `instantiate` on a factory whose action has invalid metadata (empty
+    /// name and description) must return `ActionError::Fatal`, not silently
+    /// dispatch with corrupted catalog data (FIX 3 — fail-closed).
+    #[tokio::test]
+    async fn instantiate_fails_fatal_on_invalid_metadata() {
+        let factory = GenericStatelessFactory::<InvalidMetadataAction>::new();
+        let node = stub_node();
+        let ctx = TestContextBuilder::new().build();
+
+        let result = factory.instantiate(&node, &ctx).await;
+
+        assert!(
+            matches!(result, Err(ActionError::Fatal { .. })),
+            "expected Fatal but got {result:?}",
+        );
+    }
+
+    /// The error message must name the invalid action key so operators know
+    /// which registration is broken without digging through logs.
+    #[tokio::test]
+    async fn instantiate_fatal_message_names_action_key() {
+        let factory = GenericStatelessFactory::<InvalidMetadataAction>::new();
+        let node = stub_node();
+        let ctx = TestContextBuilder::new().build();
+
+        let Err(ActionError::Fatal { error, .. }) = factory.instantiate(&node, &ctx).await else {
+            panic!("expected Fatal error");
+        };
+
+        let error_message = error.to_string();
+        assert!(
+            error_message.contains("test.invalid_meta"),
+            "error message should name the action key; got: {error_message}",
+        );
     }
 }

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -1032,4 +1032,79 @@ mod tests {
             "error message should name the action key; got: {error_message}",
         );
     }
+
+    // ── ValidMetadataAction ──────────────────────────────────────────────────
+    //
+    // A production-shaped stateless action with a non-empty name, description,
+    // and the default input+output ports from `ActionMetadata::new`. Proves
+    // that `check_metadata_or_fatal` does NOT reject valid metadata — the
+    // positive counterpart to the two fatal-path tests above.
+
+    struct ValidMetadataAction;
+
+    impl Action for ValidMetadataAction {
+        type Input = Value;
+        type Output = Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                action_key!("test.valid_meta"),
+                "Valid Metadata Action",
+                "A production-shaped action fixture used to prove the metadata gate passes valid registrations.",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static DEPS: OnceLock<Dependencies> = OnceLock::new();
+            DEPS.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl StatelessAction for ValidMetadataAction {
+        async fn execute(
+            &self,
+            _input: Value,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> Result<ActionResult<Value>, ActionError> {
+            Ok(ActionResult::success(Value::Null))
+        }
+    }
+
+    impl FromWorkflowNode for ValidMetadataAction {
+        type Error = ActionError;
+
+        async fn from_workflow_node(
+            _node: &NodeDefinition,
+            _ctx: &dyn ActionContext,
+        ) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+    }
+
+    /// A factory with valid metadata (non-empty name, description, default
+    /// ports) must succeed — `check_metadata_or_fatal` must not block valid
+    /// registrations (positive counterpart to the two fatal-path tests).
+    #[tokio::test]
+    async fn instantiate_succeeds_with_valid_metadata() {
+        let factory = GenericStatelessFactory::<ValidMetadataAction>::new();
+        let node = NodeDefinition::new(
+            node_key!("test_node"),
+            "Test Node",
+            "nebula.test",
+            "test.valid_meta",
+        )
+        .expect("stub node key is valid");
+        let ctx = TestContextBuilder::new().build();
+
+        let result = factory.instantiate(&node, &ctx).await;
+
+        assert!(
+            result.is_ok(),
+            "valid metadata must not produce a Fatal error; got: {result:?}",
+        );
+        assert!(
+            matches!(result.unwrap(), ActionHandle::Stateless(_)),
+            "valid metadata action should produce a Stateless handle",
+        );
+    }
 }

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -170,8 +170,8 @@ pub use validation::{
     ActionPackageValidationError, ActionPackageValidationErrors, validate_action_package,
 };
 pub use webhook::{
-    BuiltWebhookHandler, Clock, DEFAULT_MAX_BODY_BYTES, FactoryError, MAX_HEADER_COUNT, MockClock,
-    PreHandleOutcome, RequiredPolicy, SignatureError, SignatureOutcome, SignaturePolicy,
+    BuiltWebhookHandler, Clock, DEFAULT_MAX_BODY_BYTES, FactoryError, HmacSecret, MAX_HEADER_COUNT,
+    MockClock, PreHandleOutcome, RequiredPolicy, SignatureError, SignatureOutcome, SignaturePolicy,
     SignatureScheme, SystemClock, TimestampFormat, WebhookAction, WebhookActionFactory,
     WebhookActivationSpec, WebhookConfig, WebhookEndpointProvider, WebhookHttpResponse,
     WebhookProvider, WebhookRequest, WebhookResponse, WebhookSource, WebhookTriggerAdapter,

--- a/crates/action/src/resource.rs
+++ b/crates/action/src/resource.rs
@@ -9,7 +9,10 @@ use std::{any::Any, fmt, future::Future};
 
 use serde_json::Value;
 
-use crate::{action::Action, context::ActionContext, error::ActionError, metadata::ActionMetadata};
+use crate::{
+    action::Action, context::ActionContext, error::ActionError, metadata::ActionMetadata,
+    resource_produces::ResourceProduces,
+};
 
 // ── Core trait ──────────────────────────────────────────────────────────────
 
@@ -28,7 +31,14 @@ use crate::{action::Action, context::ActionContext, error::ActionError, metadata
 /// downcast to `Instance`, so any impl where they differed failed at
 /// runtime with `ActionError::Fatal`. Zero production impls ever used
 /// distinct types, so the split was removed rather than patched.
-pub trait ResourceAction: Action {
+///
+/// # Output type constraint
+///
+/// The `Action::Output` associated type is constrained to
+/// `ResourceProduces<Self::Resource>`. This means the compiler enforces
+/// that a `ResourceAction`'s output marker is tied to its own `Resource`
+/// type — mismatches surface at impl time, not at runtime.
+pub trait ResourceAction: Action<Output = ResourceProduces<Self::Resource>> {
     /// Resource produced by `configure`, consumed by `cleanup`.
     type Resource: Send + Sync + 'static;
 
@@ -202,7 +212,9 @@ mod tests {
 
     impl Action for MockResourceAction {
         type Input = Value;
-        type Output = Value;
+        // ResourceAction requires Output = ResourceProduces<Self::Resource>.
+        // MockResourceAction::Resource = String, so Output = ResourceProduces<String>.
+        type Output = ResourceProduces<String>;
 
         fn metadata() -> ActionMetadata {
             ActionMetadata::new(

--- a/crates/action/src/resource_produces.rs
+++ b/crates/action/src/resource_produces.rs
@@ -108,6 +108,35 @@ impl<R: ?Sized> fmt::Debug for ResourceProduces<R> {
     }
 }
 
+// ── Trait impls required by `Action::Output` bounds ─────────────────────────
+
+/// `Serialize` impl for the `Action::Output` bound.
+///
+/// `ResourceProduces<R>` is a graph-topology marker — it carries no workflow
+/// payload. Serialises to a small JSON object carrying the topology tag so
+/// the engine can log/inspect the marker without needing reflection.
+impl<R: ?Sized> serde::Serialize for ResourceProduces<R> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct as _;
+        let mut state = serializer.serialize_struct("ResourceProduces", 1)?;
+        // TopologyTag has no Serialize impl; its string form is stable and safe to log.
+        state.serialize_field("topology", self.topology.as_str())?;
+        state.end()
+    }
+}
+
+/// `HasSchema` impl for the `Action::Output` bound.
+///
+/// The schema is empty (`SchemaKind::Record` with no fields): `ResourceProduces<R>`
+/// is a graph-topology marker that produces no user-visible output fields. The
+/// engine and catalog read the topology tag directly from the value, not from
+/// the schema.
+impl<R: ?Sized> nebula_schema::HasSchema for ResourceProduces<R> {
+    fn schema() -> nebula_schema::ValidSchema {
+        nebula_schema::ValidSchema::empty()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/action/src/trigger/source.rs
+++ b/crates/action/src/trigger/source.rs
@@ -23,14 +23,18 @@
 pub trait TriggerSource: Send + Sync + 'static {
     /// Concrete event type this source delivers to the trigger handler.
     ///
-    /// `Send + Sync + 'static` matches the dyn boundary's
+    /// `Any + Send + Sync + 'static` matches the dyn boundary's
     /// [`TriggerEvent`](crate::trigger::TriggerEvent) payload requirement
     /// (`Box<dyn Any + Send + Sync>` + `downcast::<T>` requiring
-    /// `T: Any + Send + Sync + 'static`). Tightening the bound here means
+    /// `T: Any + Send + Sync + 'static`). The `Any` bound is load-bearing:
+    /// [`TriggerEvent::new`](crate::trigger::TriggerEvent::new) and
+    /// [`TriggerEvent::downcast`](crate::trigger::TriggerEvent::downcast)
+    /// both require it, so omitting it would compile the trigger definition
+    /// but panic at the downcast site. Tightening the bound here means
     /// downstream registries / adapters never need to repeat it.
     ///
     /// Examples: `WebhookSource::Event = WebhookRequest`,
     /// `PollSource::Event = ()` (poll triggers self-drive their cycle and
     /// never receive pushed events — see [`crate::poll::PollSource`]).
-    type Event: Send + Sync + 'static;
+    type Event: std::any::Any + Send + Sync + 'static;
 }

--- a/crates/action/src/webhook/factory.rs
+++ b/crates/action/src/webhook/factory.rs
@@ -14,11 +14,79 @@
 //! natively. The engine simply maintains a string-keyed map of
 //! factories.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
-use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 use crate::{trigger::TriggerHandler, webhook::WebhookConfig};
+
+// ── HmacSecret ──────────────────────────────────────────────────────────────
+
+/// Redacting wrapper for an HMAC verification secret carried in
+/// [`WebhookActivationSpec`].
+///
+/// # Security guarantees
+///
+/// - `Debug` prints `HmacSecret([REDACTED; N bytes])` — the raw bytes never
+///   appear in logs, tracing output, or structured serialization.
+/// - `Serialize` / `Deserialize` are intentionally **not** derived: the secret
+///   is resolved at runtime from a credential store (not stored inline in the
+///   spec row) and therefore has no place in any serialized envelope. Call
+///   sites that truly need to persist a secret must do so through the
+///   credential subsystem, not through this type.
+/// - The inner `Vec<u8>` is zeroed on drop via [`Zeroize`] so the bytes are
+///   not left dangling in freed heap memory.
+///
+/// # Accessing the bytes
+///
+/// Use [`HmacSecret::reveal`] at the one call site that needs the raw bytes
+/// for HMAC computation — the factory `build` implementations.
+#[derive(Clone)]
+pub struct HmacSecret(Vec<u8>);
+
+impl HmacSecret {
+    /// Wrap raw HMAC secret bytes.
+    #[must_use]
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    /// Expose the raw bytes for HMAC computation.
+    ///
+    /// Keep the returned slice as short-lived as possible — pass directly to
+    /// the HMAC primitive without binding to a named `let` that lingers in
+    /// scope.
+    #[must_use]
+    pub fn reveal(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Number of bytes in the secret (safe to log — reveals length, not content).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the secret is empty (empty secrets are the fail-closed default).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for HmacSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HmacSecret([REDACTED; {} bytes])", self.0.len())
+    }
+}
+
+impl Drop for HmacSecret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+// ── WebhookActivationSpec ────────────────────────────────────────────────────
 
 /// Operator-supplied parameters for an activation.
 ///
@@ -30,16 +98,22 @@ use crate::{trigger::TriggerHandler, webhook::WebhookConfig};
 /// interprets — Slack and Stripe use it for nothing today; Generic
 /// uses it for `challenge_token`. Future providers can extend without
 /// adding fields here.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// # Security: `secret` is redacted
+///
+/// The [`HmacSecret`] field does not implement `Serialize` / `Deserialize` and
+/// its `Debug` output is redacted. Call [`WebhookActivationSpec::secret`] to
+/// access a reference, or [`WebhookActivationSpec::into_secret`] to take
+/// ownership (e.g. when passing into a factory builder). The secret bytes are
+/// zeroed on drop.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct WebhookActivationSpec {
     /// `"slack" | "stripe" | "generic"` — keys the factory registry.
     pub action_kind: String,
-    /// HMAC secret material as raw bytes. Storage layers should
-    /// resolve this from a credential reference rather than store
-    /// raw bytes inline; see for the secret-handling
-    /// rationale.
-    pub secret: Vec<u8>,
+    /// HMAC secret material. Resolved at runtime from the credential store;
+    /// never serialized to disk or logs. Access via [`Self::secret`].
+    secret: HmacSecret,
     /// Replay window in seconds. `None` defers to the provider's
     /// published default (5 min for Slack, Stripe; opt-in for
     /// Generic).
@@ -66,13 +140,31 @@ impl WebhookActivationSpec {
     pub fn new(action_kind: impl Into<String>, secret: impl Into<Vec<u8>>) -> Self {
         Self {
             action_kind: action_kind.into(),
-            secret: secret.into(),
+            secret: HmacSecret::new(secret),
             replay_window_secs: None,
             timestamp_header: None,
             timestamp_format: None,
             provider_config: None,
             rate_limit_per_minute: None,
         }
+    }
+
+    /// Borrow the HMAC secret bytes.
+    ///
+    /// Use only at the HMAC computation call site; do not bind to a
+    /// long-lived variable.
+    #[must_use]
+    pub fn secret(&self) -> &HmacSecret {
+        &self.secret
+    }
+
+    /// Consume the spec, returning the HMAC secret.
+    ///
+    /// Use when the factory needs to take ownership of the secret bytes
+    /// to pass into a provider action constructor (`impl Into<Arc<[u8]>>`).
+    #[must_use]
+    pub fn into_secret(self) -> HmacSecret {
+        self.secret
     }
 
     /// Override the timestamp encoding (Unix seconds / Unix
@@ -109,6 +201,86 @@ impl WebhookActivationSpec {
     pub fn with_rate_limit_per_minute(mut self, rpm: u64) -> Self {
         self.rate_limit_per_minute = Some(rpm);
         self
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET_BYTES: &[u8] = b"super-secret-hmac-key";
+
+    /// `HmacSecret`'s `Debug` output must never contain the raw secret bytes.
+    /// This is a security invariant: if the type is formatted in a log or span
+    /// field, the key material must not leak (FIX 1).
+    #[test]
+    fn hmac_secret_debug_is_redacted() {
+        let secret = HmacSecret::new(SECRET_BYTES);
+        let debug_output = format!("{secret:?}");
+
+        assert!(
+            !debug_output.contains("super-secret-hmac-key"),
+            "raw secret must not appear in Debug output; got: {debug_output}",
+        );
+        assert!(
+            !debug_output.contains("115"), // 's' in ASCII — numeric form should not appear
+            "Debug must not contain raw byte values; got: {debug_output}",
+        );
+        // Length is safe to reveal (does not expose key material).
+        assert!(
+            debug_output.contains(&SECRET_BYTES.len().to_string()),
+            "Debug should report byte length for observability; got: {debug_output}",
+        );
+    }
+
+    /// `WebhookActivationSpec` formatted via `Debug` must not expose the secret.
+    /// The spec is the envelope carried through factory dispatch — it may appear
+    /// in tracing spans if a caller derives span fields from it.
+    #[test]
+    fn webhook_activation_spec_debug_redacts_secret() {
+        let spec = WebhookActivationSpec::new("slack", SECRET_BYTES);
+        let debug_output = format!("{spec:?}");
+
+        assert!(
+            !debug_output.contains("super-secret-hmac-key"),
+            "raw secret must not appear in spec Debug output; got: {debug_output}",
+        );
+    }
+
+    /// `HmacSecret` must grant access to the raw bytes only via `reveal()`,
+    /// and `reveal()` must return the original bytes unchanged.
+    #[test]
+    fn hmac_secret_reveal_returns_original_bytes() {
+        let secret = HmacSecret::new(SECRET_BYTES);
+        assert_eq!(secret.reveal(), SECRET_BYTES);
+    }
+
+    /// `HmacSecret::len` returns the byte count, not the string length of the
+    /// redacted representation — a caller must not use this to infer key material.
+    #[test]
+    fn hmac_secret_len_matches_byte_count() {
+        let secret = HmacSecret::new(SECRET_BYTES);
+        assert_eq!(secret.len(), SECRET_BYTES.len());
+        assert!(!secret.is_empty());
+    }
+
+    /// An empty `HmacSecret` is considered empty — callers can gate on this.
+    #[test]
+    fn hmac_secret_empty_is_detected() {
+        let secret = HmacSecret::new(Vec::<u8>::new());
+        assert!(secret.is_empty());
+        assert_eq!(secret.len(), 0);
+    }
+
+    /// `WebhookActivationSpec::into_secret` transfers ownership so the caller
+    /// can pass the secret directly to the HMAC primitive without cloning.
+    #[test]
+    fn webhook_activation_spec_into_secret_transfers_bytes() {
+        let spec = WebhookActivationSpec::new("generic", SECRET_BYTES);
+        let secret = spec.into_secret();
+        assert_eq!(secret.reveal(), SECRET_BYTES);
     }
 }
 

--- a/crates/action/src/webhook/factory.rs
+++ b/crates/action/src/webhook/factory.rs
@@ -220,13 +220,15 @@ mod tests {
         let secret = HmacSecret::new(SECRET_BYTES);
         let debug_output = format!("{secret:?}");
 
+        // The raw secret string must not appear — this is the load-bearing assertion.
         assert!(
             !debug_output.contains("super-secret-hmac-key"),
             "raw secret must not appear in Debug output; got: {debug_output}",
         );
+        // The redaction marker must be present so consumers know the field was intentionally hidden.
         assert!(
-            !debug_output.contains("115"), // 's' in ASCII — numeric form should not appear
-            "Debug must not contain raw byte values; got: {debug_output}",
+            debug_output.contains("REDACTED"),
+            "Debug output must include REDACTED marker; got: {debug_output}",
         );
         // Length is safe to reveal (does not expose key material).
         assert!(

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -63,7 +63,9 @@ use std::{
 };
 
 pub use clock::{Clock, MockClock, SystemClock};
-pub use factory::{BuiltWebhookHandler, FactoryError, WebhookActionFactory, WebhookActivationSpec};
+pub use factory::{
+    BuiltWebhookHandler, FactoryError, HmacSecret, WebhookActionFactory, WebhookActivationSpec,
+};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use bytes::Bytes;

--- a/crates/action/src/webhook/providers/generic.rs
+++ b/crates/action/src/webhook/providers/generic.rs
@@ -279,7 +279,7 @@ impl WebhookActionFactory for GenericWebhookActionFactory {
     }
 
     fn build(&self, spec: &WebhookActivationSpec) -> Result<BuiltWebhookHandler, FactoryError> {
-        let mut action = GenericWebhookAction::new(spec.secret.clone());
+        let mut action = GenericWebhookAction::new(spec.secret().reveal().to_vec());
         if let Some(secs) = spec.replay_window_secs {
             action = action.with_replay_window(std::time::Duration::from_secs(secs));
         }

--- a/crates/action/src/webhook/providers/slack.rs
+++ b/crates/action/src/webhook/providers/slack.rs
@@ -202,7 +202,7 @@ impl WebhookActionFactory for SlackWebhookActionFactory {
     }
 
     fn build(&self, spec: &WebhookActivationSpec) -> Result<BuiltWebhookHandler, FactoryError> {
-        let mut action = SlackWebhookAction::new(spec.secret.clone());
+        let mut action = SlackWebhookAction::new(spec.secret().reveal().to_vec());
         if let Some(secs) = spec.replay_window_secs {
             action = action.with_replay_window(Duration::from_secs(secs));
         }

--- a/crates/action/src/webhook/providers/stripe.rs
+++ b/crates/action/src/webhook/providers/stripe.rs
@@ -285,7 +285,7 @@ impl WebhookActionFactory for StripeWebhookActionFactory {
     }
 
     fn build(&self, spec: &WebhookActivationSpec) -> Result<BuiltWebhookHandler, FactoryError> {
-        let mut action = StripeWebhookAction::new(spec.secret.clone());
+        let mut action = StripeWebhookAction::new(spec.secret().reveal().to_vec());
         if let Some(secs) = spec.replay_window_secs {
             action = action.with_tolerance(Duration::from_secs(secs));
         }

--- a/crates/action/tests/probes/derive_both_resource_and_credential.stderr
+++ b/crates/action/tests/probes/derive_both_resource_and_credential.stderr
@@ -6,26 +6,6 @@ error: field has both `#[resource]` and `#[credential]` attributes — only one 
 19 | |     overloaded: CredentialGuard<FakeCred>,
    | |_________________________________________^
 
-error: cannot find attribute `resource` in this scope
-  --> tests/probes/derive_both_resource_and_credential.rs:17:7
-   |
-17 |     #[resource]
-   |       ^^^^^^^^
-   |
-help: the derive macro `Error` accepts the similarly named `source` attribute
-   |
-17 -     #[resource]
-17 +     #[source]
-   |
-
-error: cannot find attribute `credential` in this scope
-  --> tests/probes/derive_both_resource_and_credential.rs:18:7
-   |
-18 |     #[credential]
-   |       ^^^^^^^^^^
-   |
-   = note: `credential` is an attribute that can be used by the derive macros `Credential` and `Resource`, you might be missing a `derive` attribute
-
 error[E0277]: the trait bound `FakeCred: zeroize::DefaultIsZeroes` is not satisfied
   --> tests/probes/derive_both_resource_and_credential.rs:19:17
    |

--- a/crates/action/tests/probes/derive_conflicting_slot_keys.stderr
+++ b/crates/action/tests/probes/derive_conflicting_slot_keys.stderr
@@ -4,22 +4,6 @@ error: duplicate slot key `shared` on this field — same slot key is already de
 18 |     cred_b: CredentialGuard<FakeCred>,
    |     ^^^^^^
 
-error: cannot find attribute `credential` in this scope
-  --> tests/probes/derive_conflicting_slot_keys.rs:15:7
-   |
-15 |     #[credential(key = "shared")]
-   |       ^^^^^^^^^^
-   |
-   = note: `credential` is an attribute that can be used by the derive macros `Credential` and `Resource`, you might be missing a `derive` attribute
-
-error: cannot find attribute `credential` in this scope
-  --> tests/probes/derive_conflicting_slot_keys.rs:17:7
-   |
-17 |     #[credential(key = "shared")]
-   |       ^^^^^^^^^^
-   |
-   = note: `credential` is an attribute that can be used by the derive macros `Credential` and `Resource`, you might be missing a `derive` attribute
-
 error[E0277]: the trait bound `FakeCred: zeroize::DefaultIsZeroes` is not satisfied
   --> tests/probes/derive_conflicting_slot_keys.rs:16:13
    |

--- a/crates/action/tests/probes/derive_credential_on_wrong_type.stderr
+++ b/crates/action/tests/probes/derive_credential_on_wrong_type.stderr
@@ -3,11 +3,3 @@ error: field with `#[credential]` must have type `CredentialGuard<T>` (optionall
    |
 13 |     not_a_guard: u32,
    |                  ^^^
-
-error: cannot find attribute `credential` in this scope
-  --> tests/probes/derive_credential_on_wrong_type.rs:12:7
-   |
-12 |     #[credential]
-   |       ^^^^^^^^^^
-   |
-   = note: `credential` is an attribute that can be used by the derive macros `Credential` and `Resource`, you might be missing a `derive` attribute

--- a/crates/action/tests/probes/derive_resource_on_wrong_type.stderr
+++ b/crates/action/tests/probes/derive_resource_on_wrong_type.stderr
@@ -3,15 +3,3 @@ error: field with `#[resource]` must have type `ResourceGuard<T>` (optionally wr
    |
 16 |     not_a_guard: String,
    |                  ^^^^^^
-
-error: cannot find attribute `resource` in this scope
-  --> tests/probes/derive_resource_on_wrong_type.rs:15:7
-   |
-15 |     #[resource]
-   |       ^^^^^^^^
-   |
-help: the derive macro `Error` accepts the similarly named `source` attribute
-   |
-15 -     #[resource]
-15 +     #[source]
-   |

--- a/crates/action/tests/resource_roundtrip.rs
+++ b/crates/action/tests/resource_roundtrip.rs
@@ -12,7 +12,7 @@ use std::sync::{
 
 use nebula_action::{
     Action, ActionError, ActionMetadata, ActionRuntimeContext, ResourceAction,
-    ResourceActionAdapter, ResourceHandler, TestContextBuilder,
+    ResourceActionAdapter, ResourceHandler, ResourceProduces, TestContextBuilder,
 };
 use nebula_core::Dependencies;
 
@@ -37,7 +37,8 @@ struct PoolAction {
 
 impl Action for PoolAction {
     type Input = serde_json::Value;
-    type Output = serde_json::Value;
+    // ResourceAction requires Output = ResourceProduces<Self::Resource>.
+    type Output = ResourceProduces<PoolHandle>;
 
     fn metadata() -> ActionMetadata {
         ActionMetadata::new(

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -2181,7 +2181,7 @@ mod tests {
 
     #[tokio::test]
     async fn resource_rejection_does_not_increment_execution_metrics() {
-        use nebula_action::{FromWorkflowNode, ResourceAction};
+        use nebula_action::{FromWorkflowNode, ResourceAction, ResourceProduces};
 
         // Minimal ResourceAction fixture — never invoked, only its ActionHandle
         // variant matters for the rejection test.
@@ -2189,7 +2189,8 @@ mod tests {
 
         impl Action for FakeResource {
             type Input = serde_json::Value;
-            type Output = serde_json::Value;
+            // ResourceAction requires Output = ResourceProduces<Self::Resource>.
+            type Output = ResourceProduces<serde_json::Value>;
 
             fn metadata() -> ActionMetadata {
                 ActionMetadata::new(


### PR DESCRIPTION
## Summary

Closes the safe (non-ADR) findings from the multi-model `nebula-action` audit (`crates/action/audits/`). Pre-1.0 breaking-OK, no shims; gated with `--all-targets`.

## Fixes

- **HIGH (security) — WebhookActivationSpec leaked the HMAC verification secret.** `pub secret: Vec<u8>` with derived `Debug`/`Serialize` exposed the secret in logs/serialized output. Introduced an `HmacSecret` newtype: redacting `Debug` (`HmacSecret([REDACTED; N bytes])`), no `Serialize`/`Deserialize`, `zeroize`-on-drop, with an explicit `reveal()` accessor consumed directly by the HMAC primitive. The storage-layer spec (separate type) already keys by `secret_id`, so no serialization escape remains.
- **derive(Action) helper attributes** — `attributes(action, nebula)` → `(…, resource, credential)` so `#[resource]`/`#[credential]` field slots resolve; trybuild `.stderr` snapshots updated (spurious secondary errors removed; primary fail-closed rejections retained).
- **dead validation wired fail-closed** — `validate_action_package` now runs in `Generic*Factory::instantiate`; invalid metadata returns a Fatal error instead of being silently accepted. Positive- and negative-path tests added.
- **typed `ResourceAction` output** — `ResourceAction: Action<Output = ResourceProduces<Self::Resource>>` makes a mismatched produce a compile error (was runtime). Downstream `impl ResourceAction` fixtures updated across action + engine.
- **optional-slot error fidelity** — generated field-slot code now distinguishes "binding absent" (→ `None`) from "binding present but resolution failed" (→ `Fatal`), no longer masking an auth failure as an absent slot.
- **`TriggerSource::Event: Any + …`** — adds the `Any` bound the downcast paths require.

## Deferred (ADR-tier — routing seam)

`PortKey`/`BranchKey` newtype validation, the `main`/`out` routing canonicalization + declared-port fail-closed enforcement, the capability-slot `Box<dyn Any>` typed-accessor redesign, and input-schema stamping — these belong to the routing ADR (project_w0_port_seam_plan / ADR-0109), not this batch.

## Gate

`cargo check --workspace --all-targets` clean · `cargo clippy -p nebula-action -p nebula-engine --all-targets -- -D warnings` clean · `cargo nextest run -p nebula-action -p nebula-engine` 878/878 · `cargo fmt` clean · pre-push clippy-full + crate-diff-gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)