### PR TITLE
fix(resource): rebuild the Bounded-Exclusive instance on reload_config (#712)

### DIFF
--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -198,19 +198,17 @@
 //!
 //! ## Latent bugs surfaced but out of scope
 //!
-//! - **`reload_config` live-runtime application — residual: Bounded-Exclusive
-//!   only — LOW** ([#712]). The new config is now applied to the live runtime
-//!   lazily on the next acquire for every topology *except* Bounded-Exclusive:
-//!   Pooled evicts stale-fingerprint idle instances and recreates; Resident
-//!   rebuilds its shared master when the built-against config fingerprint
-//!   changes (`Resident::clone_or_create`); Bounded-Capped/Unbounded create a
-//!   fresh instance from the current config on every acquire. The one residual
-//!   is **Bounded-Exclusive**: its single reused store-held instance carries no
-//!   config fingerprint, so a fingerprint-aware `accept` (or threading the
-//!   config into `accept`) is needed to evict-and-rebuild it on reload. The
-//!   `SwappedImmediately` outcome stays accurate (config swapped immediately;
-//!   live runtime rebuilt lazily) — no eager drain-then-rebuild redesign was
-//!   needed; see the **accepted relabel** note below.
+//! - **`reload_config` live-runtime application — CLOSED** ([#712]). The new
+//!   config is applied to the live runtime lazily on the next acquire across
+//!   *every* topology: Pooled evicts stale-fingerprint idle instances and
+//!   recreates; Resident rebuilds its shared master on a changed config
+//!   fingerprint (`Resident::clone_or_create`); Bounded-Exclusive evicts its
+//!   reused instance via a fingerprint-aware `accept` (`Bounded::accept` /
+//!   `Bounded::set_fingerprint`); Bounded-Capped/Unbounded create a fresh
+//!   instance from the current config on every acquire. The `SwappedImmediately`
+//!   outcome stays accurate (config swapped immediately; live runtime rebuilt
+//!   lazily) — no eager drain-then-rebuild redesign was needed; see the
+//!   **accepted relabel** note below.
 //! - **Pool `CreateGuard` cancel-drop — residual saturation-only leak — LOW**
 //!   ([#713]). The main cancel-drop path is **closed**: `SlotCreateGuard::drop`
 //!   schedules `destroy_within` via the `ReleaseQueue` (see

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -570,9 +570,10 @@ impl Manager {
     ///   `Resident::clone_or_create`).
     /// - **Bounded (Capped / Unbounded)** — every acquire already creates a
     ///   fresh instance from the current config, so the reload is immediate.
-    /// - **Bounded (Exclusive)** — the single reused instance is **not** yet
-    ///   rebuilt on reload (tracked residual; needs a fingerprint-aware
-    ///   `accept`, since the store-held slot carries no config fingerprint).
+    /// - **Bounded (Exclusive)** — the single reused instance is evicted and
+    ///   rebuilt on the next acquire via a fingerprint-aware `accept` (the
+    ///   topology tracks the built-against vs live config fingerprint; see
+    ///   `Bounded::accept` / `Bounded::set_fingerprint`).
     ///
     /// # Errors
     ///
@@ -630,13 +631,13 @@ impl Manager {
         self.emit(ResourceEvent::ConfigReloaded { key: R::key() });
 
         // Reload outcome. The config `ArcSwap` is swapped immediately; the
-        // live runtime is rebuilt LAZILY on the next acquire (Pooled evicts
-        // stale-fingerprint idle instances; Resident rebuilds its master on a
-        // changed config fingerprint; Bounded-Capped/Unbounded create fresh
-        // per acquire). `SwappedImmediately` is therefore accurate: the config
-        // takes effect on the next acquire without an eager drain-then-rebuild.
-        // Residual: Bounded-Exclusive's single reused instance is not yet
-        // rebuilt on reload ([#712]).
+        // live runtime is rebuilt LAZILY on the next acquire across every
+        // topology (Pooled evicts stale-fingerprint idle instances; Resident
+        // rebuilds its master on a changed config fingerprint; Bounded-Exclusive
+        // evicts its reused instance via a fingerprint-aware `accept`;
+        // Bounded-Capped/Unbounded create fresh per acquire).
+        // `SwappedImmediately` is therefore accurate: the config takes effect on
+        // the next acquire without an eager drain-then-rebuild ([#712]).
         let outcome = ReloadOutcome::SwappedImmediately;
 
         tracing::info!(key = %R::key(), ?outcome, "resource config reloaded");

--- a/crates/resource/src/runtime/bounded.rs
+++ b/crates/resource/src/runtime/bounded.rs
@@ -29,7 +29,7 @@ use std::{
     num::NonZeroUsize,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
 };
 
@@ -66,6 +66,20 @@ pub struct Bounded<R: Provider> {
     /// otherwise lose an update and leave `cap` inconsistent with the real
     /// permit count. Uncontended in the common case (resize is a rare admin op).
     resize_lock: std::sync::Mutex<()>,
+    /// The live `R::Config` fingerprint, updated by
+    /// [`set_fingerprint`](Topology::set_fingerprint) on `Manager::reload_config`.
+    /// Seeded on the first [`create_slot`](Topology::create_slot) from the
+    /// registered config (so it starts equal to the built instance's
+    /// fingerprint and `accept` does not spuriously evict before any reload).
+    /// Only consulted for [`BoundedMode::Exclusive`], the one mode that pools
+    /// (reuses) its instance; `Capped`/`Unbounded` build fresh per acquire.
+    current_fingerprint: AtomicU64,
+    /// The `R::Config` fingerprint the currently-stored Exclusive instance was
+    /// built against (`0` before the first create). A reload changes
+    /// `current_fingerprint`; the next `accept` then evicts the reused instance
+    /// so it is rebuilt against the new config — symmetric to the pool's
+    /// stale-fingerprint eviction and the resident's master rebuild.
+    built_fingerprint: AtomicU64,
     _marker: PhantomData<fn() -> R>,
 }
 
@@ -94,6 +108,8 @@ impl<R: Provider> Bounded<R> {
             sem: Some(Arc::new(Semaphore::new(n.get()))),
             cap: AtomicUsize::new(n.get()),
             resize_lock: std::sync::Mutex::new(()),
+            current_fingerprint: AtomicU64::new(0),
+            built_fingerprint: AtomicU64::new(0),
             _marker: PhantomData,
         })
     }
@@ -107,6 +123,8 @@ impl<R: Provider> Bounded<R> {
             sem: Some(Arc::new(Semaphore::new(1))),
             cap: AtomicUsize::new(1),
             resize_lock: std::sync::Mutex::new(()),
+            current_fingerprint: AtomicU64::new(0),
+            built_fingerprint: AtomicU64::new(0),
             _marker: PhantomData,
         }
     }
