### PR TITLE
refactor(schema): unify the three mode-variant selector folds (audit D2)

### DIFF
--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -14,7 +14,7 @@ use smallvec::SmallVec;
 use crate::{
     error::{Severity, ValidationError, ValidationReport},
     expression::ExpressionContext,
-    field::{Field, ListField, ModeField, NumberField, ObjectField},
+    field::{Field, ListField, ModeField, ModeVariant, NumberField, ObjectField},
     key::FieldKey,
     loader::{LoaderContext, LoaderRegistry, LoaderResult},
     mode::ExpressionMode,
@@ -81,7 +81,7 @@ pub enum SchemaKind {
     /// A tagged union (sum type) — the schema is one-of N typed variants
     /// (a Rust enum with data). This is a **marker**: the variants are not stored
     /// in a parallel structure but as the schema's sole root [`Field::Mode`],
-    /// whose [`ModeVariant`](crate::field::ModeVariant) keys are the serde wire
+    /// whose [`ModeVariant`] keys are the serde wire
     /// discriminants. Keeping the union as a root `Mode` means every existing
     /// traversal — [`validate`](ValidSchema::validate), path lookup, projection,
     /// alias canonicalization, the depth guard, and the assignability lattice's
@@ -355,7 +355,7 @@ impl ValidSchema {
     /// Build a tagged-union (sum-type) schema from its variants.
     ///
     /// `mode_field` carries the union's variants — one
-    /// [`ModeVariant`](crate::field::ModeVariant) per Rust enum variant, its key
+    /// [`ModeVariant`] per Rust enum variant, its key
     /// the serde wire discriminant; `tagging` records how the enum's wire form
     /// maps onto those keys (see [`SerdeTagging`]). The union is stored as the
     /// schema's sole **required** root [`Field::Mode`] (see [`SchemaKind::Union`]),
@@ -1045,6 +1045,33 @@ fn project_value(field: &Field, value: &FieldValue) -> Option<serde_json::Value>
     }
 }
 
+/// Resolve the active mode variant from a wire `{mode, value}` object map.
+///
+/// **SECURITY-load-bearing selector rule.** This is the *single* place the
+/// "which variant is active" rule lives for every wire-`Object` fold —
+/// canonicalize ([`canonicalize_nested_value`]), secret-promote
+/// ([`promote_secrets_in_value`]), and project ([`project_mode_object`]). The
+/// three formerly carried byte-identical copies of this match; any drift
+/// between them re-opens the alias-keyed-secret bypass (a secret nested in a
+/// mode payload that one fold resolves and another skips escapes the
+/// canonicalize/strip walk). Unifying it here makes lockstep structural.
+///
+/// Rule: an explicit string `mode` selects that variant; a non-string `mode`
+/// selects none; an absent `mode` falls back to `default_variant`. Returns the
+/// matching variant, or `None` when no key resolves or the key names no
+/// declared variant.
+fn active_mode_variant_for_object<'m>(
+    mode: &'m ModeField,
+    map: &IndexMap<FieldKey, FieldValue>,
+) -> Option<&'m ModeVariant> {
+    let key: &str = match map.get(&*MODE_SELECTOR_KEY) {
+        Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => mode_key.as_str(),
+        Some(_) => return None,
+        None => mode.default_variant.as_deref()?,
+    };
+    mode.variants.iter().find(|v| v.key.as_str() == key)
+}
+
 /// Project a `Field::Mode` whose value arrived as the wire `{mode,value}` object
 /// envelope (the shape `from_json` produces). The selector is kept verbatim; the
 /// payload is projected against the active variant (explicit `mode`, else default).
@@ -1061,15 +1088,9 @@ fn project_mode_object(
         out.insert(MODE_SELECTOR_KEY.as_str().to_owned(), selector.to_json());
     }
 
-    // Resolve the active variant the same way the rest of the crate does.
-    let selected: Option<&str> = match map.get(&*MODE_SELECTOR_KEY) {
-        Some(FieldValue::Literal(Value::String(mode_key))) => Some(mode_key.as_str()),
-        Some(_) => None,
-        None => mode.default_variant.as_deref(),
-    };
+    // Resolve the active variant through the shared selector rule.
     if let Some(payload) = map.get(&*MODE_PAYLOAD_KEY)
