### PR TITLE
docs(credential): repoint stale nebula_engine::credential::* doc refs to canonical homes

### DIFF
--- a/crates/credential/src/accessor.rs
+++ b/crates/credential/src/accessor.rs
@@ -7,8 +7,8 @@
 //! inject a real accessor.
 //!
 //! The engine-runtime accessor that enforces per-action allowlists lives in
-//! `nebula_engine::credential::ScopedCredentialAccessor` (engine depends on
-//! `nebula-credential`, not the other way around).
+//! `nebula_engine::credential_accessor::EngineCredentialAccessor` (engine
+//! depends on `nebula-credential`, not the other way around).
 
 use std::{future::Future, pin::Pin, sync::Arc};
 

--- a/crates/credential/src/provider/event.rs
+++ b/crates/credential/src/provider/event.rs
@@ -1,7 +1,7 @@
 //! Lease lifecycle events for cross-crate signaling.
 //!
-//! Emitted via `EventBus<LeaseEvent>` by the engine's lease lifecycle
-//! subsystem (`nebula_engine::credential::lease`). Subscribers (audit
+//! Emitted via `EventBus<LeaseEvent>` by the lease lifecycle subsystem
+//! (`nebula_credential::runtime::lease`). Subscribers (audit
 //! sinks, metric scrapers, ops dashboards) consume these to track the
 //! health of dynamic-secret grants without reaching into provider
 //! internals.

--- a/crates/credential/src/rotation/mod.rs
+++ b/crates/credential/src/rotation/mod.rs
@@ -25,9 +25,9 @@
 //! Domain types only: rotation events, errors, state-machine enum, IDs,
 //! policy. No orchestration: no `tokio::spawn`, no `tokio::select!`, no
 //! `tokio::time::{sleep, interval, tick}`, no `JoinHandle` ownership.
-//! Background tick loops, blue-green transactions, fan-out drivers,
-//! schedulers, grace-period reapers — all live in
-//! `nebula_engine::credential::rotation::*` instead.
+//! Background tick loops, blue-green transactions, schedulers and
+//! grace-period reapers live in `crate::runtime::rotation`; the resource
+//! fan-out drivers live in `nebula_resource`.
 //!
 //! Note: `error.rs` imports `tokio::time::timeout` solely to enforce the
 //! per-test deadline declared by `TestableCredential::test_timeout()`. This

--- a/crates/credential/src/runtime/lease/mod.rs
+++ b/crates/credential/src/runtime/lease/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! ```ignore
 //! use std::sync::Arc;
-//! use nebula_engine::credential::lease::{
+//! use nebula_credential::runtime::{
 //!     LeaseLifecycle, LeaseLifecycleConfig,
 //! };
 //! use tokio_util::sync::CancellationToken;

--- a/crates/credential/src/runtime/scoped_accessor.rs
+++ b/crates/credential/src/runtime/scoped_accessor.rs
@@ -33,7 +33,7 @@ type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 ///
 /// ```rust,ignore
 /// use nebula_core::CredentialKey;
-/// use nebula_engine::credential::ScopedCredentialAccessor;
+/// use nebula_credential::runtime::ScopedCredentialAccessor;
 ///
 /// let scoped = ScopedCredentialAccessor::new(
 ///     inner_accessor,


### PR DESCRIPTION
Follow-up to [#926](https://github.com/vanyastaff/nebula/pull/926) (ADR-0092 step-8 shim drop). With the engine `credential::rotation` + `credential::mod` re-export block deleted, `nebula-credential`'s own doc comments still pointed readers at the now-removed `nebula_engine::credential::*` paths. These are non-compiling prose / `ignore` doctests, so they never broke a gate — but post-merge they would misdirect to deleted modules.

## Repointed to the canonical homes the types actually live at
- **`rotation/mod.rs`** — rotation orchestration is `crate::runtime::rotation`; the resource fan-out drivers are `nebula_resource` (the old text lumped both under one deleted engine module).
- **`runtime/scoped_accessor.rs`** + **`runtime/lease/mod.rs`** — example imports now use `nebula_credential::runtime::*` (their real home).
- **`accessor.rs`** — the allowlist-enforcing accessor is `nebula_engine::credential_accessor::EngineCredentialAccessor`, not the (deleted) `credential::ScopedCredentialAccessor` re-export. The original named the wrong type *and* a now-dead path; the cross-crate direction note is preserved.
- **`provider/event.rs`** — `LeaseEvent`s come from the lease lifecycle subsystem at `nebula_credential::runtime::lease`.

## Left intentionally
- The "relocated from `nebula-engine::credential`" **provenance** notes — historically accurate (the code *was* relocated from there).
- `contract/refreshable.rs`'s `RefreshDispatcher` link-ref — a separate, pre-existing reference to a planned-but-absent type (`RefreshDispatcher` exists only as a test stand-in), orthogonal to this shim drop.

## Verification
Pre-push gate green: clippy-full, nextest (388 credential tests), `crate-diff-gate` (`rustdoc -D warnings` on nebula-credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)