@@ -120,6 +138,8 @@ impl<R: Provider> Bounded<R> {
             sem: None,
             cap: AtomicUsize::new(0),
             resize_lock: std::sync::Mutex::new(()),
+            current_fingerprint: AtomicU64::new(0),
+            built_fingerprint: AtomicU64::new(0),
             _marker: PhantomData,
         }
     }
@@ -223,7 +243,20 @@ where
         config: &R::Config,
         ctx: &ResourceContext,
     ) -> Result<R::Instance, Error> {
-        resource.create(config, ctx).await
+        let instance = resource.create(config, ctx).await?;
+        // Stamp the config fingerprint this instance was built against, and
+        // seed the live fingerprint on the very first build. A reload updates
+        // `current_fingerprint` via `set_fingerprint`, so a later rebuild's
+        // `compare_exchange` is a no-op that does not clobber the reloaded
+        // value. Relevant only to `Exclusive` (the reused instance); harmless
+        // for `Capped`/`Unbounded`, which never reach `accept`.
+        use crate::resource::ResourceConfig as _;
+        let fp = config.fingerprint();
+        self.built_fingerprint.store(fp, Ordering::Release);
+        let _ =
+            self.current_fingerprint
+                .compare_exchange(0, fp, Ordering::AcqRel, Ordering::Acquire);
+        Ok(instance)
     }
 
     fn slot_instance<'s>(&self, slot: &'s R::Instance) -> &'s R::Instance {
