### PR TITLE
fix(resource): land nebula-resource audit — verified workflow fix set

### DIFF
--- a/crates/core/src/context/mod.rs
+++ b/crates/core/src/context/mod.rs
@@ -165,6 +165,30 @@ impl BaseContextBuilder {
             span_id: self.span_id,
         })
     }
+
+    /// Build the [`BaseContext`] with the given principal, infallibly.
+    ///
+    /// The principal is supplied here rather than via
+    /// [`principal`](Self::principal), so the only failure path of
+    /// [`build`](Self::build) (a missing principal) is eliminated by
+    /// construction — this cannot return an error. Any principal previously
+    /// staged via [`principal`](Self::principal) is overridden by the argument.
+    ///
+    /// Prefer this on hot / background paths (warmup, maintenance, type-erased
+    /// acquire dispatch) where a `.build().expect(...)` would otherwise sit and
+    /// harden into a real panic if the builder contract ever widens.
+    pub fn build_with(self, principal: Principal) -> BaseContext {
+        BaseContext {
+            scope: self.scope,
+            principal,
+            cancellation: self.cancellation.unwrap_or_default(),
+            clock: self
+                .clock
+                .unwrap_or_else(|| Box::new(crate::accessor::SystemClock)),
+            trace_id: self.trace_id,
+            span_id: self.span_id,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -108,7 +108,7 @@ pub use nebula_plugin::{Plugin, PluginKey, PluginManifest, PluginRegistry, Resol
 pub use node_output::NodeOutput;
 pub use resource::{
     KindActivator, RegisterRequest, RegistrarError, ResourceActivatorRegistry, ResourceFactory,
-    ResourceRegistrationOutcome,
+    ResourceRegistrationOutcome, SlotBinding,
 };
 pub use resource_accessor::EngineResourceAccessor;
 pub use resource_status::{

--- a/crates/engine/src/resource/mod.rs
+++ b/crates/engine/src/resource/mod.rs
@@ -11,5 +11,5 @@
 
 pub use nebula_resource::{
     KindActivator, RegisterRequest, RegistrarError, ResourceActivatorRegistry, ResourceFactory,
-    ResourceRegistrationOutcome,
+    ResourceRegistrationOutcome, SlotBinding,
 };

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -319,8 +319,7 @@ async fn wired_registrar_performs_typed_registration() {
             RegisterRequest {
                 config_json: serde_json::json!({ "label": "wired" }),
                 expr_engine: &expr,
-                slot_bindings: HashMap::new(),
-                credential_ids: HashMap::new(),
+                slot_bindings: Vec::new(),
                 scope: ScopeLevel::Global,
                 recovery_gate: None,
             },

--- a/crates/engine/tests/resource_slot_identity_cross_crate.rs
+++ b/crates/engine/tests/resource_slot_identity_cross_crate.rs
@@ -31,12 +31,9 @@
 //! and the engine accessor's independent acquire-path derive
 //! ([`slot_identities_for_key`]) agrees with the register-path value.
 
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
 };
 
 use nebula_core::{
@@ -45,7 +42,7 @@ use nebula_core::{
     resource_key,
 };
 use nebula_engine::{
-    KindActivator, RegisterRequest, ResourceActivatorRegistry,
+    KindActivator, RegisterRequest, ResourceActivatorRegistry, SlotBinding,
     resource_accessor::slot_identities_for_key,
 };
 use nebula_expression::ExpressionEngine;
@@ -192,20 +189,18 @@ fn registrars() -> ResourceActivatorRegistry {
 }
 
 fn request<'a>(expr: &'a ExpressionEngine, bindings: &[(&str, &str)]) -> RegisterRequest<'a> {
-    let slot_bindings: HashMap<String, CredentialKey> = bindings
+    let slot_bindings: Vec<SlotBinding> = bindings
         .iter()
-        .map(|(slot, cred)| {
-            (
-                (*slot).to_owned(),
-                CredentialKey::new(*cred).expect("valid credential key"),
-            )
+        .map(|(slot, cred)| SlotBinding {
+            slot_name: (*slot).to_owned(),
+            credential_key: CredentialKey::new(*cred).expect("valid credential key"),
+            credential_id: None,
         })
         .collect();
     RegisterRequest {
         config_json: serde_json::json!({ "label": "x" }),
         expr_engine: expr,
         slot_bindings,
-        credential_ids: HashMap::new(),
         scope: ScopeLevel::Global,
         recovery_gate: None,
     }

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -10,6 +10,9 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
+# Internal crate — only `nebula-sdk` is the public/publishable surface. Guard
+# against an accidental `cargo publish` leaking this adapter to crates.io.
+publish = false
 
 [features]
 default = []

--- a/crates/resource/README.md
+++ b/crates/resource/README.md
@@ -144,11 +144,11 @@ The framework resolves declared `#[credential]` slots **before** invoking `Resou
 - `ReleaseQueue` — background worker pool for async cleanup. Drain on crash is best-effort; see §11.4 canon note.
 - `DrainTimeoutPolicy` — policy controlling drain operation timeout.
 - `ReloadOutcome` — result of `Manager::reload_config` (`NoChange` / `SwappedImmediately`).
-- `Error`, `ErrorKind`, `ErrorScope` — typed error with retry classification.
+- `Error`, `ErrorKind` — typed error with retry classification.
 - `ResourceContext` — execution context with cancellation and capability traits (`HasResources`, `HasCredentials`).
 - `ScopeLevel` — re-exported from `nebula_core::ScopeLevel`.
 - `ResourcePhase`, `ResourceStatus` — lifecycle phase tracking for observability.
-- `ResourceEvent` — lifecycle events (`Registered`, `Removed`, `AcquireSuccess`, `AcquireFailed`, `Released`, `HealthChanged`, `ConfigReloaded`, `RetryAttempt`, `BackpressureDetected`, `RecoveryGateChanged`, `SlotRefreshed`, `SlotRevoked`, `SlotRefreshFailed`, `SlotRevokeFailed`).
+- `ResourceEvent` — lifecycle events (`Registered`, `Removed`, `AcquireSuccess`, `AcquireFailed`, `Released`, `HealthChanged`, `ConfigReloaded`, `RetryAttempt`, `BackpressureDetected`, `RecoveryGateChanged`, `SlotRefreshed`, `SlotRevoked`, `SlotRefreshFailed`, `SlotRevokeFailed`, `MaintenanceEvicted`, `HoldDeadlineExceeded`).
 - `ResourceOpsMetrics`, `ResourceOpsSnapshot` — registry-backed operation counters.
 - `RecoveryGate`, `RecoveryGateConfig`, `RecoveryTicket`, `RecoveryWaiter`, `GateState` — thundering-herd recovery gate.
 - Open `Topology<R>` trait + framework topology structs `Pooled<R>` / `Resident<R>` / `Bounded<R>` (reached monomorphically through `Provider::Topology`; no dispatch enum — the framework owns the acquire loop).

--- a/crates/resource/docs/DESIGN.md
+++ b/crates/resource/docs/DESIGN.md
@@ -34,7 +34,7 @@
 | `ResourceGuard<R>` (RAII Owned/Guarded); `ResourceRef<R>` (lazy-ссылка) | `src/guard.rs:99`; `src/resource_ref.rs:55` |
 | `Registry`, sealed `ManagedHandle`, `LookupOutcome` — type-erased хранилище, scope-aware lookup | `src/registry.rs:391,61,297` |
 | `ReleaseQueue` — best-effort async drain (§11.4); `RecoveryGate`+`RecoveryTicket`/`RecoveryWaiter`/`GateState` — thundering-herd | `src/release_queue.rs:106`; `src/recovery/gate.rs:327` |
-| `Error`/`ErrorKind`/`ErrorScope`; `ResourceEvent`; `ResourceOpsMetrics`/`ResourceOpsSnapshot` | `src/error.rs:15,119,127`; `src/events.rs:20`; `src/metrics.rs:78,370` |
+| `Error`/`ErrorKind`; `ResourceEvent`; `ResourceOpsMetrics`/`ResourceOpsSnapshot` | `src/error.rs:13,113`; `src/events.rs:20`; `src/metrics.rs:78,370` |
 | `ResourceContext` + scope-хелперы; `AcquireOptions`; `ReloadOutcome`; `ResourcePhase`/`ResourceStatus` | `src/context.rs:103,213-246`; `src/options.rs:24`; `src/reload.rs:18`; `src/state.rs:9,52` |
 | feature `rotation`: `ResourceFanoutDriver`, `ResourceFanoutIndex`, `Bind`, `RotationOutcome` | `src/credential_fanout/` |
 | Derive (subcrate `macros/`): `Resource`, `ResourceConfig`, `ClassifyError` | `macros/src/lib.rs` |

--- a/crates/resource/docs/README.md
+++ b/crates/resource/docs/README.md
@@ -267,8 +267,8 @@ crates/resource/
 │   ├── guard.rs            ResourceGuard — RAII acquire lease (Owned / Guarded / Shared)
 │   ├── context.rs          ResourceContext — execution context
 │   ├── dedup.rs            SlotIdentity (Unbound / Structural), DedupKey
-│   ├── error.rs            Error, ErrorKind, ErrorScope
-│   ├── events.rs           ResourceEvent — 14 lifecycle event variants (all emitted)
+│   ├── error.rs            Error, ErrorKind
+│   ├── events.rs           ResourceEvent — lifecycle event variants (all emitted)
 │   ├── options.rs          AcquireOptions (deadline-only)
 │   ├── metrics.rs          ResourceOpsMetrics, ResourceOpsSnapshot
 │   ├── state.rs            ResourcePhase, ResourceStatus

--- a/crates/resource/docs/events.md
+++ b/crates/resource/docs/events.md
@@ -45,13 +45,14 @@ ADR-0092; it reports per-resource, so there is no aggregate `CredentialRefreshed
 | `Registered` | A resource is registered | `key` |
 | `Removed` | A resource is removed | `key` |
 | `AcquireSuccess` | A handle is acquired | `key`, `duration: Duration` |
-| `AcquireFailed` | Acquire returns an error | `key`, `error: String` |
+| `AcquireFailed` | Acquire returns an error | `key`, `kind: ErrorKind`, `error: String` |
 | `Released` | A handle is dropped | `key`, `held: Duration`, `tainted: bool` |
 | `HealthChanged` | Health status transitions | `key`, `healthy: bool` |
 | `ConfigReloaded` | Config is hot-reloaded | `key` |
 | `RetryAttempt` | A retry is about to sleep after a transient acquire failure | `key`, `attempt: u32`, `backoff: Duration`, `error: String` |
 | `BackpressureDetected` | Pool backpressure was detected (semaphore full) | `key` |
 | `RecoveryGateChanged` | A recovery gate transitioned | `key`, `state: String` |
+| `HoldDeadlineExceeded` | A lease was still held past `Provider::max_hold_duration` (leak/hang detection, warn-only) | `key`, `held: Duration`, `deadline: Duration` |
 
 ### Slot-rotation variants (4)
 

--- a/crates/resource/macros/src/field_slots.rs
+++ b/crates/resource/macros/src/field_slots.rs
@@ -391,8 +391,32 @@ pub(crate) fn emit_credential_slot_epoch_body(slots: &[ParsedCredentialSlot]) ->
     }
 }
 
+/// Uppercases an ASCII slot key into the suffix of its `SLOT_*` associated
+/// constant, mapping every non-alphanumeric character (`.`/`-`) to `_` so the
+/// result is a valid identifier fragment. Two keys that sanitize to the same
+/// suffix produce a duplicate-const compile error at the call site — a loud
+/// failure, never a silent collision.
+fn slot_const_suffix(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 /// Per slot, emit a read accessor over the author-declared
-/// `SlotCell<CredentialGuard<C>>` (or `CredentialSlot<C>`) field.
+/// `SlotCell<CredentialGuard<C>>` (or `CredentialSlot<C>`) field, plus a
+/// `pub const SLOT_<KEY>: &str` naming the slot key.
+///
+/// The associated constant lets authors match the stringly `slot_name`
+/// argument of `on_credential_refresh`/`on_credential_revoke` against
+/// `Self::SLOT_DB` instead of a bare `"db"` literal — a renamed
+/// `#[credential(key = ...)]` field then turns a stale match arm into a
+/// compile error (undefined const) rather than a silent rotation no-op.
 ///
 /// Returns an empty `TokenStream2` when `slots` is empty — the caller skips
 /// emitting an empty `impl` block.
@@ -406,7 +430,17 @@ pub(crate) fn emit_slot_accessors(slots: &[ParsedCredentialSlot]) -> TokenStream
             let field = &slot.field_ident;
             let acc_ident = format_ident!("{}_slot", field);
             let inner = &slot.inner_type;
+            let slot_key = slot.slot_key();
+            let const_ident = format_ident!("SLOT_{}", slot_const_suffix(&slot_key));
+            let const_doc = format!(
+                "The `{slot_key}` credential slot key. Match `slot_name` against \
+                 `Self::{const_ident}` in `on_credential_refresh`/`on_credential_revoke` \
+                 so a renamed slot field becomes a compile error, not a silent no-op."
+            );
             quote! {
+                #[doc = #const_doc]
+                pub const #const_ident: &str = #slot_key;
+
                 /// Resolved credential for this slot, or `None` until the framework binds it.
                 pub fn #acc_ident(&self) -> ::std::option::Option<
                     ::std::sync::Arc<::nebula_credential::CredentialGuard<#inner>>

--- a/crates/resource/src/context.rs
+++ b/crates/resource/src/context.rs
@@ -122,13 +122,15 @@ impl ResourceContext {
 
     /// Creates a minimal context for cases that only need scope + cancellation
     /// (e.g., daemon loops, warmup). Uses no-op accessors internally.
+    ///
+    /// Infallible by construction — the principal is supplied directly
+    /// ([`Principal::System`]) via `BaseContextBuilder::build_with`, so there
+    /// is no `.build().expect(...)` panic to harden on a hot path.
     pub fn minimal(scope: Scope, cancellation: CancellationToken) -> Self {
         let base = BaseContext::builder(scope)
-            .principal(Principal::System)
             .cancellation(cancellation)
             .clock(SystemClock)
-            .build()
-            .expect("scope + principal must produce a valid BaseContext");
+            .build_with(Principal::System);
         Self {
             base,
             resources: Arc::new(NoopResourceAccessor),
@@ -154,9 +156,37 @@ impl ResourceContext {
         self.scope().execution_id
     }
 
-    /// Copies scope + cancellation for type-erased acquire dispatch (no accessor clone).
+    /// Clones the context for the type-erased acquire dispatch path
+    /// ([`Manager::acquire_any`](crate::Manager::acquire_any)).
+    ///
+    /// Forwards the caller's scope, principal, cancellation, and trace/span
+    /// identifiers, **plus** the resource and credential accessor arcs, so a
+    /// `Provider::create`/`prepare` reached through the erased `acquire_any`
+    /// surface observes the same identity, trace correlation, and
+    /// nested-resource/credential access it would on a typed acquire. Earlier
+    /// this returned a [`minimal`](Self::minimal) context, which silently
+    /// clobbered the principal to [`Principal::System`], dropped the trace, and
+    /// substituted no-op accessors — breaking authz checks, span parentage, and
+    /// nested `ctx.resource::<R>()` calls during creation.
+    ///
+    /// The clock is not forwarded — it is not part of the identity and
+    /// `BaseContext` is not `Clone` (its clock is boxed); a fresh `SystemClock`
+    /// is used.
     pub fn clone_for_acquire(&self) -> Self {
-        Self::minimal(self.scope().clone(), self.cancellation().clone())
+        let mut builder = BaseContext::builder(self.scope().clone())
+            .cancellation(self.cancellation().clone())
+            .clock(SystemClock);
+        if let Some(trace_id) = self.trace_id() {
+            builder = builder.trace_id(trace_id);
+        }
+        if let Some(span_id) = self.span_id() {
+            builder = builder.span_id(span_id);
+        }
+        Self {
+            base: builder.build_with(self.principal().clone()),
+            resources: Arc::clone(&self.resources),
+            credentials: Arc::clone(&self.credentials),
+        }
     }
 }
 
@@ -325,5 +355,79 @@ mod tests {
         // Noop accessors should return false for has()
         let _ = ctx.resources();
         let _ = ctx.credentials();
+    }
+
+    #[test]
+    fn clone_for_acquire_forwards_principal_and_accessors() {
+        use nebula_core::{context::HasResources, id::UserId, scope::Principal};
+
+        // Accessor that reports every key as present, distinguishable from the
+        // `NoopResourceAccessor` (which reports `false`) — proves the real
+        // accessor arc is forwarded across the erased-acquire boundary.
+        struct AlwaysHasAccessor;
+        impl ResourceAccessor for AlwaysHasAccessor {
+            fn has(&self, _key: &nebula_core::ResourceKey) -> bool {
+                true
+            }
+            fn acquire_any(
+                &self,
+                _key: &nebula_core::ResourceKey,
+            ) -> Pin<
+                Box<
+                    dyn Future<Output = Result<Box<dyn Any + Send + Sync>, nebula_core::CoreError>>
+                        + Send
+                        + '_,
+                >,
+            > {
+                Box::pin(async {
+                    Err(nebula_core::CoreError::RegistryInvariant(
+                        "test accessor never resolves",
+                    ))
+                })
+            }
+            fn try_acquire_any(
+                &self,
+                _key: &nebula_core::ResourceKey,
+            ) -> Pin<
+                Box<
+                    dyn Future<
+                            Output = Result<
+                                Option<Box<dyn Any + Send + Sync>>,
+                                nebula_core::CoreError,
+                            >,
+                        > + Send
+                        + '_,
+                >,
+            > {
+                Box::pin(async { Ok(None) })
+            }
+        }
+
+        let user = Principal::User(UserId::new());
+        let base = BaseContext::builder(Scope::default())
+            .principal(user.clone())
+            .build()
+            .expect("principal is set");
+        let ctx = ResourceContext::new(
+            base,
+            Arc::new(AlwaysHasAccessor),
+            Arc::new(NoopCredentialAccessor),
+        );
+
+        let cloned = ctx.clone_for_acquire();
+
+        // Identity is forwarded, not clobbered to `Principal::System`.
+        assert_eq!(
+            cloned.principal(),
+            &user,
+            "clone_for_acquire must forward the caller's principal"
+        );
+        // The resource accessor arc is forwarded, not replaced by the no-op —
+        // so a `Provider::create` that resolves a nested resource still works.
+        let nested = nebula_core::resource_key!("nested.dep");
+        assert!(
+            cloned.resources().has(&nested),
+            "clone_for_acquire must forward the resource accessor"
+        );
     }
 }

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -1,9 +1,7 @@
 //! Unified error types for the resource subsystem.
 //!
-//! Every resource error carries an [`ErrorKind`] (what happened) and an
-//! [`ErrorScope`] (currently resource-wide only — see the [`ErrorScope`]
-//! type docs for why it is single-variant). The framework uses
-//! `ErrorKind` to decide whether to retry, back off, or propagate.
+//! Every resource error carries an [`ErrorKind`] describing what happened.
+//! The framework uses it to decide whether to retry, back off, or propagate.
 
 use std::{fmt, time::Duration};
 
@@ -16,6 +14,10 @@ pub enum ErrorKind {
     /// Network blip, timeout — retry with backoff.
     Transient,
     /// Auth failure, invalid config — never retry.
+    ///
+    /// This is a caller/configuration fault (the caller presented state the
+    /// resource will never accept), so it classifies as a client error
+    /// (4xx), **not** a server (5xx) failure.
     Permanent,
     /// Rate limit, quota depleted — retry after cooldown.
     Exhausted {
@@ -57,7 +59,10 @@ impl ErrorKind {
     fn classification(&self) -> (nebula_error::ErrorCategory, &'static str) {
         match self {
             Self::Transient => (nebula_error::ErrorCategory::External, "RESOURCE:TRANSIENT"),
-            Self::Permanent => (nebula_error::ErrorCategory::Internal, "RESOURCE:PERMANENT"),
+            Self::Permanent => (
+                nebula_error::ErrorCategory::Validation,
+                "RESOURCE:PERMANENT",
+            ),
             Self::Exhausted { .. } => {
                 (nebula_error::ErrorCategory::Exhausted, "RESOURCE:EXHAUSTED")
             },
@@ -105,28 +110,10 @@ impl fmt::Display for ErrorKind {
     }
 }
 
-/// Whether the error is resource-wide or target-specific.
-///
-/// Currently a single-variant `#[non_exhaustive]` enum: only [`Resource`]
-/// (the default) is constructed by any production code path. Older drafts
-/// included a `Target { id: String }` variant for per-target isolation
-/// failures; it was removed since no consumer ever wired it. New
-/// variants land here when an engine surface genuinely needs them.
-///
-/// [`Resource`]: ErrorScope::Resource
-#[non_exhaustive]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum ErrorScope {
-    /// The resource itself might be broken.
-    #[default]
-    Resource,
-}
-
 /// Unified resource error.
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-    scope: ErrorScope,
     message: String,
     resource_key: Option<ResourceKey>,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
@@ -137,7 +124,6 @@ impl Error {
     pub fn new(kind: ErrorKind, message: impl Into<String>) -> Self {
         Self {
             kind,
-            scope: ErrorScope::default(),
             message: message.into(),
             resource_key: None,
             source: None,
@@ -147,11 +133,6 @@ impl Error {
     /// Returns the error kind.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
-    }
-
-    /// Returns the error scope.
-    pub fn scope(&self) -> &ErrorScope {
-        &self.scope
     }
 
     /// Returns the resource key, if set.
@@ -193,12 +174,6 @@ impl Error {
     /// Attaches a source error.
     pub fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
         self.source = Some(Box::new(source));
-        self
-    }
-
-    /// Sets the error scope.
-    pub fn with_scope(mut self, scope: ErrorScope) -> Self {
-        self.scope = scope;
         self
     }
 
@@ -299,6 +274,47 @@ impl Error {
                 true,
                 self.retry_after(),
             ),
+        }
+    }
+}
+
+impl From<nebula_core::CoreError> for Error {
+    /// Maps an accessor-seam [`CoreError`](nebula_core::CoreError) back into a
+    /// resource [`Error`], preserving the retryable / `retry_after`
+    /// classification that [`to_core_error`](Error::to_core_error) projected
+    /// onto `CoreError`.
+    ///
+    /// `CoreError::ResourceUnavailable` collapses the richer
+    /// `Revoked`/`Backpressure`/`Exhausted` taxonomy into a single
+    /// `retryable + retry_after` shape, so the inverse cannot recover that
+    /// precision: a retryable error with a hint maps to `Exhausted`, a
+    /// retryable error without one to `Transient`. That is enough for
+    /// [`is_retryable`](Error::is_retryable) to stay correct, which is what
+    /// retry machinery reads. Callers attach the resource key via
+    /// [`with_resource_key`](Error::with_resource_key).
+    fn from(err: nebula_core::CoreError) -> Self {
+        use nebula_core::CoreError;
+        match err {
+            CoreError::ResourceUnavailable {
+                detail,
+                retryable,
+                retry_after,
+                ..
+            } => {
+                let kind = match (retryable, retry_after) {
+                    (true, Some(after)) => ErrorKind::Exhausted {
+                        retry_after: Some(after),
+                    },
+                    (true, None) => ErrorKind::Transient,
+                    (false, _) => ErrorKind::Permanent,
+                };
+                Self::new(kind, detail)
+            },
+            CoreError::CredentialNotFound { key } => {
+                Self::new(ErrorKind::NotFound, format!("credential not found: {key}"))
+            },
+            CoreError::ScopeViolation { .. } => Self::new(ErrorKind::Ambiguous, err.to_string()),
+            other => Self::new(ErrorKind::Permanent, other.to_string()),
         }
     }
 }
@@ -522,7 +538,64 @@ mod tests {
     }
 
     #[test]
-    fn default_scope_is_resource() {
-        assert_eq!(ErrorScope::default(), ErrorScope::Resource);
+    fn permanent_is_caller_fault_not_internal() {
+        use nebula_error::{Classify, ErrorCategory};
+
+        let err = Error::permanent("invalid connection config");
+        // `Permanent` is a caller/config fault (auth failure, bad config),
+        // so it must surface as a 4xx client error, never a 5xx server one.
+        assert_eq!(*err.kind(), ErrorKind::Permanent);
+        assert_ne!(
+            Classify::category(&err),
+            ErrorCategory::Internal,
+            "Permanent must not surface as a 5xx server error"
+        );
+        assert!(
+            Classify::category(&err).is_client_error(),
+            "Permanent must classify as a client error"
+        );
+        assert!(
+            !Classify::category(&err).is_server_error(),
+            "Permanent must not classify as a server error"
+        );
+        assert!(!err.is_retryable(), "Permanent is never retried");
+    }
+
+    #[test]
+    fn from_core_error_preserves_retryable_classification() {
+        use nebula_core::CoreError;
+
+        // Retryable-with-hint round-trips to Exhausted (retryable).
+        let retryable_with_hint = Error::from(CoreError::resource_unavailable(
+            "postgres",
+            "pool exhausted",
+            true,
+            Some(Duration::from_millis(250)),
+        ));
+        assert!(retryable_with_hint.is_retryable());
+        assert_eq!(
+            retryable_with_hint.retry_after(),
+            Some(Duration::from_millis(250))
+        );
+
+        // Retryable-without-hint round-trips to Transient (retryable).
+        let retryable_no_hint = Error::from(CoreError::resource_unavailable(
+            "postgres",
+            "upstream blip",
+            true,
+            None,
+        ));
+        assert!(retryable_no_hint.is_retryable());
+        assert_eq!(*retryable_no_hint.kind(), ErrorKind::Transient);
+
+        // Non-retryable round-trips to Permanent (not retryable).
+        let permanent = Error::from(CoreError::resource_unavailable(
+            "postgres",
+            "auth rejected",
+            false,
+            None,
+        ));
+        assert!(!permanent.is_retryable());
+        assert_eq!(*permanent.kind(), ErrorKind::Permanent);
     }
 }

--- a/crates/resource/src/events.rs
+++ b/crates/resource/src/events.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 
 use nebula_core::ResourceKey;
 
+use crate::error::ErrorKind;
+
 /// A lifecycle event emitted by the resource manager.
 ///
 /// Events are lightweight and cheap to clone. They carry enough
@@ -39,6 +41,10 @@ pub enum ResourceEvent {
     AcquireFailed {
         /// The key of the resource that failed to acquire.
         key: ResourceKey,
+        /// Typed classification of the failure, so subscribers can route on
+        /// the kind (retryable / backpressure / revoked / …) without parsing
+        /// the `error` string.
+        kind: ErrorKind,
         /// Human-readable error description.
         error: String,
     },
@@ -129,6 +135,20 @@ pub enum ResourceEvent {
         /// Number of instances evicted in this maintenance cycle.
         evicted: usize,
     },
+    /// A lease was still held past its [`Provider::max_hold_duration`]
+    /// deadline — leak/hang detection (HikariCP `leakDetectionThreshold`
+    /// equivalent). Emitted by the hold-deadline watchdog while the guard is
+    /// still alive; the lease is NOT forcibly released (warn-only).
+    ///
+    /// [`Provider::max_hold_duration`]: crate::resource::Provider::max_hold_duration
+    HoldDeadlineExceeded {
+        /// The key of the resource whose lease overran its hold deadline.
+        key: ResourceKey,
+        /// How long the lease has been held when the watchdog fired.
+        held: Duration,
+        /// The configured hold deadline that was exceeded.
+        deadline: Duration,
+    },
 }
 
 impl ResourceEvent {
@@ -149,7 +169,8 @@ impl ResourceEvent {
             | Self::SlotRevoked { key, .. }
             | Self::SlotRefreshFailed { key, .. }
             | Self::SlotRevokeFailed { key, .. }
-            | Self::MaintenanceEvicted { key, .. } => Some(key),
+            | Self::MaintenanceEvicted { key, .. }
+            | Self::HoldDeadlineExceeded { key, .. } => Some(key),
         }
     }
 }

--- a/crates/resource/src/ext.rs
+++ b/crates/resource/src/ext.rs
@@ -95,6 +95,13 @@ mod sealed {
 /// HasResourcesExt for C`. New methods can be added here without
 /// breaking downstream code.
 ///
+/// **Call through a concrete context, not `&dyn`.** Both methods carry a
+/// `where Self: Sized` bound (their `impl Future` returns require a sized
+/// receiver pre-AFIT), so `ctx.resource::<R>()` is *not* callable on a
+/// `&dyn Context`/`&dyn ActionContext` even though the blanket impl covers
+/// `?Sized` types. Hold the concrete context type (the action body already
+/// receives `&impl ActionContext`) when reaching for this surface.
+///
 /// # Examples
 ///
 /// ```ignore
@@ -124,9 +131,15 @@ impl<C: HasResources + ?Sized> HasResourcesExt for C {
         Self: Sized,
     {
         let key = R::key();
-        let boxed = self.resources().acquire_any(&key).await.map_err(|e| {
-            Error::new(ErrorKind::Permanent, e.to_string()).with_resource_key(key.clone())
-        })?;
+        // Preserve the retryable/`retry_after` classification carried by the
+        // accessor-seam `CoreError` (see `impl From<CoreError> for Error`);
+        // re-wrapping as `Permanent` would silently disable retries for a
+        // transient acquire failure.
+        let boxed = self
+            .resources()
+            .acquire_any(&key)
+            .await
+            .map_err(|e| Error::from(e).with_resource_key(key.clone()))?;
 
         boxed
             .downcast::<ResourceGuard<R>>()
@@ -166,7 +179,9 @@ impl<C: HasResources + ?Sized> HasResourcesExt for C {
                 Ok(Some(guard))
             },
             Ok(None) => Ok(None),
-            Err(e) => Err(Error::new(ErrorKind::Permanent, e.to_string()).with_resource_key(key)),
+            // Preserve the accessor-seam retryable classification (see
+            // `impl From<CoreError> for Error`).
+            Err(e) => Err(Error::from(e).with_resource_key(key)),
         }
     }
 }

--- a/crates/resource/src/factory.rs
+++ b/crates/resource/src/factory.rs
@@ -62,6 +62,34 @@ use crate::{Manager, ScopeLevel, SlotIdentity, recovery::RecoveryGate, resource:
 /// `Manager` bridges share one async-erasure shape.
 pub type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// One resolved credential slot binding the caller threads into a registration.
+///
+/// The slot name, its resolved [`CredentialKey`](nebula_core::CredentialKey),
+/// and (when the credential participates in rotation) its resolved
+/// [`CredentialId`](nebula_credential::CredentialId) travel together as one
+/// unit, rather than as two parallel `HashMap<String, _>` keyed by slot name.
+///
+/// Co-locating them makes a key↔id divergence for the same slot structurally
+/// unrepresentable: the rotation fan-out reverse-index row and the structural
+/// [`SlotIdentity`] are derived from the **same** binding. This closes the
+/// confused-deputy gap where a revoke routed by `CredentialId` (from one map)
+/// could taint a row whose `SlotIdentity` was built from a different
+/// credential (from a divergent second map), and removes the silent
+/// `continue` that dropped a `CredentialId` whose slot was absent from the
+/// other map.
+#[derive(Debug, Clone)]
+pub struct SlotBinding {
+    /// The declared `#[credential(key = ...)]` slot name on the resource.
+    pub slot_name: String,
+    /// The resolved credential key bound to this slot — contributes to the
+    /// structural [`SlotIdentity`].
+    pub credential_key: nebula_core::CredentialKey,
+    /// The resolved `CredentialId` for the rotation fan-out reverse index, or
+    /// `None` when this credential does not participate in rotation (no
+    /// reverse-index row is staged for it).
+    pub credential_id: Option<nebula_credential::CredentialId>,
+}
+
 /// Type-agnostic inputs the *caller* threads into a typed registration.
 ///
 /// Everything here is independent of the concrete resource type `R`; the
@@ -75,15 +103,12 @@ pub struct RegisterRequest<'a> {
     /// Engine-held expression engine used to resolve `{{ … }}` templates in
     /// `config_json`.
     pub expr_engine: &'a nebula_expression::ExpressionEngine,
-    /// Slot-name → resolved-credential-key bindings. The engine resolves
-    /// credentials before calling `register`; this map is asserted against
-    /// the resource's declared slots inside the typed call.
-    pub slot_bindings: HashMap<String, nebula_core::CredentialKey>,
-    /// Slot-name → resolved `CredentialId` for the rotation fan-out reverse
-    /// index. Empty when the caller resolved no credential into a slot, or
-    /// when no fan-out index is available — registration then proceeds with
-    /// no reverse-index row.
-    pub credential_ids: HashMap<String, nebula_credential::CredentialId>,
+    /// Resolved credential slot bindings — each a [`SlotBinding`] carrying the
+    /// slot name, credential key, and optional rotation `CredentialId`
+    /// together. Asserted against the resource's declared slots inside the
+    /// typed call; both the reverse-index row and the structural identity are
+    /// derived from these same bindings, so the two cannot diverge.
+    pub slot_bindings: Vec<SlotBinding>,
     /// Registration scope.
     pub scope: ScopeLevel,
     /// Optional recovery gate shared across a recovery group.
@@ -320,11 +345,20 @@ where
         let resource = (self.resource_factory)();
         let topology = (self.topology_factory)();
         Box::pin(async move {
+            // The typed register validates declared slots and derives the
+            // structural identity from the (slot → credential-key) view; the
+            // rotation `CredentialId` lives on the same bindings and is
+            // consumed by the reverse index in `register_and_bind`.
+            let slot_keys: HashMap<String, nebula_core::CredentialKey> = request
+                .slot_bindings
+                .iter()
+                .map(|binding| (binding.slot_name.clone(), binding.credential_key.clone()))
+                .collect();
             manager
                 .register_resolved::<R>(
                     request.config_json,
                     request.expr_engine,
-                    request.slot_bindings,
+                    slot_keys,
                     resource,
                     request.scope,
                     topology,
@@ -453,31 +487,36 @@ impl ResourceActivatorRegistry {
             request
                 .slot_bindings
                 .iter()
-                .map(|(slot, cred)| (slot.as_str(), cred.as_str())),
+                .map(|binding| (binding.slot_name.as_str(), binding.credential_key.as_str())),
         );
 
         // Stage reverse-index binds BEFORE the typed register makes the
-        // Manager row discoverable.
+        // Manager row discoverable. Each `CredentialId` rides on the SAME
+        // `SlotBinding` whose `credential_key` fed `staged_slot_identity`, so
+        // the index row and the structural identity can never be derived from
+        // different credentials (confused-deputy close), and a slot without a
+        // rotation `CredentialId` is simply skipped — no silent drop of a
+        // mismatched parallel-map entry.
         let mut staged: Vec<(nebula_credential::CredentialId, _)> = Vec::new();
         if let Some(idx) = fanout_index {
-            for (slot_name, cred_id) in &request.credential_ids {
-                if !request.slot_bindings.contains_key(slot_name) {
+            for binding in &request.slot_bindings {
+                let Some(cred_id) = binding.credential_id else {
                     continue;
-                }
+                };
                 let bind = crate::Bind {
                     resource_key: resource_key.clone(),
                     scope: request.scope.clone(),
-                    slot_name: slot_name.clone(),
+                    slot_name: binding.slot_name.clone(),
                     slot_identity: staged_slot_identity.clone(),
                 };
                 idx.bind(
-                    *cred_id,
+                    cred_id,
                     resource_key.clone(),
                     request.scope.clone(),
-                    slot_name.clone(),
+                    binding.slot_name.clone(),
                     staged_slot_identity.clone(),
                 );
-                staged.push((*cred_id, bind));
+                staged.push((cred_id, bind));
             }
         }
 
@@ -667,8 +706,7 @@ mod tests {
         RegisterRequest {
             config_json: serde_json::json!({ "name": "from-factory" }),
             expr_engine,
-            slot_bindings: HashMap::new(),
-            credential_ids: HashMap::new(),
+            slot_bindings: Vec::new(),
             scope: ScopeLevel::Global,
             recovery_gate: None,
         }

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -137,6 +137,18 @@ pub struct ResourceGuard<R: Provider> {
     /// release work to queue. [`ResourceGuard::release`] does **not** touch
     /// this — it awaits the future inline instead of queueing it.
     release_queue: Option<Arc<ReleaseQueue>>,
+    /// Liveness token for the optional hold-deadline watchdog
+    /// ([`with_hold_watchdog`](Self::with_hold_watchdog)). When a resource
+    /// opts into [`Provider::max_hold_duration`], the manager spawns a
+    /// background task holding a [`std::sync::Weak`] to this `Arc`; the strong
+    /// reference lives here and dies with the guard, so the watchdog can tell
+    /// "still held past the deadline" (leaked/hung lease) from "released in
+    /// time" without any `Drop`-path logic. `None` when the resource declared
+    /// no hold deadline (the common case — zero cost).
+    // Held only for its `Drop`: the watchdog observes liveness via a `Weak`
+    // upgrade, never by reading this field, so `dead_code` is expected.
+    #[allow(dead_code)]
+    hold_token: Option<Arc<()>>,
 }
 
 enum GuardInner<R: Provider> {
@@ -165,6 +177,7 @@ impl<R: Provider> ResourceGuard<R> {
             drain_counters: None,
             event_bus: None,
             release_queue: None,
+            hold_token: None,
         }
     }
 
@@ -228,6 +241,7 @@ impl<R: Provider> ResourceGuard<R> {
             drain_counters: None,
             event_bus: None,
             release_queue: Some(release_queue),
+            hold_token: None,
         }
     }
 
@@ -257,6 +271,53 @@ impl<R: Provider> ResourceGuard<R> {
     /// discipline applies here too.
     pub(crate) fn with_event_bus(mut self, event_bus: Arc<EventBus<ResourceEvent>>) -> Self {
         self.event_bus = Some(event_bus);
+        self
+    }
+
+    /// Arms the optional hold-deadline watchdog (HikariCP-style leak detection).
+    ///
+    /// When `deadline` is `Some(d)` and an event bus is attached, spawns a
+    /// background task that, after `d` elapses, checks whether this guard is
+    /// still alive (the strong [`Arc`] held in `hold_token` has not yet
+    /// dropped). If so, the lease has been held past its deadline — a likely
+    /// leaked or hung guard pinning a bounded slot — and the watchdog emits a
+    /// [`ResourceEvent::HoldDeadlineExceeded`] plus a `WARN` span. A guard that
+    /// drops before the deadline drops its `hold_token`, the [`std::sync::Weak`]
+    /// fails to upgrade, and the watchdog stays silent — so no `Drop`-path work
+    /// is needed.
+    ///
+    /// `deadline = None` (the default [`Provider::max_hold_duration`]) is a
+    /// no-op: no task is spawned and the guard pays nothing.
+    pub(crate) fn with_hold_watchdog(mut self, deadline: Option<Duration>) -> Self {
+        let Some(deadline) = deadline else {
+            return self;
+        };
+        let Some(event_bus) = self.event_bus.clone() else {
+            return self;
+        };
+        let token = Arc::new(());
+        let weak = Arc::downgrade(&token);
+        self.hold_token = Some(token);
+        let key = self.resource_key.clone();
+        let acquired_at = self.acquired_at;
+        tokio::spawn(async move {
+            tokio::time::sleep(deadline).await;
+            // Guard still alive ⇒ the lease outlived its hold deadline.
+            if weak.upgrade().is_some() {
+                let held = acquired_at.elapsed();
+                tracing::warn!(
+                    resource = %key,
+                    held_secs = held.as_secs_f64(),
+                    deadline_secs = deadline.as_secs_f64(),
+                    "resource lease exceeded its hold deadline — possible leaked or hung guard"
+                );
+                let _ = event_bus.emit(ResourceEvent::HoldDeadlineExceeded {
+                    key,
+                    held,
+                    deadline,
+                });
+            }
+        });
         self
     }
 
@@ -799,6 +860,36 @@ mod tests {
     fn owned_deref() {
         let handle = ResourceGuard::<DummyResource>::owned(42, test_key(), TopologyTag::Pool);
         assert_eq!(*handle, 42);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hold_watchdog_emits_when_lease_overruns_deadline() {
+        // A guard armed with a hold deadline must surface a
+        // `HoldDeadlineExceeded` event (HikariCP-style leak detection) when it
+        // is still held past the deadline. Reverting `with_hold_watchdog`
+        // makes this event never fire — red-on-revert.
+        let bus = Arc::new(EventBus::<ResourceEvent>::new(256));
+        let mut events = bus.subscribe();
+
+        let _held = ResourceGuard::<DummyResource>::owned(0, test_key(), TopologyTag::Pool)
+            .with_event_bus(Arc::clone(&bus))
+            .with_hold_watchdog(Some(Duration::from_secs(1)));
+
+        // `start_paused` auto-advances the clock to the watchdog's 1s timer
+        // while this `recv` is the only pending work — deterministic, no
+        // wall-clock sleep.
+        let event = events
+            .recv()
+            .await
+            .expect("watchdog must emit a HoldDeadlineExceeded event");
+        assert!(
+            matches!(
+                event,
+                ResourceEvent::HoldDeadlineExceeded { ref key, deadline, .. }
+                    if key == &test_key() && deadline == Duration::from_secs(1)
+            ),
+            "expected HoldDeadlineExceeded, got {event:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -73,7 +73,7 @@ pub use context::{
     ResourceContext, minimal_scope_for_level, scope_levels_for_acquire, scope_to_level,
 };
 pub use dedup::{DedupKey, SlotIdentity};
-pub use error::{Error, ErrorKind, ErrorScope};
+pub use error::{Error, ErrorKind};
 pub use events::ResourceEvent;
 pub use ext::HasResourcesExt;
 pub use guard::ResourceGuard;
@@ -118,7 +118,7 @@ pub use nebula_resource_macros::ResourceConfig;
 // `nebula-schema` in extern_prelude either.
 pub use factory::{
     BoxFut, KindActivator, RegisterRequest, RegistrarError, ResourceActivatorRegistry,
-    ResourceFactory, ResourceRegistrationOutcome,
+    ResourceFactory, ResourceRegistrationOutcome, SlotBinding,
 };
 pub use nebula_schema::{HasSchema, Schema, ValidSchema, impl_empty_has_schema};
 pub use options::AcquireOptions;
@@ -139,7 +139,7 @@ pub use runtime::{
     pool::{PoolStats, Pooled},
     resident::Resident,
 };
-pub use state::{ResourcePhase, ResourceStatus};
+pub use state::{ResourceErrorSummary, ResourcePhase, ResourceStatus};
 // Topology configurations — used at registration time.
 pub use topology::{
     AdmissionPhase, AdmissionStatus, CheckedOut, Checkout, InstanceStore, Load,

--- a/crates/resource/src/manager/acquire.rs
+++ b/crates/resource/src/manager/acquire.rs
@@ -432,7 +432,8 @@ impl Manager {
             // there is nothing to release.
             Ok(h) => Ok(h
                 .with_drain_tracker(in_flight.release_to_guard())
-                .with_event_bus(Arc::clone(&self.event_bus))),
+                .with_event_bus(Arc::clone(&self.event_bus))
+                .with_hold_watchdog(R::max_hold_duration())),
             Err(e) => Err(e),
         }
     } // visible cross-module after impl split

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -206,18 +206,24 @@
 //!   Deferred because the reload redesign (drain-then-rebuild + a truthful
 //!   outcome contract) is a separate concern; see the **accepted relabel**
 //!   note below for why this is a preserved no-op, not a regression.
-//! - **Pool `CreateGuard` cancel-drop leaks the instance — MED** ([#713]).
-//!   A *cancelled* acquire whose in-flight `create` already built an instance
-//!   drops it synchronously without the async `destroy()`, leaking the
-//!   server-side handle. (The *other* `CreateGuard` race — an in-flight
-//!   create completing *after a revoke* — is the same isolation defect as
-//!   the revoke→recycle TOCTOU and **was fixed** by the pooled revoke-epoch
-//!   fence; only the cancelled-acquire leak remains.)
-//! - **Resident recreate `take()`+destroy-under-lock vs dispatch — MED**
-//!   ([#714]). The resident recreate clears the slot then destroys under the
-//!   lock; a concurrent revoke/refresh dispatch in that window can run
-//!   against the absent/old runtime, losing the revoke for that window.
-//!   Resident internals, out of the collapse seam.
+//! - **Pool `CreateGuard` cancel-drop — residual saturation-only leak — LOW**
+//!   ([#713]). The main cancel-drop path is **closed**: `SlotCreateGuard::drop`
+//!   schedules `destroy_within` via the `ReleaseQueue` (see
+//!   `runtime/acquire_loop.rs`), proven by
+//!   `slot_create_guard_drop_destroys_via_release_queue`. The residual: under
+//!   extreme double-full saturation (the primary *and* fallback release-queue
+//!   channels both full) a rescue task's timeout can elapse — or the cancel
+//!   token fire — before the destroy task is delivered, and the slot leaks,
+//!   observable via `ReleaseQueue::dropped_count`. Best-effort by design
+//!   (canon §11.4), not a normal-path defect.
+//! - **Resident recreate vs dispatch — closed by `create_lock`** ([#714]).
+//!   Both `clone_or_create` and `dispatch_resident_hook` take the same
+//!   `create_lock` before touching the cell, and the
+//!   `take()`→destroy→create→`store()` sequence runs under a continuously held
+//!   lock with no yield that releases it. Dispatch therefore either observes
+//!   the new runtime (correct delivery) or `None` because create failed
+//!   (correct no-op — nothing is bound). No lost-revoke window exists; earlier
+//!   ledger text overstated this.
 //! - **`graceful_shutdown` phase-4 detached workers can outlive
 //!   `release_queue_timeout` — LOW** ([#715]). The timeout bounds the wait,
 //!   not the detached release work; it eventually drains. shutdown.rs was
@@ -680,6 +686,7 @@ impl Manager {
                 }
                 self.emit(ResourceEvent::AcquireFailed {
                     key,
+                    kind: e.kind().clone(),
                     error: e.to_string(),
                 });
             },

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -307,12 +307,13 @@ impl Manager {
         // rather than the raw variant discriminant. The serde wire still
         // deserializes into `R::Config` directly below (no egress on the read path).
         let field_values = schema.values_from_wire(config_json.clone()).map_err(|e| {
-            Error::permanent(format!("validate_config_value: invalid field tree: {e}"))
+            Error::permanent("validate_config_value: invalid field tree").with_source(e)
         })?;
         if let Err(report) = schema.validate(&field_values) {
-            return Err(Error::permanent(format!(
-                "validate_config_value: schema validation failed: {report:?}"
-            )));
+            return Err(
+                Error::permanent("validate_config_value: schema validation failed")
+                    .with_source(report),
+            );
         }
 
         // Closed-set guard: reject any config key the typed `R::Config` schema does
@@ -356,9 +357,10 @@ impl Manager {
         // deserialized exactly once across validation + typed dispatch.
         serde_json::from_value::<R::Config>(config_json).map_err(|e| {
             Error::permanent(format!(
-                "validate_config_value: failed to deserialize {ty} config from JSON: {e}",
+                "validate_config_value: failed to deserialize {ty} config from JSON",
                 ty = std::any::type_name::<R::Config>()
             ))
+            .with_source(e)
         })
     }
 

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -322,7 +322,10 @@ impl Manager {
     pub(super) fn set_phase_all_failed(&self, error: &ShutdownError) {
         let reason = error.to_string();
         for managed in self.registry.all_managed() {
-            managed.set_failed(&reason);
+            // A drain-abort leaves the resource permanently bankrupt — the
+            // manager will reject every subsequent acquire until it is
+            // re-registered, so this is a non-retryable `Permanent` failure.
+            managed.set_failed(crate::error::ErrorKind::Permanent, &reason);
             self.emit(ResourceEvent::HealthChanged {
                 key: managed.resource_key(),
                 healthy: false,

--- a/crates/resource/src/metrics.rs
+++ b/crates/resource/src/metrics.rs
@@ -256,7 +256,7 @@ impl ResourceOpsMetrics {
     /// Incremented by the bounded release path when `release_one` (a
     /// token return / session close / exclusive reset) — or a follow-up
     /// destroy after a failed reset — returns `Err`. The error is observed
-    /// here instead of being `let _ =`-swallowed (R17).
+    /// here instead of being `let _ =`-swallowed.
     pub fn record_release_error(&self) {
         self.release_errors.inc();
     }

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -81,13 +81,13 @@ pub trait ManagedHandle: sealed::Sealed + Send + Sync + 'static {
     /// Terminal failure transition.
     ///
     /// Transitions the resource to [`ResourcePhase::Failed`] and records
-    /// the supplied human-readable reason in `last_error`. Used by
-    /// `Manager::set_phase_all_failed` so `DrainTimeoutPolicy::Abort` can
-    /// signal per-resource failure without needing typed access to each
+    /// the supplied typed `kind` + human-readable reason in `last_error`.
+    /// Used by `Manager::set_phase_all_failed` so `DrainTimeoutPolicy::Abort`
+    /// can signal per-resource failure without needing typed access to each
     /// entry.
     ///
     /// [`ResourcePhase::Failed`]: crate::state::ResourcePhase::Failed
-    fn set_failed(&self, reason: &str);
+    fn set_failed(&self, kind: crate::error::ErrorKind, reason: &str);
 
     /// Current lifecycle phase — diagnostic-only; typed callers should prefer
     /// `ManagedResource::status().phase` after a successful downcast.
@@ -216,8 +216,8 @@ where
         ManagedResource::set_phase(self, phase);
     }
 
-    fn set_failed(&self, reason: &str) {
-        ManagedResource::set_failed(self, reason.to_owned());
+    fn set_failed(&self, kind: crate::error::ErrorKind, reason: &str) {
+        ManagedResource::set_failed(self, kind, reason.to_owned());
     }
 
     fn phase(&self) -> crate::state::ResourcePhase {
@@ -1049,7 +1049,7 @@ mod tests {
                     TypeId::of::<$T>()
                 }
                 fn set_phase(&self, _phase: crate::state::ResourcePhase) {}
-                fn set_failed(&self, _reason: &str) {}
+                fn set_failed(&self, _kind: crate::error::ErrorKind, _reason: &str) {}
                 fn phase(&self) -> crate::state::ResourcePhase {
                     crate::state::ResourcePhase::Ready
                 }

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -533,6 +533,23 @@ pub trait Provider: Send + Sync + Sized + 'static {
         std::time::Duration::from_secs(30)
     }
 
+    /// Optional maximum lease-hold duration — leak / hang detection.
+    ///
+    /// When `Some(d)`, the framework arms a background watchdog on every
+    /// acquired [`ResourceGuard`](crate::guard::ResourceGuard): if the lease is
+    /// still held `d` after acquisition, it emits a
+    /// [`ResourceEvent::HoldDeadlineExceeded`](crate::events::ResourceEvent::HoldDeadlineExceeded)
+    /// and a `WARN` span. The lease is **not** forcibly released — this is an
+    /// observability signal (the HikariCP `leakDetectionThreshold` equivalent)
+    /// that surfaces a node which acquired a bounded-exclusive lease and hung,
+    /// pinning the slot while siblings back up on the semaphore.
+    ///
+    /// The default is `None` (no watchdog, zero cost). Receiver-less because
+    /// the deadline is a resource-type policy, not a per-instance value.
+    fn max_hold_duration() -> Option<std::time::Duration> {
+        None
+    }
+
     /// Final cleanup — consumes the instance.
     ///
     /// The default implementation drops the instance.

--- a/crates/resource/src/resource_ref.rs
+++ b/crates/resource/src/resource_ref.rs
@@ -108,9 +108,14 @@ impl<R: Provider> ResourceRef<R> {
             )
         })?;
 
-        let boxed = ctx.resources().acquire_any(&key).await.map_err(|e| {
-            Error::new(ErrorKind::Permanent, e.to_string()).with_resource_key(key.clone())
-        })?;
+        // Preserve the accessor-seam retryable/`retry_after` classification
+        // (see `impl From<CoreError> for Error`); re-wrapping as `Permanent`
+        // would silently disable retries for a transient acquire failure.
+        let boxed = ctx
+            .resources()
+            .acquire_any(&key)
+            .await
+            .map_err(|e| Error::from(e).with_resource_key(key.clone()))?;
 
         boxed
             .downcast::<ResourceGuard<R>>()

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -146,11 +146,14 @@ impl<R: Provider> ManagedResource<R> {
     /// resource the manager has already declared bankrupt. Per-resource
     /// `HealthChanged{healthy:false}` event emission is owned by the
     /// manager because it holds the event bus.
-    pub(crate) fn set_failed(&self, error: impl Into<String>) {
+    pub(crate) fn set_failed(&self, kind: crate::error::ErrorKind, message: impl Into<String>) {
         let next = ResourceStatus {
             phase: ResourcePhase::Failed,
             generation: self.generation(),
-            last_error: Some(error.into()),
+            last_error: Some(crate::state::ResourceErrorSummary {
+                kind,
+                message: message.into(),
+            }),
         };
         self.status.store(Arc::new(next));
     }

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -82,7 +82,6 @@ impl<R: Provider> std::fmt::Debug for PoolSlot<R> {
         f.debug_struct("PoolSlot")
             .field("fingerprint", &self.fingerprint)
             .field("checkout_count", &self.metrics.checkout_count)
-            .field("error_count", &self.metrics.error_count)
             .field("returned_at", &self.returned_at)
             .finish()
     }
@@ -97,6 +96,7 @@ impl<R: Provider> std::fmt::Debug for PoolSlot<R> {
 /// `idle` and `in_use` are sampled separately and may not add up to `capacity`
 /// precisely due to concurrent activity between reads.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub struct PoolStats {
     /// Number of instances currently sitting idle in the pool.
     pub idle: usize,
@@ -350,7 +350,6 @@ where
         Ok(PoolSlot {
             instance,
             metrics: InstanceMetrics {
-                error_count: 0,
                 checkout_count: 1,
                 created_at: Instant::now(),
             },
@@ -527,10 +526,22 @@ where
                     .on_credential_revoke(slot, &entry.slot.instance)
                     .await
             };
-            if let Err(e) = res
-                && first_err.is_none()
-            {
-                first_err = Some(e);
+            if let Err(error) = res {
+                // Surface EVERY per-slot hook failure. Returning only the
+                // first would silently hide a partial rotation where some
+                // idle instances refreshed and others did not, leaving them
+                // in an uncertain credential state. The hook error is the
+                // author's, already redacted (never credential material).
+                tracing::warn!(
+                    resource = %R::key(),
+                    slot,
+                    refresh,
+                    %error,
+                    "credential rotation hook failed for an idle pool instance"
+                );
+                if first_err.is_none() {
+                    first_err = Some(error);
+                }
             }
         }
         match first_err {
@@ -711,7 +722,6 @@ mod tests {
             .await
             .expect("create_slot must succeed");
         assert_eq!(slot.metrics.checkout_count, 1);
-        assert_eq!(slot.metrics.error_count, 0);
         assert_eq!(resource.created.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/resource/src/runtime/teardown.rs
+++ b/crates/resource/src/runtime/teardown.rs
@@ -53,10 +53,16 @@ pub(crate) fn teardown_deadline<R: Provider>(resource: &R, reason: TeardownReaso
 /// Composes the deadline from [`teardown_deadline`], builds the read-only
 /// [`TeardownCx`], and runs [`Provider::destroy`] under
 /// [`tokio::time::timeout_at`]. On timeout the in-flight destroy future is
-/// dropped (abandoned) and a typed [`Error::backpressure`] is returned so the
-/// caller can record the abandoned teardown — the framework never blocks past
-/// the deadline. An author doing graceful work bounds it to the same
-/// `cx.deadline`, so the two deadlines coincide. See ADR-0093.
+/// dropped (abandoned) and a typed [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled)
+/// error is returned so the caller can record the abandoned teardown — the
+/// framework never blocks past the deadline. An author doing graceful work
+/// bounds it to the same `cx.deadline`, so the two deadlines coincide.
+///
+/// Every failure path is observed here with a `WARN` span: most call sites
+/// discard the result (`let _ = destroy_within(...)`) on a best-effort
+/// background path, so logging centrally keeps stale-eviction / fence /
+/// maintenance destroy failures visible without each site re-logging. See
+/// ADR-0093.
 pub(crate) async fn destroy_within<R: Provider>(
     resource: &R,
     instance: R::Instance,
@@ -65,10 +71,30 @@ pub(crate) async fn destroy_within<R: Provider>(
     let deadline = teardown_deadline(resource, reason);
     let cx = TeardownCx::new(deadline, reason);
     match tokio::time::timeout_at(deadline.into(), resource.destroy(instance, cx)).await {
-        Ok(res) => res,
-        Err(_elapsed) => Err(Error::backpressure(format!(
-            "{}: destroy exceeded teardown budget",
-            R::key()
-        ))),
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            tracing::warn!(
+                resource = %R::key(),
+                ?reason,
+                %error,
+                "resource destroy failed"
+            );
+            Err(error)
+        },
+        Err(_elapsed) => {
+            // A teardown that exceeds its budget is abandoned (the destroy
+            // future is dropped); that is a cancellation of the teardown, not
+            // a system-overload `Backpressure` condition — classify it as
+            // `Cancelled` so downstream routing is not misled.
+            tracing::warn!(
+                resource = %R::key(),
+                ?reason,
+                "resource destroy abandoned — exceeded teardown budget"
+            );
+            Err(Error::new(
+                crate::error::ErrorKind::Cancelled,
+                format!("{}: destroy abandoned — exceeded teardown budget", R::key()),
+            ))
+        },
     }
 }

--- a/crates/resource/src/state.rs
+++ b/crates/resource/src/state.rs
@@ -3,6 +3,8 @@
 //! [`ResourcePhase`] represents the current lifecycle phase of a resource,
 //! and [`ResourceStatus`] bundles phase with generation and error information.
 
+use crate::error::ErrorKind;
+
 /// Lifecycle phase of a managed resource.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +49,19 @@ impl std::fmt::Display for ResourcePhase {
     }
 }
 
+/// Structured summary of the last error a resource recorded.
+///
+/// Carries the typed [`ErrorKind`] classification alongside the
+/// human-readable message, so status consumers can route on the kind
+/// without parsing strings (the typed-observability definition of done).
+#[derive(Debug, Clone)]
+pub struct ResourceErrorSummary {
+    /// Typed classification of the failure.
+    pub kind: ErrorKind,
+    /// Human-readable, secret-free description of the failure.
+    pub message: String,
+}
+
 /// Snapshot of a resource's current status.
 #[derive(Debug, Clone)]
 pub struct ResourceStatus {
@@ -54,8 +69,8 @@ pub struct ResourceStatus {
     pub phase: ResourcePhase,
     /// Monotonically increasing generation counter (incremented on reload).
     pub generation: u64,
-    /// Human-readable description of the last error, if any.
-    pub last_error: Option<String>,
+    /// Typed summary of the last error, if any.
+    pub last_error: Option<ResourceErrorSummary>,
 }
 
 impl ResourceStatus {

--- a/crates/resource/src/topology/pooled.rs
+++ b/crates/resource/src/topology/pooled.rs
@@ -42,8 +42,6 @@ pub enum RecycleDecision {
 /// keep-or-drop decisions.
 #[derive(Debug, Clone)]
 pub struct InstanceMetrics {
-    /// Number of errors observed during checkouts of this instance.
-    pub error_count: u64,
     /// Number of times this instance has been checked out.
     pub checkout_count: u64,
     /// When this instance was created.
@@ -80,6 +78,14 @@ impl InstanceMetrics {
 /// [`Manager::acquire_pooled`](crate::Manager::acquire_pooled) requires:
 /// - `R: Clone + Send + Sync + 'static`
 /// - `R::Instance: Clone + Send + Sync + 'static`
+///
+/// # Object safety
+///
+/// `PoolProvider` is **not** object-safe: [`recycle`](Self::recycle) and
+/// [`prepare`](Self::prepare) return `impl Future` (RPITIT), and it inherits
+/// [`Provider`]'s receiver-less `key()`. The framework reaches these hooks
+/// monomorphically inside [`Pooled<R>`](crate::topology::Pooled), never through
+/// a trait object — do not attempt `Box<dyn PoolProvider<…>>`.
 pub trait PoolProvider: Provider + crate::resource::HasCredentialSlots {
     /// Sync O(1) broken check. Called in the `Drop` path — NO async, NO I/O.
     ///

--- a/crates/resource/src/topology/store.rs
+++ b/crates/resource/src/topology/store.rs
@@ -472,6 +472,7 @@ impl<S> CheckedOut<S> {
 
 /// The outcome of [`InstanceStore::return_slot`] / [`InstanceStore::deposit_fresh`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ReturnOutcome<S> {
     /// The slot was returned to the idle queue — it is clean and ready to
     /// be leased again.

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -2969,7 +2969,8 @@ async fn release_bounds_a_hanging_author_teardown() {
     // a caller that awaited `release()`. Per ADR-0093 the per-resource teardown
     // deadline is the effective bound: a tainted lease is a revoke teardown, so
     // the default 30s budget is capped to the 5s revoke cap, and `destroy_within`
-    // abandons the hang with a typed `backpressure` error well before the outer
+    // abandons the hang with a typed `Cancelled` error (a teardown abandonment,
+    // NOT a retryable `Backpressure` overload) well before the outer
     // `hook_guard` ceiling. `start_paused` advances virtual time to the deadline
     // instantly + deterministically — no wall-clock wait.
     let manager = Manager::new();
@@ -2995,8 +2996,12 @@ async fn release_bounds_a_hanging_author_teardown() {
     let outcome = handle.release().await;
     let err = outcome.expect_err("a hanging author teardown must make release() return Err");
     assert!(
-        err.to_string().contains("destroy exceeded teardown budget"),
+        err.to_string().contains("exceeded teardown budget"),
         "release() must surface the per-resource teardown-budget bound, got: {err}"
+    );
+    assert!(
+        !err.is_retryable(),
+        "an abandoned teardown is a Cancelled-class error, not a retryable backpressure, got: {err}"
     );
 }
 

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -436,10 +436,20 @@ async fn register_from_value_rejects_unknown_union_variant() {
         .await
         .expect_err("an unknown union variant must be rejected at registration");
 
-    let msg = err.to_string();
+    // The top-level message names the operation; the structured cause (the
+    // unknown-variant detail) is preserved on the source chain via
+    // `.with_source(e)` rather than flattened into the message. Walk the whole
+    // chain so the rejection detail must survive somewhere in it.
+    let mut chain = err.to_string();
+    let mut source = std::error::Error::source(&err);
+    while let Some(cause) = source {
+        chain.push_str(": ");
+        chain.push_str(&cause.to_string());
+        source = cause.source();
+    }
     assert!(
-        msg.contains("unknown_variant") || msg.contains("Nope"),
-        "expected an unknown-variant rejection, got: {msg}"
+        chain.contains("unknown_variant") || chain.contains("Nope"),
+        "expected an unknown-variant rejection in the error chain, got: {chain}"
     );
 }
 

--- a/examples/examples/resource_postgres_pool.rs
+++ b/examples/examples/resource_postgres_pool.rs
@@ -251,7 +251,13 @@ impl PoolProvider for Postgres {
             );
             return Ok(RecycleDecision::Drop);
         }
-        if metrics.error_count >= 3 {
+        // Bound connection lifetime by checkout count — a real, framework-fed
+        // signal (a long-lived connection is recycled after many leases).
+        if metrics.checkout_count >= 500 {
+            tracing::info!(
+                connection_id = runtime.id,
+                "recycle: drop after checkout budget"
+            );
             return Ok(RecycleDecision::Drop);
         }
         Ok(RecycleDecision::Keep)


### PR DESCRIPTION
## What

Adversarially **verified** the 5-model `nebula-resource` audit findings against code (15 verifier agents + 3 independent sweeps: confused-deputy / async-correctness / API-semver), then fixed **every confirmed finding** in one pass. Refuted findings are deliberately left untouched (see below).

## Confirmed & fixed

**Security / structural (pre-1.0, breaking-impossible-later)**
- **`RegisterRequest` dual-map collapse → one `SlotBinding`** — closes a confused-deputy gap *all 5 audits missed* (sweep **S1**): rotation routed by `CredentialId` while the slot port verifies only `SlotIdentity`, never cross-checked; plus the silent `continue` that dropped a mismatched parallel-map entry. **[F11 + S1]**
- **Error taxonomy** — `Permanent` → `Validation` (client 4xx) not `Internal` (5xx); `From<CoreError> for Error` preserving `retryable`, used by `HasResourcesExt`/`ResourceRef` instead of flattening every failure to `Permanent`; drop dead single-variant `ErrorScope`. **[F6, F2]**
- **Typed observability** — `AcquireFailed { kind }`; `ResourceStatus.last_error: ResourceErrorSummary{kind,message}`. **[F13b/c]**
- **`#[non_exhaustive]`** on `PoolStats` + `ReturnOutcome` (caller-constructed `ManagerConfig`/`RegistrationSpec` intentionally left — `#[non_exhaustive]` would break in-workspace struct literals with zero external-semver gain per the `types` rule). **[F14]**
- **Slot-name `SLOT_*` consts** from the derive, so a renamed `#[credential]` field is a compile error in rotation match arms, not a silent no-op (additive; full enum spine deferred). **[F10]**

**Correctness / observability**
- **Hold-deadline leak detection** — `Provider::max_hold_duration()` (default `None`) + a `Weak`-token background watchdog emitting `HoldDeadlineExceeded` (HikariCP `leakDetectionThreshold` equivalent). **[F9]**
- **`clone_for_acquire`** forwards principal/trace/accessors instead of a stripped `minimal` context; infallible `BaseContextBuilder::build_with` removes a hot-path `.expect`. **[F1 + sweep S3a]**
- **`destroy_within`** traces every failure; teardown timeout is `Cancelled`, not a misclassified retryable `Backpressure`. **[F4 + kimi #27]**
- Pool credential hook surfaces **every** per-slot failure (was first-only); `.with_source` at 3 `validate_config_value` sites. **[F8a, F13a]**
- Corrected `#713`/`#714` ledger text; documented `PoolProvider`/`HasResourcesExt` object-safety; scrubbed plan-id `(R17)`; dropped dead `InstanceMetrics.error_count` (repointed the example to the working `checkout_count` signal); `publish = false`. **[F12, S3b/c, F15a/b/d]**

## Refuted (left untouched — not bugs)
`run_acquire_loop` options-discard (deadline enforced one level up), `to_core_error` key (uses bare key), `resolve_typed` downcast (dead arm, TypeId pre-filtered), **#714** resident race (fully serialized by `create_lock`), idle-lock-across-rotation (intentional), `recreate_on_failure` (is read), README examples (compile fine), file-size splits.

## Deferred (own-ADR / cross-crate, out of scope)
`#712` reload drain-rebuild redesign · full per-resource `SlotName` enum spine · `CredentialRevocationSink` port · two-way fanout index.

## Verification
Pre-push gate green: **918 workspace tests passed (0 skipped)**, `clippy-full`, and `rustdoc -D warnings` (core/engine/resource). New red-on-revert tests: hold-deadline watchdog, `clone_for_acquire` identity/accessor forwarding, `From<CoreError>` retryable round-trip, `Permanent` client-class, abandoned-teardown classification, unknown-variant source-chain preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)