### PR TITLE
feat(engine): durable-timer wake scanner — recover crashed-runner timer waits (ADR-0099)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -501,7 +501,9 @@ mod frontier;
 mod outcome;
 mod persistence;
 mod resume;
+mod timer_scan;
 use outcome::*;
+pub use timer_scan::DEFAULT_TIMER_SCAN_INTERVAL;
 
 impl WorkflowEngine {
     /// Create a new engine with the given components.

--- a/crates/engine/src/engine/timer_scan.rs
+++ b/crates/engine/src/engine/timer_scan.rs
@@ -1,0 +1,172 @@
+//! Durable-timer wake scanner — the cross-execution liveness safety net for
+//! parked timer waits (ADR-0099 pre-1.0 durability requirement).
+//!
+//! A timer-`Waiting` node fires in-process while its owning runner is alive (the
+//! frontier loop blocks in `select!` on the wake deadline). If that runner
+//! **crashes**, nothing re-drives the timer: a re-delivered `Start` no-ops on
+//! the `Running` status ([`control_dispatch`](crate::control_dispatch)), and
+//! `Resume` recovery only arms *signal* waits — so the overdue timer is
+//! stranded until this scanner picks it up. The durable-timer guarantee is
+//! otherwise *conditional on the parking runner surviving until the deadline*,
+//! which is not durable.
+//!
+//! The sweep lists `Running` executions, finds any with a `Waiting` node whose
+//! persisted `next_attempt_at` is now overdue, and re-drives each through
+//! [`WorkflowEngine::resume_execution`] — the same path a fresh runner takes,
+//! which re-seeds the `wait_heap` from the persisted deadline and fires the
+//! overdue wake in the frontier's Phase 0b.
+//!
+//! The **execution lease is the liveness oracle** (canon: `acquire_lease` is
+//! the sole liveness authority — no second liveness store): a live owner still
+//! holds the lease, so `resume_execution` returns [`EngineError::Leased`] and
+//! the scanner skips (no double-drive); a crashed owner's lease has expired, so
+//! `resume_execution` acquires it and drives the wake. The scanner therefore
+//! adds no new persisted state and no new claim protocol — it only re-invokes,
+//! under the existing lease discipline, the wake path that already works.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nebula_execution::ExecutionState;
+use tokio::task::JoinHandle;
+
+use super::*;
+
+/// Default cadence of the durable-timer wake scanner sweep.
+pub const DEFAULT_TIMER_SCAN_INTERVAL: Duration = Duration::from_secs(30);
+
+impl WorkflowEngine {
+    /// Re-drive every `Running` execution that has an overdue parked timer but
+    /// no live owner, firing the wake the crashed runner would have fired.
+    ///
+    /// The execution lease is the dead-vs-live oracle: a live owner holds it
+    /// (`resume_execution` → [`EngineError::Leased`] → skipped, no double-drive);
+    /// a crashed owner's lease has expired (acquired → wake driven). Per-node
+    /// signal-only waits (`next_attempt_at == None`) are never touched — they
+    /// are not timers. A signal wait parked *with* a timeout (`wait_wake ==
+    /// Timeout`) whose deadline is overdue is correctly fired down its timeout
+    /// (fail) branch, exactly as a live runner would.
+    ///
+    /// Returns the number of executions re-driven. Per-execution errors are
+    /// logged and never abort the sweep.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError::PlanningFailed`] only if the initial
+    /// `list_running` storage call fails; individual execution failures are
+    /// absorbed so one bad row cannot wedge the sweep.
+    pub async fn sweep_overdue_timers(&self, scope: &Scope) -> Result<usize, EngineError> {
+        let Some(stores) = self.stores.clone() else {
+            // No durable store wired (library mode) — nothing to scan.
+            return Ok(0);
+        };
+        let now = self.clock.now();
+        let running =
+            stores.execution.list_running(scope).await.map_err(|e| {
+                EngineError::PlanningFailed(format!("timer-scan list_running: {e}"))
+            })?;
+
+        let mut redriven = 0usize;
+        for id in running {
+            let Ok(Some(record)) = stores.execution.get(scope, &id).await else {
+                // Storage blip or the row vanished between list and get — the
+                // next sweep retries.
+                continue;
+            };
+            // `from_str` (not `from_value`): `ExecutionState` carries a borrowing
+            // field that `serde_json::from_value` cannot deserialize from an owned
+            // `Value`, so round-trip through the string form (the same convention
+            // the engine's own state-load path uses).
+            let Ok(state) = serde_json::from_str::<ExecutionState>(&record.state.to_string())
+            else {
+                continue;
+            };
+            let has_overdue_timer = state.node_states.values().any(|ns| {
+                ns.state == NodeState::Waiting && ns.next_attempt_at.is_some_and(|when| when <= now)
+            });
+            if !has_overdue_timer {
+                continue;
+            }
+            let Ok(execution_id) = id.parse::<ExecutionId>() else {
+                tracing::warn!(
+                    target = "engine::timer_scan",
+                    execution_id = %id,
+                    "unparseable execution id in running set; skipping"
+                );
+                continue;
+            };
+            match self.resume_execution(scope, execution_id).await {
+                Ok(_) => {
+                    redriven += 1;
+                    tracing::debug!(
+                        target = "engine::timer_scan",
+                        %execution_id,
+                        "re-drove overdue timer wake for a no-live-owner execution"
+                    );
+                },
+                // Live owner holds the lease — it will fire the wake in-process.
+                Err(EngineError::Leased { .. }) => {},
+                Err(e) => {
+                    tracing::warn!(
+                        target = "engine::timer_scan",
+                        %execution_id,
+                        error = %e,
+                        "overdue-timer re-drive failed; will retry next sweep"
+                    );
+                },
+            }
+        }
+        Ok(redriven)
+    }
+
+    /// Spawn the durable-timer wake scanner as a background task.
+    ///
+    /// Ticks every `interval`, calling [`sweep_overdue_timers`](Self::sweep_overdue_timers)
+    /// for `scope`, until `shutdown` is cancelled. Mirrors the control-queue
+    /// reclaim sweep's plain-task model (a missed tick is delayed, not bursted).
+    /// The composition root owns the cadence; [`DEFAULT_TIMER_SCAN_INTERVAL`] is
+    /// a sane default.
+    #[must_use = "the returned JoinHandle owns the scanner task; dropping it detaches the loop"]
+    pub fn spawn_timer_scanner(
+        self: Arc<Self>,
+        scope: Scope,
+        interval: Duration,
+        shutdown: CancellationToken,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // Skip the immediate first tick: nothing is overdue the instant we
+            // start, and a freshly-restarted process should let live runners
+            // re-seed before sweeping.
+            let _ = ticker.tick().await;
+            loop {
+                tokio::select! {
+                    biased;
+                    () = shutdown.cancelled() => {
+                        tracing::info!(
+                            target = "engine::timer_scan",
+                            "durable-timer scanner shutting down"
+                        );
+                        return;
+                    }
+                    _ = ticker.tick() => {
+                        match self.sweep_overdue_timers(&scope).await {
+                            Ok(n) if n > 0 => tracing::info!(
+                                target = "engine::timer_scan",
+                                redriven = n,
+                                "durable-timer scanner re-drove overdue wakes"
+                            ),
+                            Ok(_) => {},
+                            Err(e) => tracing::warn!(
+                                target = "engine::timer_scan",
+                                error = %e,
+                                "durable-timer sweep failed; will retry next tick"
+                            ),
+                        }
+                    }
+                }
+            }
+        })
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -98,7 +98,7 @@ pub use daemon::{
     EventSource, EventSourceAdapter, EventSourceConfig, EventSourceRuntime, RestartPolicy,
     RoutingError, RoutingResolver, SLICE_FLAVOR_SHA,
 };
-pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, WorkflowEngine};
+pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, DEFAULT_TIMER_SCAN_INTERVAL, WorkflowEngine};
 pub use error::EngineError;
 pub use event::{ExecutionEvent, NodeFailedDetails};
 pub use nebula_storage_port::dto::ResumeTarget;

