### PR TITLE
fix(resource): rebuild the Resident master on reload_config (#712)

### DIFF
--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -198,14 +198,19 @@
 //!
 //! ## Latent bugs surfaced but out of scope
 //!
-//! - **`reload_config` never drains/rebuilds the live runtime — MED-HIGH**
-//!   ([#712]). `reload_config` swaps the config `ArcSwap` (and the Pool
-//!   fingerprint) but never drains in-flight work or rebuilds the
-//!   caller-supplied live `Arc<R::Instance>` for any topology, so a reload
-//!   that should rotate the running runtime is silently not applied to it.
-//!   Deferred because the reload redesign (drain-then-rebuild + a truthful
-//!   outcome contract) is a separate concern; see the **accepted relabel**
-//!   note below for why this is a preserved no-op, not a regression.
+//! - **`reload_config` live-runtime application — residual: Bounded-Exclusive
+//!   only — LOW** ([#712]). The new config is now applied to the live runtime
+//!   lazily on the next acquire for every topology *except* Bounded-Exclusive:
+//!   Pooled evicts stale-fingerprint idle instances and recreates; Resident
+//!   rebuilds its shared master when the built-against config fingerprint
+//!   changes (`Resident::clone_or_create`); Bounded-Capped/Unbounded create a
+//!   fresh instance from the current config on every acquire. The one residual
+//!   is **Bounded-Exclusive**: its single reused store-held instance carries no
+//!   config fingerprint, so a fingerprint-aware `accept` (or threading the
+//!   config into `accept`) is needed to evict-and-rebuild it on reload. The
+//!   `SwappedImmediately` outcome stays accurate (config swapped immediately;
+//!   live runtime rebuilt lazily) — no eager drain-then-rebuild redesign was
+//!   needed; see the **accepted relabel** note below.
 //! - **Pool `CreateGuard` cancel-drop — residual saturation-only leak — LOW**
 //!   ([#713]). The main cancel-drop path is **closed**: `SlotCreateGuard::drop`
 //!   schedules `destroy_within` via the `ReleaseQueue` (see

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -560,9 +560,19 @@ impl Manager {
     /// Hot-reloads the configuration for a registered resource.
     ///
     /// Validates the new config, swaps it into the [`ArcSwap`](arc_swap::ArcSwap),
-    /// increments the generation counter, and — for pool topologies — updates the
-    /// fingerprint so idle instances with stale configs are evicted on next
-    /// acquire or release.
+    /// and increments the generation counter. The new config is applied to the
+    /// live runtime **lazily, on the next acquire**, per topology:
+    ///
+    /// - **Pooled** — the fingerprint is updated so idle instances with stale
+    ///   configs are evicted on the next acquire / sweep and recreated.
+    /// - **Resident** — the shared master is rebuilt on the next acquire when
+    ///   its built-against config fingerprint no longer matches (see
+    ///   `Resident::clone_or_create`).
+    /// - **Bounded (Capped / Unbounded)** — every acquire already creates a
+    ///   fresh instance from the current config, so the reload is immediate.
+    /// - **Bounded (Exclusive)** — the single reused instance is **not** yet
+    ///   rebuilt on reload (tracked residual; needs a fingerprint-aware
+    ///   `accept`, since the store-held slot carries no config fingerprint).
     ///
     /// # Errors
     ///
@@ -619,13 +629,14 @@ impl Manager {
 
         self.emit(ResourceEvent::ConfigReloaded { key: R::key() });
 
-        // Reload outcome. `reload_config` swaps the config `ArcSwap`
-        // without rebuilding the caller-supplied live `Arc<R::Instance>` for
-        // *any* topology — only the Pool fingerprint is updated, above. So
-        // the honest outcome is `SwappedImmediately` for every variant: the
-        // config is swapped, the live runtime is not rebuilt. The genuine
-        // "drain + rebuild the live runtime on reload" behavior is the
-        // separately-tracked deferred `reload_config` redesign ([#712]).
+        // Reload outcome. The config `ArcSwap` is swapped immediately; the
+        // live runtime is rebuilt LAZILY on the next acquire (Pooled evicts
+        // stale-fingerprint idle instances; Resident rebuilds its master on a
+        // changed config fingerprint; Bounded-Capped/Unbounded create fresh
+        // per acquire). `SwappedImmediately` is therefore accurate: the config
+        // takes effect on the next acquire without an eager drain-then-rebuild.
+        // Residual: Bounded-Exclusive's single reused instance is not yet
+        // rebuilt on reload ([#712]).
         let outcome = ReloadOutcome::SwappedImmediately;
 
         tracing::info!(key = %R::key(), ?outcome, "resource config reloaded");

--- a/crates/resource/src/runtime/resident.rs
+++ b/crates/resource/src/runtime/resident.rs
@@ -93,6 +93,19 @@ pub struct Resident<R: Provider> {
     ///
     /// [`dispatch_resident_hook`]: Self::dispatch_resident_hook
     built_epoch: AtomicU64,
+    /// The `R::Config` fingerprint the currently-stored master runtime was
+    /// built against (`0` before the first create). Compared on each acquire
+    /// against the live config snapshot's fingerprint: a mismatch means
+    /// `Manager::reload_config` swapped the config, so the master is rebuilt
+    /// with the new config on the next acquire (lazy rebuild, symmetric to the
+    /// pool's stale-fingerprint eviction). Written only under `create_lock`.
+    ///
+    /// Distinct from [`built_epoch`](Self::built_epoch) (credential rotation)
+    /// and from `Pooled::current_fingerprint` (the pool is seeded with the
+    /// fingerprint at construction; the resident instead derives it from the
+    /// live config the framework threads into every `create_slot`, so no
+    /// constructor or `set_fingerprint` change is needed).
+    built_fingerprint: AtomicU64,
 }
 
 impl<R: Provider + HasCredentialSlots> Resident<R> {
@@ -103,6 +116,7 @@ impl<R: Provider + HasCredentialSlots> Resident<R> {
             config,
             create_lock: Mutex::new(()),
             built_epoch: AtomicU64::new(0),
+            built_fingerprint: AtomicU64::new(0),
         }
     }
 
@@ -236,9 +250,19 @@ where
         resource_config: &R::Config,
         ctx: &ResourceContext,
     ) -> Result<R::Instance, Error> {
-        // Fast path — lock-free load + liveness check.
+        // The `R::Config` fingerprint of the live snapshot the framework
+        // threaded in. `Manager::reload_config` swaps that snapshot, so a
+        // changed fingerprint is the signal to rebuild the master against the
+        // new config (lazy rebuild, symmetric to the pool's stale-fingerprint
+        // eviction). Computed once and reused — `resource_config` is fixed for
+        // this acquire.
+        use crate::resource::ResourceConfig as _;
+        let config_fp = resource_config.fingerprint();
+
+        // Fast path — lock-free load + liveness + config-fingerprint check.
         if let Some(existing) = self.cell.load()
             && resource.is_alive_sync(&existing)
+            && self.built_fingerprint.load(Ordering::Acquire) == config_fp
         {
             return Ok((*existing).clone());
         }
@@ -248,12 +272,18 @@ where
 
         // Double-check: another task may have created while we waited.
         if let Some(existing) = self.cell.load() {
-            if resource.is_alive_sync(&existing) {
+            let alive = resource.is_alive_sync(&existing);
+            let config_unchanged = self.built_fingerprint.load(Ordering::Acquire) == config_fp;
+            if alive && config_unchanged {
                 return Ok((*existing).clone());
             }
 
-            // Still not alive — destroy and recreate if configured.
-            if !self.config.recreate_on_failure {
+            // A live runtime that merely failed its liveness check is recreated
+            // only when the resident opts in via `recreate_on_failure`. A config
+            // reload (fingerprint changed) ALWAYS rebuilds — it is an explicit
+            // operator action, not failure recovery — so it is not gated on
+            // that flag.
+            if config_unchanged && !self.config.recreate_on_failure {
                 return Err(Error::transient("resident runtime is not alive"));
             }
 
@@ -303,6 +333,9 @@ where
         let cloned = runtime.clone();
         self.cell.store(Arc::new(runtime));
         self.built_epoch.store(built_epoch, Ordering::Release);
+        // Stamp the config fingerprint this master was built against so a
+        // later reload (changed fingerprint) triggers a rebuild on next acquire.
+        self.built_fingerprint.store(config_fp, Ordering::Release);
 
         Ok(cloned)
     }

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -1130,6 +1130,61 @@ async fn reload_config_bumps_status_generation() {
 }
 
 #[tokio::test]
+async fn reload_config_rebuilds_resident_master_with_new_config() {
+    // A resident holds ONE shared master and clones it per acquire. Before the
+    // fix, `reload_config` swapped the config but never rebuilt that master, so
+    // an operator's new config never took effect on the live runtime. The
+    // master must be rebuilt — lazily, on the next acquire — when the config
+    // fingerprint changes. `ResidentTestResource::create` returns a fresh
+    // instance carrying a monotonic create-id, so a rebuild is observable as a
+    // changed id. Red-on-revert: without the rebuild, the same master (same id)
+    // is reused after reload.
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt = Resident::<ResidentTestResource>::new(ResidentConfig::default());
+    manager
+        .register(RegistrationSpec {
+            resource,
+            config: test_config(),
+            scope: ScopeLevel::Global,
+            slot_identity: SlotIdentity::Unbound,
+            topology: resident_rt,
+            recovery_gate: None,
+        })
+        .expect("register");
+
+    let ctx = test_ctx();
+    let first = manager
+        .acquire_resident::<ResidentTestResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("first acquire");
+    let first_id = first.load(Ordering::Relaxed);
+    drop(first);
+
+    // Reload to a config with a DIFFERENT fingerprint (a different name).
+    manager
+        .reload_config::<ResidentTestResource>(
+            TestConfig {
+                name: "test-v2".into(),
+            },
+            &ScopeLevel::Global,
+        )
+        .expect("reload");
+
+    let second = manager
+        .acquire_resident::<ResidentTestResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("second acquire");
+    let second_id = second.load(Ordering::Relaxed);
+
+    assert_ne!(
+        first_id, second_id,
+        "reload_config must rebuild the resident master with the new config \
+         (a changed config fingerprint forces a fresh create on the next acquire)"
+    );
+}
+
+#[tokio::test]
 async fn graceful_shutdown_report_marks_registry_cleared() {
     use nebula_resource::manager::ShutdownConfig;
 


### PR DESCRIPTION
## What

Closes the bulk of the deferred **#712** gap: `reload_config` swapped the config `ArcSwap` but never rebuilt a **Resident** topology's single shared master, so an operator's new config never took effect on the live runtime.

## How

The framework already threads the live config snapshot into `create_slot` on every acquire, so the fix needs **no new wiring**: `Resident` stamps the `R::Config` fingerprint its master was built against (`built_fingerprint`) and, on each acquire, rebuilds the master when that fingerprint no longer matches the live config's — a lazy rebuild **symmetric to the pool's stale-fingerprint eviction**. A config reload rebuilds unconditionally (an explicit operator action), independent of `recreate_on_failure`.

Comparing against the **actual** config fingerprint each acquire (not a cached counter) avoids the zero-seed miss a `set_fingerprint`/`current_fingerprint` approach would have (the resident isn't seeded with the registered fingerprint the way `Pooled::new(config, fp)` is). `SwappedImmediately` stays accurate — no eager drain-then-rebuild redesign was needed.

## Reload coverage after this change (documented in the ledger + `reload_config` docs)
| Topology | Reload behavior |
|---|---|
| Pooled | already rebuilt lazily via stale-fingerprint eviction |
| **Resident** | **now rebuilt lazily on a changed config fingerprint** |
| Bounded Capped / Unbounded | create fresh per acquire (immediate) |
| Bounded Exclusive | **residual** — single reused store-held instance carries no config fingerprint; rebuild-on-reload needs a fingerprint-aware `accept` (tracked LOW) |

## Test
`reload_config_rebuilds_resident_master_with_new_config` — acquire, reload to a differently-fingerprinted config, re-acquire, assert a fresh create-id. Red-on-revert: the alive master is otherwise reused (same id). All other reload tests (pool eviction, generation bump) and the resident reuse-when-unchanged test still pass.

## Verification
Pre-push gate green: nextest (410 resource-scoped tests, 0 skipped), `clippy-full`, `rustdoc -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)