### PR TITLE
docs(schema): correct Expression eq guidance — content id is also by-source

### DIFF
--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -164,9 +164,12 @@ fn parse_expression_source(source: &str) -> Result<(), String> {
 
 /// Equality is **by source string, not by parsed AST** — two expressions that
 /// parse to the same tree but differ in whitespace or formatting compare
-/// unequal. Parsing inside `eq` would be surprising and allocate; a caller that
-/// needs semantic deduplication should key on the canonical-bytes content id
-/// (see `value.rs`), not on `Expression`'s `PartialEq`.
+/// unequal. The canonical-bytes content id keys off the same `source()` bytes
+/// (`value.rs` writes `expr.source().as_bytes()`), so it shares this exact
+/// limitation — neither offers AST-level / semantic dedup. A caller that needs
+/// to collapse whitespace- or formatting-only differences must normalize the
+/// source (or parse and compare the AST) itself. Parsing inside `eq` is
+/// deliberately avoided — it would be surprising and would allocate.
 impl PartialEq for Expression {
     fn eq(&self, other: &Self) -> bool {
         self.source == other.source


### PR DESCRIPTION
Follow-up to [#922](https://github.com/vanyastaff/nebula/pull/922), fixing a **Codex review** catch.

#922's `Expression: PartialEq` doc wrongly steered callers needing semantic dedup to the canonical-bytes content id. That id keys off the **same** `source()` bytes — `value.rs::write_canonical` emits `expr.source().as_bytes()` — so `{{ $x }}` and `{{  $x  }}` still produce different ids. It shares the by-source limitation; it does not solve it.

Reworded: neither `==` nor the content id offers AST-level / semantic dedup; a caller must normalize the source (or compare ASTs) itself.

Doc-only. `rustdoc -D warnings`, `clippy`, `fmt` clean; pre-push nextest 641 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified inline comments to explain how expression equality works and its formatting limitations.
  * Added note that related content-id behavior follows the same raw-text comparison constraints.
  * Documented that parsing is intentionally avoided during equality checks to prevent unexpected allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->