--- a/crates/engine/tests/timer_wait_crash_recovery.rs
+++ b/crates/engine/tests/timer_wait_crash_recovery.rs
@@ -1,0 +1,553 @@
+//! Integration test: crash-without-Resume timer-wait recovery.
+//!
+//! Verifies the HYPOTHESIS from the engine audit:
+//!
+//! > crash → control-queue row stays Processing → reclaim re-delivers the
+//! > original command → dispatch → `resume_execution` → re-seeds `wait_heap`
+//! > from persisted `next_attempt_at` → Phase 0b fires the now-overdue timer.
+//!
+//! Specifically, this test exercises the **pure timer-wait** path
+//! (`WaitCondition::Duration`, `timeout: None`) — distinct from the
+//! signal+timeout wait already covered in `wait_timeout.rs`. The timer-only
+//! path:
+//!
+//! - Produces `wake_at = Some(deadline)` → pushed to `wait_heap`.
+//! - Persists `next_attempt_at = deadline`, `wait_wake = None` (Completion).
+//! - Keeps the execution `Running` (not `Paused`) because `wake_at.is_some()`.
+//!
+//! On a fresh re-drive (`resume_execution` from a new engine instance, same
+//! durable store, NO Resume command), `run_frontier` re-seeds `wait_heap` from
+//! `next_attempt_at` at lines 105-111 of `frontier.rs`. If the deadline is
+//! already past, Phase 0b drains the entry immediately, reads `wait_wake = None`
+//! (treated as `Completion`), transitions `Waiting → Completed`, and activates
+//! downstream edges. The execution then completes.
+//!
+//! ## Timing model
+//!
+//! The engine's `wait_heap` deadlines are wall-clock (`chrono::Utc`), not tokio
+//! timers, so `tokio::time::pause`/`advance` cannot drive them. The test uses
+//! real, short durations: 1s timer deadline, abort at 200ms, sleep 1.2s to
+//! ensure the deadline is overdue before the re-drive. This mirrors the pattern
+//! from `wait_timeout.rs` (`crash_mid_wait_with_timeout_recovers_and_can_still_timeout`).
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, ExecutionEvent,
+    InProcessRunner, WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
+use nebula_storage_port::{
+    dto::WorkflowVersionRecord,
+    store::{ExecutionStore, WorkflowVersionStore},
+};
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Action stubs ─────────────────────────────────────────────────────────────
+
+macro_rules! static_action_impl {
+    ($ty:ty, $key:expr, $name:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, "timer_wait_crash_recovery test stub")
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+/// Parks on a `WaitCondition::Duration` timer — the pure timer-wait path.
+/// `timeout: None` means `wait_wake = None` on the persisted row, which
+/// Phase 0b treats as `Completion` (not `Timeout`). The execution stays
+/// `Running` (not `Paused`) because `wake_at = Some(deadline)`.
+struct TimerWaitAction {
+    duration: Duration,
+}
+
+static_action_impl!(
+    TimerWaitAction,
+    action_key!("test.twcr.timer_wait"),
+    "TimerWaitAction"
+);
+
+impl StatelessAction for TimerWaitAction {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Duration {
+                duration: self.duration,
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Counts invocations. The downstream node is the observable gate: it must run
+/// after the recovered timer fires, proving Phase 0b completed the wait node.
+struct CountingDownstream {
+    invocations: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingDownstream,
+    action_key!("test.twcr.downstream"),
+    "CountingDownstream"
+);
+
+impl StatelessAction for CountingDownstream {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Shared store bundle ───────────────────────────────────────────────────────
+
+struct CrashRecoveryStores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl CrashRecoveryStores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+            resume_tokens: Arc::new(self.execution.resume_token_store()),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+
+    async fn save_workflow(&self, wf: &WorkflowDefinition) {
+        self.versions
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                WorkflowVersionRecord {
+                    workflow_id: wf.id.to_string(),
+                    number: 0,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(wf).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn persist_created_execution(&self, workflow_id: nebula_core::WorkflowId) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        self.execution
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+                &workflow_id.to_string(),
+                serde_json::to_value(&exec_state).unwrap(),
+            )
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    async fn load_state(&self, execution_id: ExecutionId) -> ExecutionState {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        let raw = serde_json::to_string(&record.state).unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    async fn persisted_status(&self, execution_id: ExecutionId) -> ExecutionStatus {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        serde_json::from_value(record.state["status"].clone()).unwrap()
+    }
+}
+
+// ── Engine assembly ───────────────────────────────────────────────────────────
+
+fn build_registry(
+    timer_duration: Duration,
+    downstream_invocations: &Arc<AtomicU32>,
+) -> Arc<ActionRegistry> {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.twcr.timer_wait"),
+            "TimerWaitAction",
+            "timer_wait_crash_recovery stub",
+        ),
+        TimerWaitAction {
+            duration: timer_duration,
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.twcr.downstream"),
+            "CountingDownstream",
+            "timer_wait_crash_recovery stub",
+        ),
+        CountingDownstream {
+            invocations: Arc::clone(downstream_invocations),
+        },
+    );
+    registry
+}
+
+fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
+}
+
+/// Workflow: `timer_node ──main──> downstream_node`.
+/// `timer_node` parks on a `Duration` wait; `downstream_node` counts invocations.
+fn build_workflow() -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    let timer_node = node_key!("timer_node");
+    let downstream_node = node_key!("downstream_node");
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "timer-wait-crash-recovery".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                timer_node.clone(),
+                "TimerNode",
+                "core",
+                "test.twcr.timer_wait",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                downstream_node.clone(),
+                "DownstreamNode",
+                "core",
+                "test.twcr.downstream",
+            )
+            .unwrap(),
+        ],
+        connections: vec![Connection::new(timer_node, downstream_node)],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+// ── Shared park-then-crash setup ───────────────────────────────────────────────
+
+/// Lease TTL: the in-mem store clamps to >= 1s, so 1s is the floor — long enough
+/// that runner A holds the lease while alive, short enough that it expires in the
+/// overdue-sleep window so the recovery path can re-acquire the abandoned lease.
+const LEASE_TTL: Duration = Duration::from_secs(1);
+const HEARTBEAT: Duration = Duration::from_millis(300);
+/// 1s timer — will NOT fire before we abort runner A, clearly overdue after the
+/// 1.2s sleep.
+const TIMER_DURATION: Duration = Duration::from_secs(1);
+/// Sleep until the deadline is overdue AND the abandoned lease's TTL has lapsed.
+const OVERDUE_SLEEP: Duration = Duration::from_millis(1_200);
+
+/// Drive a single-timer workflow to its park, then "crash" the runner (abort the
+/// drive task right after `NodeParked`), and sleep until the deadline is overdue
+/// and the abandoned lease has expired. Returns the persisted `execution_id` of a
+/// `Running` execution holding a `Waiting` timer node with an overdue
+/// `next_attempt_at` and no live owner — the exact durable state a recovery path
+/// must wake.
+async fn park_timer_then_crash(
+    stores: &CrashRecoveryStores,
+    downstream_invocations: &Arc<AtomicU32>,
+) -> ExecutionId {
+    let wf = build_workflow();
+    stores.save_workflow(&wf).await;
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_registry(TIMER_DURATION, downstream_invocations))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(LEASE_TTL)
+            .with_lease_heartbeat_interval(HEARTBEAT),
+    );
+
+    let execution_id = stores.persist_created_execution(wf.id).await;
+    let engine_a_handle = Arc::clone(&engine_a);
+    let scope_a = nebula_engine::store_seam::single_tenant_scope();
+    let task_a = tokio::spawn(async move {
+        engine_a_handle
+            .resume_execution(&scope_a, execution_id)
+            .await
+    });
+
+    // `NodeParked` fires only after the park checkpoint has durably landed, so
+    // aborting now cannot race the park write.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { .. }) => break,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeParked"),
+            }
+        }
+    })
+    .await
+    .expect("runner A must emit NodeParked for the timer-wait node");
+
+    assert_eq!(
+        downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must be gated while the timer node is Waiting"
+    );
+
+    // Crash: abort the parking runner. The park is already durable.
+    task_a.abort();
+    let _ = task_a.await;
+
+    // The parked node is Waiting with a future deadline, and the execution is
+    // Running (a timer-wait with `wake_at = Some` keeps the frontier alive, so
+    // the row is NOT Paused — confirming nothing but a timer scanner can wake it).
+    let parked_state = stores.load_state(execution_id).await;
+    let timer_node_state = parked_state
+        .node_states
+        .values()
+        .find(|ns| ns.state == nebula_workflow::NodeState::Waiting)
+        .expect("timer_node must be in Waiting after the park checkpoint");
+    let persisted_deadline = timer_node_state
+        .next_attempt_at
+        .expect("next_attempt_at must be persisted so a re-drive can re-seed the wait_heap");
+    assert!(
+        persisted_deadline > chrono::Utc::now(),
+        "deadline must be in the future right after the park: deadline={persisted_deadline}"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "a timer-wait node with wake_at must keep the execution Running, not Paused"
+    );
+
+    // Sleep until the deadline is overdue AND the abandoned lease has expired.
+    tokio::time::sleep(OVERDUE_SLEEP).await;
+    assert!(
+        persisted_deadline <= chrono::Utc::now(),
+        "deadline must be in the past after the overdue sleep: deadline={persisted_deadline}, \
+         now={}",
+        chrono::Utc::now()
+    );
+
+    execution_id
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+/// **Mechanism:** a fresh re-drive of `resume_execution` fires the overdue timer.
+///
+/// Proves the underlying wake path is sound: `run_frontier` re-seeds `wait_heap`
+/// from the persisted `next_attempt_at` (frontier.rs lines 105-111); because the
+/// deadline is overdue, Phase 0b drains it immediately, reads `wait_wake = None`
+/// (Completion), transitions `Waiting → Completed`, and activates downstream — all
+/// with NO Resume command.
+///
+/// **Falsifiability**: drop the `wait_heap` re-seed loop → the overdue entry is
+/// never pushed → Phase 0b never fires → the wait stays `Waiting`, downstream
+/// stays gated → both final assertions fail → RED.
+#[tokio::test]
+async fn resume_execution_redrive_fires_overdue_timer() {
+    let downstream_invocations = Arc::new(AtomicU32::new(0));
+    let stores = CrashRecoveryStores::new();
+    let execution_id = park_timer_then_crash(&stores, &downstream_invocations).await;
+
+    // Fresh runner B (no in-process RunningEntry) re-drives directly.
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_registry(
+                TIMER_DURATION,
+                &downstream_invocations,
+            )))
+            .with_lease_ttl(LEASE_TTL)
+            .with_lease_heartbeat_interval(HEARTBEAT),
+    );
+    let engine_b_handle = Arc::clone(&engine_b);
+    let scope_b = nebula_engine::store_seam::single_tenant_scope();
+    let recovery_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::spawn(async move {
+            engine_b_handle
+                .resume_execution(&scope_b, execution_id)
+                .await
+        }),
+    )
+    .await
+    .expect("runner B must settle the recovered timer within 10s")
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        recovery_result.status,
+        ExecutionStatus::Completed,
+        "re-drive must complete the execution after re-seeding the overdue timer; got {:?}",
+        recovery_result.status
+    );
+    assert_eq!(
+        downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once after the recovered timer fires"
+    );
+}
+
+/// **Production path:** the durable-timer scanner (`sweep_overdue_timers`) is what
+/// actually wakes a crashed timer.
+///
+/// Nothing else re-drives a crashed pure-timer execution — a re-delivered `Start`
+/// no-ops on the `Running` status, and `Resume` recovery only arms *signal* waits.
+/// So the scanner is the recovery mechanism: it must DISCOVER the `Running`
+/// execution with an overdue `Waiting` timer (whose lease is now free) and re-drive
+/// it. This test runs the scanner — NOT `resume_execution` directly — and asserts
+/// it found and woke the one stranded execution.
+///
+/// **Falsifiability**: if the sweep's overdue predicate is wrong (never matches the
+/// row) or it does not call `resume_execution`, it returns `0`, downstream stays
+/// gated at `0`, and the execution stays `Running` with a `Waiting` node → RED.
+#[tokio::test]
+async fn durable_timer_scanner_recovers_crashed_timer_without_resume() {
+    let downstream_invocations = Arc::new(AtomicU32::new(0));
+    let stores = CrashRecoveryStores::new();
+    let execution_id = park_timer_then_crash(&stores, &downstream_invocations).await;
+
+    // Fresh runner B runs the SCANNER (the production recovery path), not a direct
+    // resume_execution. The scanner lists Running executions, finds the overdue
+    // Waiting timer, sees the lease is free (crashed owner), and re-drives.
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_registry(
+                TIMER_DURATION,
+                &downstream_invocations,
+            )))
+            .with_lease_ttl(LEASE_TTL)
+            .with_lease_heartbeat_interval(HEARTBEAT),
+    );
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let redriven = tokio::time::timeout(
+        Duration::from_secs(10),
+        engine_b.sweep_overdue_timers(&scope),
+    )
+    .await
+    .expect("the scanner must settle within 10s")
+    .expect("the scanner sweep must not error");
+
+    assert_eq!(
+        redriven, 1,
+        "the scanner must discover and re-drive exactly one crashed overdue-timer execution"
+    );
+    assert_eq!(
+        downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "the scanner must fire the overdue timer so downstream runs exactly once"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "the execution must reach Completed after the scanner wakes the stranded timer"
+    );
+}