@@ -232,6 +265,30 @@ where
 
     fn into_instance(&self, slot: R::Instance) -> R::Instance {
         slot
+    }
+
+    /// Evicts the reused `Exclusive` instance when its config has been
+    /// hot-reloaded, so it is rebuilt against the new config on the next
+    /// acquire.
+    ///
+    /// `accept` runs only for a pooling topology — here, `Exclusive`: the
+    /// framework calls it on the checked-out reused instance before handing it
+    /// to a lease, and `false` makes the framework destroy and recreate it via
+    /// `create_slot`. The check compares the built-against vs live config
+    /// fingerprint; `Manager::reload_config` bumps the live one through
+    /// [`set_fingerprint`](Self::set_fingerprint), so the stale instance is
+    /// rebuilt. Normal reuse (unchanged config) matches — the fingerprint is
+    /// seeded at first build. `Capped`/`Unbounded` never pool, so `accept` is
+    /// not reached for them. This mirrors the pool's stale-fingerprint eviction
+    /// and the resident's master rebuild.
+    async fn accept(&self, _slot: &mut R::Instance, _resource: &R, _ctx: &ResourceContext) -> bool {
+        self.built_fingerprint.load(Ordering::Acquire)
+            == self.current_fingerprint.load(Ordering::Acquire)
+    }
+
+    fn set_fingerprint(&self, fingerprint: u64) {
+        self.current_fingerprint
+            .store(fingerprint, Ordering::Release);
     }
 
     async fn on_release(&self, slot: &mut R::Instance, resource: &R) -> Result<bool, Error> {

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -12,14 +12,15 @@ use std::sync::{
 use nebula_core::{ExecutionId, ResourceKey, resource_key};
 use nebula_resource::ResidentConfig;
 use nebula_resource::{
-    AcquireOptions, Manager, ManagerConfig, Pooled, RegistrationSpec, Resident, ResourceContext,
-    ScopeLevel, ShutdownConfig, SlotIdentity, TopologyTag,
+    AcquireOptions, Bounded, Manager, ManagerConfig, Pooled, RegistrationSpec, Resident,
+    ResourceContext, ScopeLevel, ShutdownConfig, SlotIdentity, TopologyTag,
     error::{Error, ErrorKind},
     guard::ResourceGuard,
     recovery::{GateState, RecoveryGate, RecoveryGateConfig},
     release_queue::ReleaseQueue,
     resource::{HasCredentialSlots, Provider, ResourceConfig, ResourceMetadata},
     topology::{
+        bounded::BoundedProvider,
         pooled::{BrokenCheck, PoolProvider, RecycleDecision},
         resident::ResidentProvider,
     },
@@ -3893,6 +3894,114 @@ impl PoolProvider for ReloadPoolResource {
     fn is_broken(&self, _runtime: &Arc<AtomicU64>) -> BrokenCheck {
         BrokenCheck::Healthy
     }
+}
+
+/// Minimal Bounded-Exclusive resource for reload tests — reuses one instance,
+/// reset between leases. `create` carries a monotonic id so a rebuild is
+/// observable.
+#[derive(Clone)]
+struct ReloadExclusiveResource {
+    create_counter: Arc<AtomicU64>,
+}
+
+impl ReloadExclusiveResource {
+    fn new() -> Self {
+        Self {
+            create_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for ReloadExclusiveResource {
+    type Config = ReloadConfig;
+    type Instance = Arc<AtomicU64>;
+    type Topology = Bounded<Self>;
+
+    fn key() -> ResourceKey {
+        resource_key!("test-reload-exclusive")
+    }
+
+    async fn create(
+        &self,
+        _config: &ReloadConfig,
+        _ctx: &ResourceContext,
+    ) -> Result<Arc<AtomicU64>, Error> {
+        let id = self.create_counter.fetch_add(1, Ordering::Relaxed);
+        Ok(Arc::new(AtomicU64::new(id)))
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl HasCredentialSlots for ReloadExclusiveResource {
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+}
+
+impl BoundedProvider for ReloadExclusiveResource {}
+
+#[tokio::test]
+async fn reload_config_rebuilds_bounded_exclusive_instance_with_new_config() {
+    // Bounded-Exclusive reuses ONE instance (reset between leases). Before the
+    // fix, `reload_config` swapped the config but never rebuilt that reused
+    // store-held instance, so an operator's new config never took effect. A
+    // changed config fingerprint must evict-and-rebuild it on the next acquire
+    // — symmetric to Pooled eviction and the Resident master rebuild. The
+    // create-id makes a rebuild observable. Red-on-revert: without the
+    // fingerprint-aware `accept`, the reset instance (same id) is reused.
+    let manager = Arc::new(Manager::new());
+    let resource = ReloadExclusiveResource::new();
+    manager
+        .register(RegistrationSpec {
+            resource,
+            config: ReloadConfig::new(1),
+            scope: ScopeLevel::Global,
+            slot_identity: SlotIdentity::Unbound,
+            topology: Bounded::<ReloadExclusiveResource>::exclusive(),
+            recovery_gate: None,
+        })
+        .expect("register");
+
+    let ctx = test_ctx();
+    let key = ReloadExclusiveResource::key();
+    let acquire = || async {
+        let boxed = Manager::acquire_any(
+            Arc::clone(&manager),
+            &key,
+            &ctx,
+            &AcquireOptions::default(),
+            &SlotIdentity::Unbound,
+        )
+        .await
+        .expect("acquire");
+        *boxed
+            .downcast::<ResourceGuard<ReloadExclusiveResource>>()
+            .expect("downcast")
+    };
+
+    let first = acquire().await;
+    let first_id = first.load(Ordering::Relaxed);
+    // Await release so the reset instance is back in the store BEFORE the
+    // reload — otherwise the next acquire would create fresh from an empty
+    // store and not exercise the fingerprint-aware eviction.
+    first.release().await.expect("release returns the instance");
+
+    manager
+        .reload_config::<ReloadExclusiveResource>(ReloadConfig::new(42), &ScopeLevel::Global)
+        .expect("reload");
+
+    let second = acquire().await;
+    let second_id = second.load(Ordering::Relaxed);
+
+    assert_ne!(
+        first_id, second_id,
+        "reload_config must evict-and-rebuild the Bounded-Exclusive instance \
+         with the new config (a changed fingerprint forces a fresh create)"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Closes the **last #712 residual**. Bounded-Exclusive reuses ONE store-held instance (reset between leases), and `reload_config` swapped the config but never rebuilt it — so an operator's new config never took effect on the live Exclusive runtime. After this, **#712 is closed across every topology** (Pooled #915-era eviction, Resident [#917](https://github.com/vanyastaff/nebula/pull/917), and now Bounded-Exclusive).

## How

`Bounded` tracks the `R::Config` fingerprint its instance was built against (`built_fingerprint`) and the live one (`current_fingerprint`, updated by `set_fingerprint` on reload, **self-seeded** on first build via a `compare_exchange` from `0` so it cannot clobber a reloaded value). A new fingerprint-aware `accept` override evicts the reused instance when the two diverge, so the framework rebuilds it against the new config on the next acquire — **symmetric to Pooled's stale-fingerprint eviction and Resident's master rebuild**. `accept` runs only for the pooling mode (`Exclusive`); `Capped`/`Unbounded` build fresh per acquire and never reach it.

Comparing the built-against fingerprint against the live `set_fingerprint` value — kept **local to `bounded.rs`** — avoids a `Topology::accept` signature change and any churn to Pooled or the manager.

## Reload coverage (now complete)
| Topology | Reload behavior |
|---|---|
| Pooled | stale-fingerprint idle eviction → recreate |
| Resident | master rebuilt on changed config fingerprint |
| **Bounded Exclusive** | **reused instance evicted via fingerprint-aware `accept` → rebuilt** |
| Bounded Capped / Unbounded | fresh per acquire (immediate) |

## Test
`reload_config_rebuilds_bounded_exclusive_instance_with_new_config` — acquire, `release().await` (so the reset instance is back in the store), reload to a differently-fingerprinted config, re-acquire, assert a fresh create-id. Red-on-revert: the reset instance (same id) is otherwise reused.

## Verification
Pre-push gate green: nextest (411 resource-scoped tests, 0 skipped), `clippy-full`, `rustdoc -D warnings`. Ledger + `reload_config` docs updated to mark #712 CLOSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)