### PR TITLE
docs(schema): clarify Expression eq + hide FieldValues Any escape hatch (audit D4/D5/D7)

### DIFF
--- a/crates/schema/AGENTS.md
+++ b/crates/schema/AGENTS.md
@@ -26,7 +26,6 @@
 - No KDF/hashing here (removed as a weaker dup of nebula-credential's Argon2id); do not re-add.
 - Public surface is strict: `Field::*::new` needs a pre-validated `FieldKey`; use `field_key!(...)` or `Field::try_*` — no panic-on-bad-key helpers (`set_raw` removed; use `try_set_raw`).
 - `#[deny(clippy::disallowed_macros)]` bans `#[async_trait]`; use the crate's `EvalFuture` (BoxFuture) alias for object-safe async.
-- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
 - Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
 
 ## See also

--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -162,6 +162,11 @@ fn parse_expression_source(source: &str) -> Result<(), String> {
     nebula_expression::parse_expression(source).map_err(|e| e.to_string())
 }
 
+/// Equality is **by source string, not by parsed AST** — two expressions that
+/// parse to the same tree but differ in whitespace or formatting compare
+/// unequal. Parsing inside `eq` would be surprising and allocate; a caller that
+/// needs semantic deduplication should key on the canonical-bytes content id
+/// (see `value.rs`), not on `Expression`'s `PartialEq`.
 impl PartialEq for Expression {
     fn eq(&self, other: &Self) -> bool {
         self.source == other.source

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -91,6 +91,13 @@ impl HasSchema for serde_json::Value {
 /// Baseline `HasSchema` impl for [`FieldValues`] — legacy code paths that still
 /// treat the raw value bag as the input type advertise the gradual-typing `Any`
 /// (unknown shape), not an empty record.
+///
+/// Hidden from the public docs (`#[doc(hidden)]`): it is a soft escape hatch
+/// that partially undercuts the "`schema_of` is the sole path" invariant. New
+/// code must declare a real `#[derive(Schema)]` type rather than lean on
+/// `FieldValues` advertising `Any`; this impl is slated for removal once every
+/// consumer declares a real schema.
+#[doc(hidden)]
 impl HasSchema for FieldValues {
     fn schema() -> ValidSchema {
         any_schema()


### PR DESCRIPTION
## What

Three zero-risk schema-audit **LOW** items (GLM D4/D5/D7), no behaviour change:

- **D5** — document `Expression: PartialEq` as **by source string, not parsed AST**: two whitespace-different but structurally-equal expressions compare unequal. Steers a caller needing semantic dedup to the canonical-bytes content id instead of `==`.
- **D4** — `#[doc(hidden)]` on `impl HasSchema for FieldValues` (the gradual-typing `Any` escape hatch that partially undercuts *"`schema_of` is the sole path"*). Hidden from the public docs so new code declares a real `#[derive(Schema)]` type instead of leaning on it; slated for removal once all consumers do.
- **D7** — delete the stale *"cross-crate calls go through nebula-eventbus"* line from `schema/AGENTS.md` — false boilerplate for a Core crate with no eventbus dependency (flagged in DESIGN §6.4); it misleads an agent reading AGENTS.md first.

## Verification
`clippy -D warnings`, `fmt`, `rustdoc -D warnings` clean; 279 lib tests pass. Pre-push: nextest 641 / clippy-full / crate-diff-gate green. Touches only `expression.rs` / `has_schema.rs` / `AGENTS.md` — independent of the D2 dedup ([#921](https://github.com/vanyastaff/nebula/pull/921)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)