### PR DESCRIPTION
Closes the cross-execution **durable-timer liveness gap** the durable canon names a pre-1.0 blocker. Surfaced by an advisory agent panel, then **verify-first** pinned the precise hole (the panel's "timers never fire" framing was imprecise — the truth is narrower and was confirmed in code + a characterization test).

## The verified hole
- A timer-`Waiting` node fires in-process **while its owning runner is alive** — `run_frontier` blocks in `select!` on the wake deadline, so the execution stays `Running`, not `Paused`.
- If that runner **crashes**, nothing re-drives the timer:
  - a re-delivered `Start` **no-ops on `Running`** (`control_dispatch.rs`);
  - `Resume` no-live-owner recovery (`recover_running_resume` → `satisfy_running_signal_waits`, W-S3b) only arms **signal** waits → a pure timer node is `NothingToSatisfy` → acked as a no-op;
  - there is **no scanner**, and the control-queue reclaim sweep only re-delivers stuck `Processing` rows — and `Start` is **not** budget-exempt, so a long delay outliving a few reclaim cycles is force-`Failed`.

Net: the durable-timer guarantee was *conditional on the parking runner surviving until the deadline* — not durable. (`resume_execution` itself **does** fire an overdue timer on re-drive — proven by a test — but no production path invokes it for a crashed pure-timer execution. That's the gap.)

## Fix
`WorkflowEngine::sweep_overdue_timers` lists `Running` executions, finds any with a `Waiting` node whose persisted `next_attempt_at` is overdue, and re-drives each through `resume_execution` (which re-seeds the `wait_heap` and fires the wake in Phase 0b). The **execution lease is the liveness oracle** (canon: `acquire_lease` is the sole liveness authority): a live owner holds it → `EngineError::Leased` → skipped (no double-drive); a crashed owner's lease has expired → acquired → wake driven. **No new persisted state, no new status, no new claim protocol** — it only re-invokes the wake path that already works, under the existing lease discipline. `spawn_timer_scanner` runs it on a cadence (`DEFAULT_TIMER_SCAN_INTERVAL` = 30s), mirroring the control-consumer reclaim sweep; composition roots wire it alongside `ControlConsumer`.

Signal-only waits (`next_attempt_at == None`) are never touched. An overdue signal+timeout wait is correctly fired down its timeout (fail) branch, exactly as a live runner would.

## Tests (red-on-revert)
- **`durable_timer_scanner_recovers_crashed_timer_without_resume`** — the production path: crash a pure-timer owner, run the **scanner** (not `resume_execution` directly), assert it discovers + wakes the stranded execution. RED without the scanner.
- `resume_execution_redrive_fires_overdue_timer` — the underlying wake mechanism.

## Verification
Pre-push gate green: clippy-full, nextest (427 engine tests, 0 skipped), `crate-diff-gate` (`rustdoc -D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for overdue timer waits, helping workflows continue after a crash or restart.
  * Introduced a background timer scan that periodically checks for stranded timer waits and resumes them when needed.

* **Bug Fixes**
  * Improved reliability for workflows that pause on timers, reducing the chance of timers being left behind after failures.
  * Ensured recovered timers can continue to the next step and complete as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->