-        && let Some(key) = selected
-        && let Some(variant) = mode.variants.iter().find(|v| v.key.as_str() == key)
+        && let Some(variant) = active_mode_variant_for_object(mode, map)
         && let Some(projected) = project_value(variant.field.as_ref(), payload)
     {
         out.insert(MODE_PAYLOAD_KEY.as_str().to_owned(), projected);
@@ -1207,23 +1228,14 @@ fn canonicalize_nested_value(field: &Field, value: &mut FieldValue) {
             // SECURITY: wire ingest parses a `{"mode","value"}` envelope into a
             // `FieldValue::Object`, NEVER a `FieldValue::Mode` (see
             // `value::FieldValue::from_json_limited`), so the typed arm above is
-            // dead for `from_json` input. Resolve the active variant exactly as
-            // `promote_secrets_in_value` / loader / context do — an explicit
-            // string `mode`, else `default_variant` — and recurse into the
-            // payload so alias keys inside the variant fold onto their canonical
-            // FieldKey BEFORE secret-strip, loader redaction, and projection
-            // run. Without this arm an alias-keyed secret in a mode payload
-            // escapes canonicalization and leaks plaintext.
-            let resolved_key = match map.get(&*MODE_SELECTOR_KEY) {
-                Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => {
-                    Some(mode_key.clone())
-                },
-                Some(_) => None,
-                None => mode_field.default_variant.clone(),
-            };
-            if let Some(variant) = resolved_key
-                .as_deref()
-                .and_then(|mode_key| mode_field.variants.iter().find(|v| v.key == mode_key))
+            // dead for `from_json` input. Resolve the active variant through the
+            // shared `active_mode_variant_for_object` selector rule (identical to
+            // `promote_secrets_in_value` / `project_mode_object`) and recurse into
+            // the payload so alias keys inside the variant fold onto their
+            // canonical FieldKey BEFORE secret-strip, loader redaction, and
+            // projection run. Without this arm an alias-keyed secret in a mode
+            // payload escapes canonicalization and leaks plaintext.
+            if let Some(variant) = active_mode_variant_for_object(mode_field, map)
                 && let Some(payload) = map.get_mut(&*MODE_PAYLOAD_KEY)
             {
                 canonicalize_nested_value(variant.field.as_ref(), payload);
@@ -1779,19 +1791,9 @@ fn promote_secrets_in_value(
             promote_secrets_in_value(&var.field, mv.as_mut(), &p, report);
         },
         (Field::Mode(mode), FieldValue::Object(map)) => {
-            let mode_selector_key = &*MODE_SELECTOR_KEY;
             let payload_key = &*MODE_PAYLOAD_KEY;
-            let resolved_key = match map.get(mode_selector_key) {
-                Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => {
-                    Some(mode_key.clone())
-                },
-                Some(_) => None,
-                None => mode.default_variant.clone(),
-            };
-            let Some(var) = resolved_key
-                .as_deref()
-                .and_then(|mode_key| mode.variants.iter().find(|v| v.key == mode_key))
-            else {
+            // Shared selector rule (see `active_mode_variant_for_object`).
+            let Some(var) = active_mode_variant_for_object(mode, map) else {
                 return;
             };
             let Some(mv) = map.get_mut(payload_key) else {


### PR DESCRIPTION
## What

Addresses the schema audit's **D2** (GLM, MEDIUM): the wire `{mode, value}` envelope's *"which variant is active"* rule was duplicated byte-for-byte across the three security-relevant folds — `canonicalize_nested_value`, `promote_secrets_in_value`, and `project_mode_object`. Their own comments admitted the coupling (*"resolve the active variant exactly as … do"*).

The hazard: the three **must stay in lockstep** or an alias-keyed secret nested in a mode payload that one fold resolves and another skips escapes the canonicalize/secret-strip walk and **leaks plaintext**.

## How

Extract one `active_mode_variant_for_object(mode, map)` helper that owns the selector rule (explicit string `mode` → else `default_variant` → find the matching variant), and route all three folds through it. Lockstep is now **structural** ("one fact, one place"), so the alias-secret bypass cannot re-open by drift.

Behaviour is byte-for-byte preserved. The `validate` path keeps its own two-step resolution because it needs the *NoKey vs UnknownKey* distinction for its `mode.required` / `mode.invalid` error reporting — a different concern from the best-effort folds.

## Verification
- Full schema suite passes, including the security seam test **`seam_root_rule_scrub`** (9) and the property tests **`canonical_bytes`** / **`serde_preserves`** — proving no behaviour/canonical-bytes change.
- Pre-push gate green: nextest (641 tests, 0 skipped), `clippy-full`, `rustdoc -D warnings`.

Net `+42/-40` in one file (a wash — the dedup removes the triplicated match). Importing `ModeVariant` made two pre-existing explicit-target doc links redundant; collapsed to shortcut form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)