### PR TITLE
fix(action)!: validated PortKey/BranchKey newtypes close serde phantom-port forgery (W0 U1)

### DIFF
--- a/crates/action/src/branch_key.rs
+++ b/crates/action/src/branch_key.rs
@@ -1,0 +1,285 @@
+//! [`BranchKey`] — validated newtype for workflow branch identifiers.
+//!
+//! A `BranchKey` names a specific branch selected by an action (e.g. `"true"`,
+//! `"false"`, `"case_1"`). It shares the same validation rules as
+//! [`PortKey`](crate::PortKey) but is a **distinct type**: assigning a
+//! `BranchKey` where a `PortKey` is required (or vice-versa) is a compile-time
+//! type error.
+//!
+//! # Serde security contract
+//!
+//! `#[serde(try_from = "String", into = "String")]` routes deserialization
+//! through [`TryFrom<String>`] so invalid branch names are rejected at the
+//! serde boundary.
+//!
+//! # Compile-time literals
+//!
+//! Use the [`branch_key!`](crate::branch_key!) macro for hard-coded literals.
+//!
+//! ```rust
+//! use nebula_action::branch_key;
+//! let k = branch_key!("true");
+//! assert_eq!(k.as_str(), "true");
+//! ```
+
+use std::borrow::Borrow;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::key_validation::{KeyValidationError, is_valid_key, validate_key};
+
+// ── BranchKey ────────────────────────────────────────────────────────────────
+
+/// A validated branch key identifying a selected workflow branch.
+///
+/// Valid keys satisfy:
+/// - Non-empty, ≤ 64 bytes.
+/// - Characters `[a-zA-Z0-9_-]` only (case-sensitive).
+/// - No leading or trailing `_`/`-`.
+/// - No consecutive `--` or `__`.
+///
+/// Construct from a literal with [`branch_key!`](crate::branch_key!), or at
+/// runtime via [`BranchKey::new`] / [`TryFrom`].
+///
+/// The [`Borrow<str>`] and [`AsRef<str>`] impls allow `HashMap<BranchKey, _>`
+/// to be queried with a bare `&str` key.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct BranchKey(String);
+
+impl BranchKey {
+    /// Construct a `BranchKey`, validating the supplied string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyValidationError`] when the string violates any key rule.
+    pub fn new(s: impl Into<String>) -> Result<Self, KeyValidationError> {
+        let s = s.into();
+        validate_key(&s).map_err(|kind| KeyValidationError::new(s.clone(), kind))?;
+        Ok(Self(s))
+    }
+
+    /// Borrow the key as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns `true` when `s` satisfies all key rules.
+    ///
+    /// Used by the [`branch_key!`](crate::branch_key!) macro's compile-time
+    /// `const assert!`.
+    #[must_use]
+    pub const fn is_valid_key_const(s: &str) -> bool {
+        is_valid_key(s)
+    }
+}
+
+// ── Standard trait impls ─────────────────────────────────────────────────────
+
+impl fmt::Debug for BranchKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BranchKey({:?})", self.0)
+    }
+}
+
+impl fmt::Display for BranchKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for BranchKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// `Borrow<str>` is required so `HashMap<BranchKey, _>::get("true")` works
+/// without an owned `BranchKey`. The `Hash` and `PartialEq` impls delegate to
+/// `str` (via the derived impls on the inner `String`), satisfying the
+/// `Borrow` contract: `hash(key) == hash(key.borrow())`.
+impl Borrow<str> for BranchKey {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for BranchKey {
+    type Error = KeyValidationError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        validate_key(&s).map_err(|kind| KeyValidationError::new(s.clone(), kind))?;
+        Ok(Self(s))
+    }
+}
+
+impl TryFrom<&str> for BranchKey {
+    type Error = KeyValidationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        validate_key(s).map_err(|kind| KeyValidationError::new(s, kind))?;
+        Ok(Self(s.to_owned()))
+    }
+}
+
+/// Required by `#[serde(into = "String")]`.
+impl From<BranchKey> for String {
+    fn from(k: BranchKey) -> Self {
+        k.0
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::key_validation::KeyValidationErrorKind;
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_branch_keys() {
+        for key in ["true", "false", "default", "case-1", "case_1", "a"] {
+            assert!(BranchKey::new(key).is_ok(), "{key:?} should be valid");
+        }
+    }
+
+    #[test]
+    fn invalid_empty() {
+        assert!(matches!(
+            BranchKey::new("").unwrap_err().kind,
+            KeyValidationErrorKind::Empty
+        ));
+    }
+
+    #[test]
+    fn invalid_leading_underscore() {
+        assert!(matches!(
+            BranchKey::new("_x").unwrap_err().kind,
+            KeyValidationErrorKind::LeadingOrTrailingSeparator
+        ));
+    }
+
+    #[test]
+    fn invalid_consecutive_dash() {
+        assert!(matches!(
+            BranchKey::new("a--b").unwrap_err().kind,
+            KeyValidationErrorKind::ConsecutiveSeparator
+        ));
+    }
+
+    #[test]
+    fn invalid_space() {
+        assert!(matches!(
+            BranchKey::new("bad branch").unwrap_err().kind,
+            KeyValidationErrorKind::InvalidChar { ch: ' ', .. }
+        ));
+    }
+
+    // ── Type distinctness: BranchKey ≠ PortKey ───────────────────────────────
+
+    // Enforced at compile time: the following would be a type error:
+    //   let _: PortKey = BranchKey::new("out").unwrap();
+    // No runtime test is needed; the absence of From<BranchKey> for PortKey
+    // makes the wrong assignment a compiler error.
+
+    // ── HashMap Borrow<str> ──────────────────────────────────────────────────
+
+    #[test]
+    fn hashmap_get_by_str_via_borrow() {
+        let mut map: HashMap<BranchKey, &str> = HashMap::new();
+        map.insert(BranchKey::new("true").unwrap(), "yes");
+        map.insert(BranchKey::new("false").unwrap(), "no");
+
+        assert_eq!(map.get("true"), Some(&"yes"));
+        assert_eq!(map.get("false"), Some(&"no"));
+        assert_eq!(map.get("missing"), None);
+        assert!(map.contains_key("true"));
+    }
+
+    // ── Serde round-trip ─────────────────────────────────────────────────────
+
+    #[test]
+    fn serde_round_trip_valid() {
+        let key = BranchKey::new("true").unwrap();
+        let json = serde_json::to_string(&key).unwrap();
+        assert_eq!(json, r#""true""#);
+        let back: BranchKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(key, back);
+    }
+
+    #[test]
+    fn serde_rejects_forged_invalid_char() {
+        let result: Result<BranchKey, _> = serde_json::from_str(r#""bad branch!""#);
+        assert!(
+            result.is_err(),
+            "BranchKey deserialization must reject keys with invalid characters"
+        );
+    }
+
+    #[test]
+    fn serde_rejects_empty_key() {
+        let result: Result<BranchKey, _> = serde_json::from_str(r#""""#);
+        assert!(
+            result.is_err(),
+            "BranchKey deserialization must reject empty string"
+        );
+    }
+
+    // ── Display / Debug ──────────────────────────────────────────────────────
+
+    #[test]
+    fn display_shows_key_string() {
+        let key = BranchKey::new("true").unwrap();
+        assert_eq!(key.to_string(), "true");
+    }
+
+    #[test]
+    fn debug_is_readable() {
+        let key = BranchKey::new("true").unwrap();
+        assert_eq!(format!("{key:?}"), r#"BranchKey("true")"#);
+    }
+
+    // ── From<BranchKey> for String ────────────────────────────────────────────
+
+    #[test]
+    fn into_string_conversion() {
+        let key = BranchKey::new("false").unwrap();
+        let s: String = key.into();
+        assert_eq!(s, "false");
+    }
+
+    // ── TryFrom<&str> ────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_from_str_valid() {
+        let key = BranchKey::try_from("true").unwrap();
+        assert_eq!(key.as_str(), "true");
+    }
+
+    #[test]
+    fn try_from_str_invalid() {
+        assert!(BranchKey::try_from("bad!").is_err());
+    }
+
+    // ── is_valid_key_const ───────────────────────────────────────────────────
+
+    #[test]
+    fn const_check_valid() {
+        assert!(BranchKey::is_valid_key_const("true"));
+        assert!(BranchKey::is_valid_key_const("false"));
+        assert!(BranchKey::is_valid_key_const("default"));
+    }
+
+    #[test]
+    fn const_check_invalid() {
+        assert!(!BranchKey::is_valid_key_const(""));
+        assert!(!BranchKey::is_valid_key_const("_x"));
+        assert!(!BranchKey::is_valid_key_const("a--b"));
+    }
+}

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -66,9 +66,9 @@
 //!         _ctx: &(impl nebula_action::ActionContext + ?Sized),
 //!     ) -> Result<ControlOutcome, ActionError> {
 //!         let condition = input.get_bool("/condition")?;
-//!         let selected = if condition { "true" } else { "false" };
+//!         let selected = if condition { nebula_action::branch_key!("true") } else { nebula_action::branch_key!("false") };
 //!         Ok(ControlOutcome::Branch {
-//!             selected: selected.into(),
+//!             selected,
 //!             output: input.into_value(),
 //!         })
 //!     }
@@ -81,10 +81,11 @@ use serde_json::Value;
 
 use crate::{
     action::Action,
+    branch_key::BranchKey,
     context::ActionContext,
     error::{ActionError, ValidationReason},
     metadata::{ActionKind, ActionMetadata},
-    port::PortKey,
+    port_key::PortKey,
     result::{ActionResult, TerminationReason},
     stateless::StatelessHandler,
 };
@@ -274,8 +275,8 @@ pub enum ControlOutcome {
     /// first-match mode. `selected` must match a port key declared in
     /// [`ActionMetadata::outputs`].
     Branch {
-        /// Key of the chosen output port.
-        selected: PortKey,
+        /// Key of the chosen branch output port.
+        selected: BranchKey,
         /// Value to emit on the selected port.
         output: Value,
     },
@@ -413,7 +414,7 @@ pub trait ControlAction: Action {
     ///
     /// ```ignore
     /// // Explicit form — use this if you want to spell out bounds
-    /// // or match the existing StatelessAction::execute convention.
+    /// // or match the existing `StatelessAction::execute` convention.
     /// fn evaluate(
     ///     &self,
     ///     input: ControlInput,
@@ -532,7 +533,9 @@ mod tests {
 
     use super::*;
     use crate::{
+        branch_key,
         port::{OutputPort, default_input_ports, default_output_ports},
+        port_key,
         testing::{TestActionContext, TestContextBuilder},
     };
 
@@ -609,7 +612,7 @@ mod tests {
     #[test]
     fn outcome_branch_desugars_to_action_result_branch() {
         let outcome = ControlOutcome::Branch {
-            selected: "true".into(),
+            selected: branch_key!("true"),
             output: serde_json::json!({"v": 1}),
         };
         let result: ActionResult<Value> = outcome.into();
@@ -619,7 +622,7 @@ mod tests {
                 output,
                 alternatives,
             } => {
-                assert_eq!(selected, "true");
+                assert_eq!(selected.as_str(), "true");
                 assert_eq!(output.as_value(), Some(&serde_json::json!({"v": 1})));
                 assert!(alternatives.is_empty());
             },
@@ -631,8 +634,8 @@ mod tests {
     fn outcome_route_desugars_to_multi_output() {
         let outcome = ControlOutcome::Route {
             ports: std::collections::HashMap::from([
-                ("high".into(), serde_json::json!(1)),
-                ("low".into(), serde_json::json!(2)),
+                (port_key!("high"), serde_json::json!(1)),
+                (port_key!("low"), serde_json::json!(2)),
             ]),
         };
         let result: ActionResult<Value> = outcome.into();
@@ -734,7 +737,10 @@ mod tests {
         fn metadata() -> ActionMetadata {
             ActionMetadata::new(action_key!("test.if"), "TestIf", "Binary branch")
                 .with_inputs(default_input_ports())
-                .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
+                .with_outputs(vec![
+                    OutputPort::flow(port_key!("true")),
+                    OutputPort::flow(port_key!("false")),
+                ])
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -749,9 +755,13 @@ mod tests {
             _ctx: &(impl ActionContext + ?Sized),
         ) -> Result<ControlOutcome, ActionError> {
             let condition = input.get_bool("/condition")?;
-            let selected = if condition { "true" } else { "false" };
+            let selected = if condition {
+                branch_key!("true")
+            } else {
+                branch_key!("false")
+            };
             Ok(ControlOutcome::Branch {
-                selected: selected.into(),
+                selected,
                 output: input.into_value(),
             })
         }
@@ -845,7 +855,7 @@ mod tests {
             ActionResult::Branch {
                 selected, output, ..
             } => {
-                assert_eq!(selected, "true");
+                assert_eq!(selected.as_str(), "true");
                 assert_eq!(
                     output.as_value(),
                     Some(&serde_json::json!({ "condition": true, "payload": 42 }))
@@ -866,7 +876,7 @@ mod tests {
                 .unwrap();
 
         match result {
-            ActionResult::Branch { selected, .. } => assert_eq!(selected, "false"),
+            ActionResult::Branch { selected, .. } => assert_eq!(selected.as_str(), "false"),
             _ => panic!("expected Branch"),
         }
     }

--- a/crates/action/src/key_validation.rs
+++ b/crates/action/src/key_validation.rs
@@ -1,0 +1,259 @@
+//! Shared validation logic for port and branch key newtypes.
+//!
+//! Both [`PortKey`](crate::PortKey) and [`BranchKey`](crate::BranchKey) enforce
+//! the same rules — only the type identity differs. This private module is the
+//! single source of truth so the rules cannot drift between the two types.
+//!
+//! Validation rules (charset is **case-sensitive**):
+//! - Non-empty, ≤ 64 characters.
+//! - Characters: `[a-zA-Z0-9_-]` only.
+//! - No leading or trailing `_` or `-`.
+//! - No consecutive `--` or `__`.
+
+/// Maximum allowed byte length of a port/branch key.
+pub(crate) const MAX_KEY_LEN: usize = 64;
+
+/// Error produced when constructing a [`PortKey`](crate::PortKey) or
+/// [`BranchKey`](crate::BranchKey) from an invalid string.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid key {key:?}: {kind}")]
+pub struct KeyValidationError {
+    /// The string that failed validation.
+    pub key: String,
+    /// The specific reason validation failed.
+    pub kind: KeyValidationErrorKind,
+}
+
+impl KeyValidationError {
+    pub(crate) fn new(key: impl Into<String>, kind: KeyValidationErrorKind) -> Self {
+        Self {
+            key: key.into(),
+            kind,
+        }
+    }
+}
+
+/// Classification of a [`KeyValidationError`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum KeyValidationErrorKind {
+    /// Key has zero characters.
+    #[error("key must not be empty")]
+    Empty,
+    /// Key exceeds the maximum allowed length.
+    #[error("key is too long: {actual} bytes (max {max})")]
+    TooLong {
+        /// Maximum allowed length.
+        max: usize,
+        /// Actual length of the rejected key.
+        actual: usize,
+    },
+    /// Key contains a character outside `[a-zA-Z0-9_-]`.
+    #[error("key contains invalid character {ch:?} at position {pos}")]
+    InvalidChar {
+        /// The disallowed character.
+        ch: char,
+        /// Byte position in the key string.
+        pos: usize,
+    },
+    /// Key starts or ends with `_` or `-`.
+    #[error("key must not start or end with '_' or '-'")]
+    LeadingOrTrailingSeparator,
+    /// Key contains `--` or `__`.
+    #[error("key must not contain consecutive separators ('--' or '__')")]
+    ConsecutiveSeparator,
+}
+
+/// Validate `s` against the shared port/branch key rules.
+///
+/// Returns `Ok(())` on success, `Err(kind)` on the first rule violation.
+pub(crate) fn validate_key(s: &str) -> Result<(), KeyValidationErrorKind> {
+    if s.is_empty() {
+        return Err(KeyValidationErrorKind::Empty);
+    }
+    if s.len() > MAX_KEY_LEN {
+        return Err(KeyValidationErrorKind::TooLong {
+            max: MAX_KEY_LEN,
+            actual: s.len(),
+        });
+    }
+
+    // Charset check.
+    for (pos, ch) in s.char_indices() {
+        if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-') {
+            return Err(KeyValidationErrorKind::InvalidChar { ch, pos });
+        }
+    }
+
+    // Leading/trailing separator.
+    let first = s.chars().next().expect("non-empty string has a first char");
+    let last = s
+        .chars()
+        .next_back()
+        .expect("non-empty string has a last char");
+    if matches!(first, '_' | '-') || matches!(last, '_' | '-') {
+        return Err(KeyValidationErrorKind::LeadingOrTrailingSeparator);
+    }
+
+    // Consecutive separator.
+    if s.contains("--") || s.contains("__") {
+        return Err(KeyValidationErrorKind::ConsecutiveSeparator);
+    }
+
+    Ok(())
+}
+
+/// `const fn` validator used by the compile-time macro assertions.
+///
+/// Returns `true` when `s` satisfies all key rules, `false` otherwise.
+/// Mirrors [`validate_key`] but operates at compile time.
+pub(crate) const fn is_valid_key(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+
+    if len == 0 || len > MAX_KEY_LEN {
+        return false;
+    }
+
+    let first = bytes[0];
+    let last = bytes[len - 1];
+    if matches!(first, b'_' | b'-') || matches!(last, b'_' | b'-') {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < len {
+        let b = bytes[i];
+        let valid_char = matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-');
+        if !valid_char {
+            return false;
+        }
+        // Consecutive separator check.
+        if i + 1 < len && (b == b'-' || b == b'_') && bytes[i + 1] == b {
+            return false;
+        }
+        i += 1;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Runtime validator ────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_is_invalid() {
+        assert_eq!(validate_key(""), Err(KeyValidationErrorKind::Empty));
+    }
+
+    #[test]
+    fn too_long_is_invalid() {
+        let long = "a".repeat(MAX_KEY_LEN + 1);
+        assert!(matches!(
+            validate_key(&long),
+            Err(KeyValidationErrorKind::TooLong { actual, .. }) if actual == MAX_KEY_LEN + 1
+        ));
+    }
+
+    #[test]
+    fn exactly_max_length_is_valid() {
+        let s = "a".repeat(MAX_KEY_LEN);
+        assert!(validate_key(&s).is_ok());
+    }
+
+    #[test]
+    fn invalid_char_space() {
+        assert!(matches!(
+            validate_key("bad key"),
+            Err(KeyValidationErrorKind::InvalidChar { ch: ' ', .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_char_dot() {
+        assert!(matches!(
+            validate_key("bad.key"),
+            Err(KeyValidationErrorKind::InvalidChar { ch: '.', .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_char_bang() {
+        assert!(matches!(
+            validate_key("bad!"),
+            Err(KeyValidationErrorKind::InvalidChar { ch: '!', .. })
+        ));
+    }
+
+    #[test]
+    fn leading_underscore_is_invalid() {
+        assert_eq!(
+            validate_key("_x"),
+            Err(KeyValidationErrorKind::LeadingOrTrailingSeparator)
+        );
+    }
+
+    #[test]
+    fn trailing_dash_is_invalid() {
+        assert_eq!(
+            validate_key("x-"),
+            Err(KeyValidationErrorKind::LeadingOrTrailingSeparator)
+        );
+    }
+
+    #[test]
+    fn consecutive_dash_is_invalid() {
+        assert_eq!(
+            validate_key("a--b"),
+            Err(KeyValidationErrorKind::ConsecutiveSeparator)
+        );
+    }
+
+    #[test]
+    fn consecutive_underscore_is_invalid() {
+        assert_eq!(
+            validate_key("a__b"),
+            Err(KeyValidationErrorKind::ConsecutiveSeparator)
+        );
+    }
+
+    #[test]
+    fn valid_keys() {
+        for s in [
+            "in",
+            "out",
+            "error",
+            "true",
+            "false",
+            "main",
+            "default",
+            "a",
+            "rule-0",
+            "rule_1",
+            "CamelCase",
+        ] {
+            assert!(validate_key(s).is_ok(), "{s:?} should be valid");
+        }
+    }
+
+    // ── Const validator ──────────────────────────────────────────────────────
+
+    #[test]
+    fn const_validator_matches_runtime_for_valid() {
+        for s in ["in", "out", "error", "a", "rule-0", "Main", "default"] {
+            assert!(is_valid_key(s), "{s:?}: const said invalid");
+            assert!(validate_key(s).is_ok(), "{s:?}: runtime said invalid");
+        }
+    }
+
+    #[test]
+    fn const_validator_matches_runtime_for_invalid() {
+        for s in ["", "_x", "a--b", "a__b", "bad key", "bad.key", "x-"] {
+            assert!(!is_valid_key(s), "{s:?}: const said valid");
+            assert!(validate_key(s).is_err(), "{s:?}: runtime said valid");
+        }
+    }
+}

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -37,7 +37,7 @@ pub mod action;
 /// public contract for autonomous multi-turn reasoning nodes.
 pub mod agent;
 /// [`BranchKey`] validated newtype for workflow branch identifiers.
-pub mod branch_key;
+pub(crate) mod branch_key;
 /// Capability interfaces injected into contexts (resources, logger, trigger).
 pub mod capability;
 /// Runtime context provided to actions during execution.
@@ -74,7 +74,7 @@ pub mod poll;
 /// Port definitions describing action input/output connection points.
 pub mod port;
 /// [`PortKey`] validated newtype for action port identifiers.
-pub mod port_key;
+pub(crate) mod port_key;
 /// Convenience re-exports for action authors.
 pub mod prelude;
 /// [`ResourceAction`] DX trait, [`ResourceHandler`] dyn contract, and adapter.

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -36,6 +36,8 @@ pub mod action;
 /// [`AgentActionAdapter`] bridging to the engine's turn loop. The
 /// public contract for autonomous multi-turn reasoning nodes.
 pub mod agent;
+/// [`BranchKey`] validated newtype for workflow branch identifiers.
+pub mod branch_key;
 /// Capability interfaces injected into contexts (resources, logger, trigger).
 pub mod capability;
 /// Runtime context provided to actions during execution.
@@ -58,6 +60,8 @@ pub mod from_workflow_node;
 pub mod handle;
 /// [`IdempotencyKey`] — transport-level dedup identifier returned by triggers.
 pub mod idempotency;
+/// Shared validation logic for port and branch key newtypes.
+mod key_validation;
 /// Assertion macros for testing action results (`assert_success!`, etc.).
 mod macros;
 /// Static metadata, versioning, and execution mode descriptors.
@@ -69,6 +73,8 @@ pub mod output;
 pub mod poll;
 /// Port definitions describing action input/output connection points.
 pub mod port;
+/// [`PortKey`] validated newtype for action port identifiers.
+pub mod port_key;
 /// Convenience re-exports for action authors.
 pub mod prelude;
 /// [`ResourceAction`] DX trait, [`ResourceHandler`] dyn contract, and adapter.
@@ -104,6 +110,7 @@ pub mod webhook;
 
 pub use action::Action;
 pub use agent::{AgentAction, AgentActionAdapter};
+pub use branch_key::BranchKey;
 pub use capability::{ExecutionEmitter, TriggerHealth, TriggerHealthSnapshot, TriggerScheduler};
 pub use context::{
     ActionContext, ActionContextExt, ActionRuntimeContext, CredentialContextExt, HasNodeIdentity,
@@ -124,6 +131,7 @@ pub use handle::{
     StreamHandle, TriggerHandle,
 };
 pub use idempotency::IdempotencyKey;
+pub use key_validation::{KeyValidationError, KeyValidationErrorKind};
 pub use metadata::{
     ActionKind, ActionMetadata, CheckpointPolicy, IsolationLevel, MetadataCompatibilityError,
 };
@@ -146,12 +154,10 @@ pub use poll::{
     PollCursor, PollOutcome, PollResult, PollSource, PollTriggerAdapter,
 };
 pub use port::{ConnectionFilter, DynamicPort, FlowKind, InputPort, OutputPort, SupportPort};
+pub use port_key::PortKey;
 pub use resource::{ResourceAction, ResourceActionAdapter, ResourceHandler};
 pub use resource_produces::ResourceProduces;
-pub use result::{
-    ActionResult, BranchKey, BreakReason, PortKey, TerminationCode, TerminationReason,
-    WaitCondition,
-};
+pub use result::{ActionResult, BreakReason, TerminationCode, TerminationReason, WaitCondition};
 pub use stateful::{
     BatchAction, BatchItemResult, BatchState, PageResult, PaginatedAction, PaginationState,
     StatefulAction, StatefulActionAdapter, StatefulHandler,
@@ -178,3 +184,49 @@ pub use webhook::{
     hmac_sha256_compute, validate_timestamp, verify_hmac_sha256, verify_hmac_sha256_base64,
     verify_hmac_sha256_with_timestamp, verify_tag_constant_time,
 };
+
+// ── Compile-time key macros ─────────────────────────────────────────────────
+
+/// Constructs a [`PortKey`] from a string literal, validated at **compile time**.
+///
+/// Invalid literals cause a compile error, not a runtime panic.
+///
+/// # Example
+///
+/// ```
+/// use nebula_action::port_key;
+/// let k = port_key!("out");
+/// assert_eq!(k.as_str(), "out");
+/// ```
+#[macro_export]
+macro_rules! port_key {
+    ($s:literal) => {{
+        const _: () = assert!(
+            $crate::PortKey::is_valid_key_const($s),
+            "invalid port key literal"
+        );
+        $crate::PortKey::new($s).unwrap()
+    }};
+}
+
+/// Constructs a [`BranchKey`] from a string literal, validated at **compile time**.
+///
+/// Invalid literals cause a compile error, not a runtime panic.
+///
+/// # Example
+///
+/// ```
+/// use nebula_action::branch_key;
+/// let k = branch_key!("true");
+/// assert_eq!(k.as_str(), "true");
+/// ```
+#[macro_export]
+macro_rules! branch_key {
+    ($s:literal) => {{
+        const _: () = assert!(
+            $crate::BranchKey::is_valid_key_const($s),
+            "invalid branch key literal"
+        );
+        $crate::BranchKey::new($s).unwrap()
+    }};
+}

--- a/crates/action/src/macros.rs
+++ b/crates/action/src/macros.rs
@@ -52,9 +52,11 @@ macro_rules! assert_branch {
         match &$result {
             Ok($crate::ActionResult::Branch { selected, .. }) => {
                 assert_eq!(
-                    selected, $key,
+                    selected.as_str(),
+                    $key,
                     "expected branch key '{}', got '{}'",
-                    $key, selected
+                    $key,
+                    selected
                 );
             },
             other => panic!("expected ActionResult::Branch, got {:?}", other),

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -486,6 +486,7 @@ mod tests {
     use nebula_metadata::BaseCompatError;
 
     use super::*;
+    use crate::port_key;
 
     #[test]
     fn metadata_builder() {
@@ -703,8 +704,8 @@ mod tests {
     fn with_inputs_builder() {
         let meta = ActionMetadata::new(action_key!("ai.agent"), "AI Agent", "Run agent")
             .with_inputs(vec![
-                InputPort::flow("in"),
-                InputPort::support("model", "AI Model", "Language model"),
+                InputPort::flow(port_key!("in")),
+                InputPort::support(port_key!("model"), "AI Model", "Language model"),
             ]);
         assert_eq!(meta.inputs.len(), 2);
         assert!(meta.inputs[0].is_flow());
@@ -717,7 +718,10 @@ mod tests {
         use crate::port::FlowKind;
 
         let meta = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "Make calls")
-            .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
+            .with_outputs(vec![
+                OutputPort::flow(port_key!("out")),
+                OutputPort::error(port_key!("error")),
+            ]);
         assert_eq!(meta.outputs.len(), 2);
         if let OutputPort::Flow { kind, .. } = &meta.outputs[0] {
             assert_eq!(*kind, FlowKind::Main);
@@ -730,8 +734,8 @@ mod tests {
     #[test]
     fn with_dynamic_output() {
         let meta = ActionMetadata::new(action_key!("flow.switch"), "Switch", "Route by conditions")
-            .with_inputs(vec![InputPort::flow("in")])
-            .with_outputs(vec![OutputPort::dynamic("rule", "rules")]);
+            .with_inputs(vec![InputPort::flow(port_key!("in"))])
+            .with_outputs(vec![OutputPort::dynamic(port_key!("rule"), "rules")]);
         assert_eq!(meta.outputs.len(), 1);
         assert!(meta.outputs[0].is_dynamic());
         assert_eq!(meta.outputs[0].key(), "rule");
@@ -743,9 +747,9 @@ mod tests {
 
         let meta = ActionMetadata::new(action_key!("ai.agent"), "AI Agent", "Run agent")
             .with_inputs(vec![
-                InputPort::flow("in"),
+                InputPort::flow(port_key!("in")),
                 InputPort::Support(SupportPort {
-                    key: "tools".into(),
+                    key: port_key!("tools"),
                     name: "Tools".into(),
                     description: "Agent tools".into(),
                     required: false,
@@ -768,8 +772,11 @@ mod tests {
     fn builder_chaining_with_ports() {
         let meta = ActionMetadata::new(action_key!("test"), "Test", "desc")
             .with_version(2, 0)
-            .with_inputs(vec![InputPort::flow("in")])
-            .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
+            .with_inputs(vec![InputPort::flow(port_key!("in"))])
+            .with_outputs(vec![
+                OutputPort::flow(port_key!("out")),
+                OutputPort::error(port_key!("error")),
+            ]);
 
         assert_eq!(meta.base.version, Version::new(2, 0, 0));
         assert_eq!(meta.inputs.len(), 1);
@@ -780,10 +787,13 @@ mod tests {
     fn ports_change_requires_major_bump() {
         let prev = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "desc")
             .with_version(1, 0)
-            .with_outputs(vec![OutputPort::flow("out")]);
+            .with_outputs(vec![OutputPort::flow(port_key!("out"))]);
         let next = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "desc")
             .with_version(1, 1)
-            .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
+            .with_outputs(vec![
+                OutputPort::flow(port_key!("out")),
+                OutputPort::error(port_key!("error")),
+            ]);
 
         let err = next.validate_compatibility(&prev).unwrap_err();
         assert_eq!(err, MetadataCompatibilityError::PortsChangeWithoutMajorBump);
@@ -815,10 +825,13 @@ mod tests {
     fn schema_change_with_major_bump_is_valid() {
         let prev = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "desc")
             .with_version(1, 0)
-            .with_outputs(vec![OutputPort::flow("out")]);
+            .with_outputs(vec![OutputPort::flow(port_key!("out"))]);
         let next = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "desc")
             .with_version(2, 0)
-            .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
+            .with_outputs(vec![
+                OutputPort::flow(port_key!("out")),
+                OutputPort::error(port_key!("error")),
+            ]);
 
         assert!(next.validate_compatibility(&prev).is_ok());
     }

--- a/crates/action/src/port.rs
+++ b/crates/action/src/port.rs
@@ -13,8 +13,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Type alias for port keys (e.g. `"in"`, `"out"`, `"error"`, `"tools"`).
-pub type PortKey = String;
+use crate::port_key::PortKey;
 
 // ── FlowKind ────────────────────────────────────────────────────────────────
 
@@ -131,21 +130,17 @@ pub enum InputPort {
 impl InputPort {
     /// Create a flow input port.
     #[must_use]
-    pub fn flow(key: impl Into<PortKey>) -> Self {
-        Self::Flow { key: key.into() }
+    pub fn flow(key: PortKey) -> Self {
+        Self::Flow { key }
     }
 
     /// Create a support input port with sensible defaults.
     ///
     /// Defaults: `required = false`, `multi = false`, empty filter.
     #[must_use]
-    pub fn support(
-        key: impl Into<PortKey>,
-        name: impl Into<String>,
-        description: impl Into<String>,
-    ) -> Self {
+    pub fn support(key: PortKey, name: impl Into<String>, description: impl Into<String>) -> Self {
         Self::Support(SupportPort {
-            key: key.into(),
+            key,
             name: name.into(),
             description: description.into(),
             required: false,
@@ -158,8 +153,8 @@ impl InputPort {
     #[must_use]
     pub fn key(&self) -> &str {
         match self {
-            Self::Flow { key } => key,
-            Self::Support(p) => &p.key,
+            Self::Flow { key } => key.as_str(),
+            Self::Support(p) => p.key.as_str(),
         }
     }
 
@@ -197,18 +192,18 @@ pub enum OutputPort {
 impl OutputPort {
     /// Create a main flow output port.
     #[must_use]
-    pub fn flow(key: impl Into<PortKey>) -> Self {
+    pub fn flow(key: PortKey) -> Self {
         Self::Flow {
-            key: key.into(),
+            key,
             kind: FlowKind::Main,
         }
     }
 
     /// Create an error flow output port.
     #[must_use]
-    pub fn error(key: impl Into<PortKey>) -> Self {
+    pub fn error(key: PortKey) -> Self {
         Self::Flow {
-            key: key.into(),
+            key,
             kind: FlowKind::Error,
         }
     }
@@ -217,9 +212,9 @@ impl OutputPort {
     ///
     /// Defaults: no `label_field`, `include_fallback = false`.
     #[must_use]
-    pub fn dynamic(key: impl Into<PortKey>, source_field: impl Into<String>) -> Self {
+    pub fn dynamic(key: PortKey, source_field: impl Into<String>) -> Self {
         Self::Dynamic(DynamicPort {
-            key: key.into(),
+            key,
             source_field: source_field.into(),
             label_field: None,
             include_fallback: false,
@@ -230,8 +225,8 @@ impl OutputPort {
     #[must_use]
     pub fn key(&self) -> &str {
         match self {
-            Self::Flow { key, .. } => key,
-            Self::Dynamic(p) => &p.key,
+            Self::Flow { key, .. } => key.as_str(),
+            Self::Dynamic(p) => p.key.as_str(),
         }
     }
 
@@ -253,19 +248,21 @@ impl OutputPort {
 /// Returns the default input ports: a single flow input `"in"`.
 #[must_use]
 pub fn default_input_ports() -> Vec<InputPort> {
-    vec![InputPort::flow("in")]
+    vec![InputPort::flow(crate::port_key!("in"))]
 }
 
 /// Returns the default output ports: a single main flow output `"out"`.
 #[must_use]
 pub fn default_output_ports() -> Vec<OutputPort> {
-    vec![OutputPort::flow("out")]
+    vec![OutputPort::flow(crate::port_key!("out"))]
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
+    use crate::port_key;
+
     use super::*;
 
     // ── FlowKind ────────────────────────────────────────────────────
@@ -329,7 +326,7 @@ mod tests {
 
     #[test]
     fn input_port_flow_constructor() {
-        let port = InputPort::flow("in");
+        let port = InputPort::flow(port_key!("in"));
         assert_eq!(port.key(), "in");
         assert!(port.is_flow());
         assert!(!port.is_support());
@@ -337,7 +334,7 @@ mod tests {
 
     #[test]
     fn input_port_support_constructor() {
-        let port = InputPort::support("tools", "Tools", "Available tools");
+        let port = InputPort::support(port_key!("tools"), "Tools", "Available tools");
         assert_eq!(port.key(), "tools");
         assert!(!port.is_flow());
         assert!(port.is_support());
@@ -353,8 +350,8 @@ mod tests {
     #[test]
     fn input_port_serde_roundtrip() {
         let ports = [
-            InputPort::flow("in"),
-            InputPort::support("model", "Model", "LLM model"),
+            InputPort::flow(port_key!("in")),
+            InputPort::support(port_key!("model"), "Model", "LLM model"),
         ];
         for port in &ports {
             let json = serde_json::to_string(port).unwrap();
@@ -365,7 +362,7 @@ mod tests {
 
     #[test]
     fn input_port_flow_serde_tagged() {
-        let port = InputPort::flow("in");
+        let port = InputPort::flow(port_key!("in"));
         let json = serde_json::to_value(&port).unwrap();
         assert_eq!(json["type"], "flow");
         assert_eq!(json["key"], "in");
@@ -373,7 +370,7 @@ mod tests {
 
     #[test]
     fn input_port_support_serde_tagged() {
-        let port = InputPort::support("tools", "Tools", "desc");
+        let port = InputPort::support(port_key!("tools"), "Tools", "desc");
         let json = serde_json::to_value(&port).unwrap();
         assert_eq!(json["type"], "support");
         assert_eq!(json["key"], "tools");
@@ -384,7 +381,7 @@ mod tests {
 
     #[test]
     fn output_port_flow_constructor() {
-        let port = OutputPort::flow("out");
+        let port = OutputPort::flow(port_key!("out"));
         assert_eq!(port.key(), "out");
         assert!(port.is_flow());
         assert!(!port.is_dynamic());
@@ -395,7 +392,7 @@ mod tests {
 
     #[test]
     fn output_port_error_constructor() {
-        let port = OutputPort::error("error");
+        let port = OutputPort::error(port_key!("error"));
         assert_eq!(port.key(), "error");
         assert!(port.is_flow());
         if let OutputPort::Flow { kind, .. } = &port {
@@ -405,7 +402,7 @@ mod tests {
 
     #[test]
     fn output_port_dynamic_constructor() {
-        let port = OutputPort::dynamic("rule", "rules");
+        let port = OutputPort::dynamic(port_key!("rule"), "rules");
         assert_eq!(port.key(), "rule");
         assert!(port.is_dynamic());
         assert!(!port.is_flow());
@@ -419,9 +416,9 @@ mod tests {
     #[test]
     fn output_port_serde_roundtrip() {
         let ports = [
-            OutputPort::flow("out"),
-            OutputPort::error("error"),
-            OutputPort::dynamic("rule", "rules"),
+            OutputPort::flow(port_key!("out")),
+            OutputPort::error(port_key!("error")),
+            OutputPort::dynamic(port_key!("rule"), "rules"),
         ];
         for port in &ports {
             let json = serde_json::to_string(port).unwrap();
@@ -432,7 +429,7 @@ mod tests {
 
     #[test]
     fn output_port_flow_serde_tagged() {
-        let port = OutputPort::flow("out");
+        let port = OutputPort::flow(port_key!("out"));
         let json = serde_json::to_value(&port).unwrap();
         assert_eq!(json["type"], "flow");
         assert_eq!(json["key"], "out");
@@ -441,7 +438,7 @@ mod tests {
 
     #[test]
     fn output_port_dynamic_serde_tagged() {
-        let port = OutputPort::dynamic("rule", "rules");
+        let port = OutputPort::dynamic(port_key!("rule"), "rules");
         let json = serde_json::to_value(&port).unwrap();
         assert_eq!(json["type"], "dynamic");
         assert_eq!(json["key"], "rule");
@@ -453,7 +450,7 @@ mod tests {
     #[test]
     fn dynamic_port_with_label_and_fallback() {
         let port = OutputPort::Dynamic(DynamicPort {
-            key: "rule".into(),
+            key: port_key!("rule"),
             source_field: "rules".into(),
             label_field: Some("label".into()),
             include_fallback: true,
@@ -472,7 +469,7 @@ mod tests {
     #[test]
     fn support_port_full_config() {
         let port = InputPort::Support(SupportPort {
-            key: "model".into(),
+            key: port_key!("model"),
             name: "AI Model".into(),
             description: "Language model to use".into(),
             required: true,

--- a/crates/action/src/port_key.rs
+++ b/crates/action/src/port_key.rs
@@ -1,0 +1,383 @@
+//! [`PortKey`] — validated newtype for action port identifiers.
+//!
+//! A `PortKey` names a specific input or output connection point on an action
+//! (e.g. `"in"`, `"out"`, `"error"`, `"tools"`). It enforces the charset and
+//! structural rules shared with [`BranchKey`](crate::BranchKey) at construction
+//! time, so an invalid port name can never reach the engine's routing tables.
+//!
+//! # Serde security contract
+//!
+//! `#[serde(try_from = "String", into = "String")]` routes deserialization
+//! through [`TryFrom<String>`] — forged port names in JSON (e.g.
+//! `"bad port!"`) are rejected at the serde boundary rather than accepted as
+//! raw strings. `#[serde(transparent)]` would bypass this check.
+//!
+//! # Compile-time literals
+//!
+//! Use the [`port_key!`](crate::port_key!) macro for hard-coded literals;
+//! invalid literals are rejected at compile time.
+//!
+//! ```rust
+//! use nebula_action::port_key;
+//! let k = port_key!("out");
+//! assert_eq!(k.as_str(), "out");
+//! ```
+
+use std::borrow::Borrow;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::key_validation::{KeyValidationError, is_valid_key, validate_key};
+
+// ── PortKey ──────────────────────────────────────────────────────────────────
+
+/// A validated port key identifying an input or output connection point.
+///
+/// Valid keys satisfy:
+/// - Non-empty, ≤ 64 bytes.
+/// - Characters `[a-zA-Z0-9_-]` only (case-sensitive).
+/// - No leading or trailing `_`/`-`.
+/// - No consecutive `--` or `__`.
+///
+/// Construct from a literal with [`port_key!`](crate::port_key!), or at runtime
+/// via [`PortKey::new`] / [`TryFrom`].
+///
+/// The [`Borrow<str>`] and [`AsRef<str>`] impls allow `HashMap<PortKey, _>` to
+/// be queried with a bare `&str` key (e.g.
+/// `map.contains_key("out")`).
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct PortKey(String);
+
+impl PortKey {
+    /// Construct a `PortKey`, validating the supplied string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyValidationError`] when the string violates any key rule.
+    pub fn new(s: impl Into<String>) -> Result<Self, KeyValidationError> {
+        let s = s.into();
+        validate_key(&s).map_err(|kind| KeyValidationError::new(s.clone(), kind))?;
+        Ok(Self(s))
+    }
+
+    /// Borrow the key as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns `true` when `s` satisfies all key rules.
+    ///
+    /// Used by the [`port_key!`](crate::port_key!) macro's compile-time
+    /// `const assert!`.
+    #[must_use]
+    pub const fn is_valid_key_const(s: &str) -> bool {
+        is_valid_key(s)
+    }
+}
+
+// ── Standard trait impls ─────────────────────────────────────────────────────
+
+impl fmt::Debug for PortKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PortKey({:?})", self.0)
+    }
+}
+
+impl fmt::Display for PortKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for PortKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// `Borrow<str>` is required so `HashMap<PortKey, _>::get("out")` works
+/// without an owned `PortKey`. The `Hash` and `PartialEq` impls delegate to
+/// `str` (via the derived impls on the inner `String`), satisfying the
+/// `Borrow` contract: `hash(key) == hash(key.borrow())`.
+impl Borrow<str> for PortKey {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for PortKey {
+    type Error = KeyValidationError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        validate_key(&s).map_err(|kind| KeyValidationError::new(s.clone(), kind))?;
+        Ok(Self(s))
+    }
+}
+
+impl TryFrom<&str> for PortKey {
+    type Error = KeyValidationError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        validate_key(s).map_err(|kind| KeyValidationError::new(s, kind))?;
+        Ok(Self(s.to_owned()))
+    }
+}
+
+/// Required by `#[serde(into = "String")]`.
+impl From<PortKey> for String {
+    fn from(k: PortKey) -> Self {
+        k.0
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::key_validation::KeyValidationErrorKind;
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn valid_single_char() {
+        assert_eq!(PortKey::new("a").unwrap().as_str(), "a");
+    }
+
+    #[test]
+    fn valid_standard_keys() {
+        for key in ["in", "out", "error", "main", "default", "true", "false"] {
+            assert!(PortKey::new(key).is_ok(), "{key:?} should be valid");
+        }
+    }
+
+    #[test]
+    fn valid_max_length() {
+        let s = "a".repeat(64);
+        assert!(PortKey::new(s).is_ok());
+    }
+
+    #[test]
+    fn valid_mixed_case_preserved() {
+        // Keys are case-sensitive; "Main" and "main" are distinct.
+        let upper = PortKey::new("Main").unwrap();
+        let lower = PortKey::new("main").unwrap();
+        assert_ne!(upper, lower, "case must be preserved");
+        assert_eq!(upper.as_str(), "Main");
+    }
+
+    #[test]
+    fn invalid_empty() {
+        assert!(matches!(
+            PortKey::new("").unwrap_err().kind,
+            KeyValidationErrorKind::Empty
+        ));
+    }
+
+    #[test]
+    fn invalid_too_long() {
+        let s = "a".repeat(65);
+        assert!(matches!(
+            PortKey::new(s).unwrap_err().kind,
+            KeyValidationErrorKind::TooLong { actual: 65, .. }
+        ));
+    }
+
+    #[test]
+    fn invalid_leading_underscore() {
+        assert!(matches!(
+            PortKey::new("_x").unwrap_err().kind,
+            KeyValidationErrorKind::LeadingOrTrailingSeparator
+        ));
+    }
+
+    #[test]
+    fn invalid_consecutive_dash() {
+        assert!(matches!(
+            PortKey::new("a--b").unwrap_err().kind,
+            KeyValidationErrorKind::ConsecutiveSeparator
+        ));
+    }
+
+    #[test]
+    fn invalid_space() {
+        assert!(matches!(
+            PortKey::new("bad port").unwrap_err().kind,
+            KeyValidationErrorKind::InvalidChar { ch: ' ', .. }
+        ));
+    }
+
+    // ── is_valid_key_const ───────────────────────────────────────────────────
+
+    #[test]
+    fn const_check_accepts_valid() {
+        assert!(PortKey::is_valid_key_const("out"));
+        assert!(PortKey::is_valid_key_const("in"));
+        assert!(PortKey::is_valid_key_const("error"));
+    }
+
+    #[test]
+    fn const_check_rejects_invalid() {
+        assert!(!PortKey::is_valid_key_const(""));
+        assert!(!PortKey::is_valid_key_const("_x"));
+        assert!(!PortKey::is_valid_key_const("a--b"));
+        assert!(!PortKey::is_valid_key_const("bad port!"));
+    }
+
+    // ── HashMap Borrow<str> ──────────────────────────────────────────────────
+
+    #[test]
+    fn hashmap_get_by_str_via_borrow() {
+        let mut map: HashMap<PortKey, u32> = HashMap::new();
+        map.insert(PortKey::new("out").unwrap(), 42);
+        map.insert(PortKey::new("error").unwrap(), 7);
+
+        // Queried by &str — works via Borrow<str>.
+        assert_eq!(map.get("out"), Some(&42));
+        assert_eq!(map.get("error"), Some(&7));
+        assert_eq!(map.get("missing"), None);
+        assert!(map.contains_key("out"));
+    }
+
+    // ── Serde round-trip ─────────────────────────────────────────────────────
+
+    #[test]
+    fn serde_round_trip_valid() {
+        let key = PortKey::new("out").unwrap();
+        let json = serde_json::to_string(&key).unwrap();
+        assert_eq!(json, r#""out""#);
+        let back: PortKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(key, back);
+    }
+
+    // ── SECURITY: forged port key rejected at serde boundary ─────────────────
+
+    #[test]
+    fn serde_rejects_forged_invalid_char() {
+        // A forged key with an invalid character must be rejected on deserialization.
+        // This would have been accepted when PortKey was `type PortKey = String`.
+        let result: Result<PortKey, _> = serde_json::from_str(r#""bad port!""#);
+        assert!(
+            result.is_err(),
+            "PortKey deserialization must reject keys with invalid characters"
+        );
+    }
+
+    #[test]
+    fn serde_rejects_empty_key() {
+        let result: Result<PortKey, _> = serde_json::from_str(r#""""#);
+        assert!(
+            result.is_err(),
+            "PortKey deserialization must reject empty string"
+        );
+    }
+
+    // ── Display / Debug ──────────────────────────────────────────────────────
+
+    #[test]
+    fn display_shows_key_string() {
+        let key = PortKey::new("out").unwrap();
+        assert_eq!(key.to_string(), "out");
+    }
+
+    #[test]
+    fn debug_is_readable() {
+        let key = PortKey::new("out").unwrap();
+        assert_eq!(format!("{key:?}"), r#"PortKey("out")"#);
+    }
+
+    // ── From<PortKey> for String ─────────────────────────────────────────────
+
+    #[test]
+    fn into_string_conversion() {
+        let key = PortKey::new("out").unwrap();
+        let s: String = key.into();
+        assert_eq!(s, "out");
+    }
+
+    // ── in-JSON context: ActionResult::Route ─────────────────────────────────
+
+    #[test]
+    fn route_with_forged_port_rejected_via_action_result_serde() {
+        use crate::result::ActionResult;
+        // This is the primary security test. Before the newtype, this would
+        // deserialize Ok because `PortKey = String` accepted anything.
+        // After the newtype, "bad port!" is rejected through try_from regardless
+        // of whether the data payload itself is valid.
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"Route","port":"bad port!","data":{"type":"Empty"}}"#,
+        );
+        assert!(
+            result.is_err(),
+            "ActionResult::Route with a forged port key must be rejected at the serde boundary"
+        );
+    }
+
+    #[test]
+    fn route_with_empty_port_rejected_via_action_result_serde() {
+        use crate::result::ActionResult;
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"Route","port":"","data":{"type":"Empty"}}"#,
+        );
+        assert!(
+            result.is_err(),
+            "ActionResult::Route with an empty port key must be rejected at the serde boundary"
+        );
+    }
+
+    #[test]
+    fn route_with_valid_port_accepted_via_action_result_serde() {
+        use crate::result::ActionResult;
+        // ActionOutput uses adjacent tagging: {"type":"Empty"} or
+        // {"type":"Value","data":<val>}. Use Empty here to keep the fixture minimal.
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"Route","port":"out","data":{"type":"Empty"}}"#,
+        );
+        assert!(
+            result.is_ok(),
+            "ActionResult::Route with a valid port key must deserialize successfully"
+        );
+    }
+
+    // ── TryFrom<&str> ────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_from_str_valid() {
+        let key = PortKey::try_from("out").unwrap();
+        assert_eq!(key.as_str(), "out");
+    }
+
+    #[test]
+    fn try_from_str_invalid() {
+        assert!(PortKey::try_from("bad!").is_err());
+    }
+
+    // ── as_value in JSON object ──────────────────────────────────────────────
+
+    #[test]
+    fn port_key_in_json_object_serde() {
+        let map: HashMap<PortKey, i32> = [
+            (PortKey::new("out").unwrap(), 1),
+            (PortKey::new("error").unwrap(), 2),
+        ]
+        .into_iter()
+        .collect();
+
+        // Serializes to a JSON object with string keys.
+        let val = serde_json::to_value(&map).unwrap();
+        assert_eq!(val["out"], json!(1));
+        assert_eq!(val["error"], json!(2));
+
+        // Round-trips back cleanly.
+        let back: HashMap<PortKey, i32> = serde_json::from_value(val).unwrap();
+        assert_eq!(back.get("out"), Some(&1));
+        assert_eq!(back.get("error"), Some(&2));
+    }
+}

--- a/crates/action/src/port_key.rs
+++ b/crates/action/src/port_key.rs
@@ -346,6 +346,53 @@ mod tests {
         );
     }
 
+    // ── ActionResult-level serde rejection — Branch / MultiOutput ────────────
+    //
+    // These tests are RED on the old `pub type PortKey/BranchKey = String`
+    // aliases (invalid strings deserialize Ok) and GREEN after the newtypes
+    // route deserialization through TryFrom<String>.
+
+    #[test]
+    fn branch_with_forged_selected_rejected_via_action_result_serde() {
+        use crate::result::ActionResult;
+        // "bad branch!" contains a space and exclamation mark — always invalid.
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"Branch","selected":"bad branch!","output":{"type":"Empty"},"alternatives":{}}"#,
+        );
+        assert!(
+            result.is_err(),
+            "ActionResult::Branch with a forged `selected` key must be rejected at the serde boundary"
+        );
+    }
+
+    #[test]
+    fn branch_with_forged_alternatives_key_rejected_via_action_result_serde() {
+        use crate::result::ActionResult;
+        // `selected` is valid but an alternatives map key is forged.
+        // Proves that HashMap<BranchKey, _> key deserialization is also guarded.
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"Branch","selected":"ok","output":{"type":"Empty"},"alternatives":{"bad key!":{"type":"Empty"}}}"#,
+        );
+        assert!(
+            result.is_err(),
+            "ActionResult::Branch with a forged alternatives map key must be rejected at the serde boundary"
+        );
+    }
+
+    #[test]
+    fn multi_output_with_forged_port_key_rejected_via_action_result_serde() {
+        use crate::result::ActionResult;
+        // `outputs` map key "bad port!" is invalid — must be rejected even though
+        // the outer type tag and main_output are well-formed.
+        let result = serde_json::from_str::<ActionResult<serde_json::Value>>(
+            r#"{"type":"MultiOutput","outputs":{"bad port!":{"type":"Empty"}},"main_output":null}"#,
+        );
+        assert!(
+            result.is_err(),
+            "ActionResult::MultiOutput with a forged port key must be rejected at the serde boundary"
+        );
+    }
+
     // ── TryFrom<&str> ────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/action/src/result.rs
+++ b/crates/action/src/result.rs
@@ -4,15 +4,9 @@ use chrono::{DateTime, Utc};
 use nebula_core::id::ExecutionId;
 use serde::{Deserialize, Serialize};
 
+use crate::branch_key::BranchKey;
 use crate::output::{ActionOutput, BinaryData, DataReference, DeferredOutput};
-
-/// Type alias for workflow branch keys (e.g. `"true"`, `"false"`, `"case_1"`).
-pub type BranchKey = String;
-
-/// Type alias for action output port keys (e.g. `"main"`, `"error"`, `"filtered"`).
-///
-/// Canonical definition lives in [`crate::port`]; re-exported here for convenience.
-pub use crate::port::PortKey;
+use crate::port_key::PortKey;
 
 /// Result of an action execution, carrying both data and flow-control intent.
 ///
@@ -754,6 +748,8 @@ impl<T> ActionResult<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{branch_key, port_key};
+
     use super::*;
 
     #[test]
@@ -817,10 +813,10 @@ mod tests {
     #[test]
     fn branch_result() {
         let mut alts = HashMap::new();
-        alts.insert("true".into(), ActionOutput::Value("yes"));
-        alts.insert("false".into(), ActionOutput::Value("no"));
+        alts.insert(branch_key!("true"), ActionOutput::Value("yes"));
+        alts.insert(branch_key!("false"), ActionOutput::Value("no"));
         let result = ActionResult::Branch {
-            selected: "true".into(),
+            selected: branch_key!("true"),
             output: ActionOutput::Value("yes"),
             alternatives: alts,
         };
@@ -830,7 +826,7 @@ mod tests {
                 alternatives,
                 ..
             } => {
-                assert_eq!(selected, "true");
+                assert_eq!(selected.as_str(), "true");
                 assert_eq!(alternatives.len(), 2);
             },
             _ => panic!("expected Branch"),
@@ -840,7 +836,7 @@ mod tests {
     #[test]
     fn route_result() {
         let result = ActionResult::Route {
-            port: "error".into(),
+            port: port_key!("error"),
             data: ActionOutput::Value("something failed"),
         };
         assert!(!result.is_success());
@@ -849,8 +845,8 @@ mod tests {
     #[test]
     fn multi_output_result() {
         let mut outputs = HashMap::new();
-        outputs.insert("main".into(), ActionOutput::Value(1));
-        outputs.insert("audit".into(), ActionOutput::Value(2));
+        outputs.insert(port_key!("main"), ActionOutput::Value(1));
+        outputs.insert(port_key!("audit"), ActionOutput::Value(2));
         let result = ActionResult::MultiOutput {
             outputs,
             main_output: Some(ActionOutput::Value(1)),
@@ -956,10 +952,10 @@ mod tests {
     #[test]
     fn map_output_branch() {
         let mut alts = HashMap::new();
-        alts.insert("a".into(), ActionOutput::Value(1));
-        alts.insert("b".into(), ActionOutput::Value(2));
+        alts.insert(branch_key!("a"), ActionOutput::Value(1));
+        alts.insert(branch_key!("b"), ActionOutput::Value(2));
         let r = ActionResult::Branch {
-            selected: "a".into(),
+            selected: branch_key!("a"),
             output: ActionOutput::Value(10),
             alternatives: alts,
         };
@@ -970,7 +966,7 @@ mod tests {
                 output,
                 alternatives,
             } => {
-                assert_eq!(selected, "a");
+                assert_eq!(selected.as_str(), "a");
                 assert_eq!(output.into_value(), Some(100));
                 assert_eq!(alternatives.get("a").unwrap().as_value(), Some(&10));
                 assert_eq!(alternatives.get("b").unwrap().as_value(), Some(&20));
@@ -982,13 +978,13 @@ mod tests {
     #[test]
     fn map_output_route() {
         let r = ActionResult::Route {
-            port: "out".into(),
+            port: port_key!("out"),
             data: ActionOutput::Value(99),
         };
         let mapped = r.map_output(|n| n as f64);
         match mapped {
             ActionResult::Route { port, data } => {
-                assert_eq!(port, "out");
+                assert_eq!(port.as_str(), "out");
                 assert_eq!(data.into_value(), Some(99.0));
             },
             _ => panic!("expected Route"),
@@ -998,7 +994,7 @@ mod tests {
     #[test]
     fn map_output_multi_output() {
         let mut outputs = HashMap::new();
-        outputs.insert("x".into(), ActionOutput::Value(1));
+        outputs.insert(port_key!("x"), ActionOutput::Value(1));
         let r = ActionResult::MultiOutput {
             outputs,
             main_output: Some(ActionOutput::Value(0)),
@@ -1084,10 +1080,10 @@ mod tests {
     #[test]
     fn try_map_output_branch_partial_failure() {
         let mut alts = HashMap::new();
-        alts.insert("a".into(), ActionOutput::Value(1));
-        alts.insert("b".into(), ActionOutput::Value(2));
+        alts.insert(branch_key!("a"), ActionOutput::Value(1));
+        alts.insert(branch_key!("b"), ActionOutput::Value(2));
         let r = ActionResult::Branch {
-            selected: "a".into(),
+            selected: branch_key!("a"),
             output: ActionOutput::Value(10),
             alternatives: alts,
         };
@@ -1132,7 +1128,7 @@ mod tests {
     #[test]
     fn into_primary_output_branch() {
         let r = ActionResult::Branch {
-            selected: "a".into(),
+            selected: branch_key!("a"),
             output: ActionOutput::Value(10),
             alternatives: HashMap::new(),
         };
@@ -1143,7 +1139,7 @@ mod tests {
     #[test]
     fn into_primary_output_route() {
         let r = ActionResult::Route {
-            port: "out".into(),
+            port: port_key!("out"),
             data: ActionOutput::Value(55),
         };
         let out = r.into_primary_output().unwrap();

--- a/crates/action/src/validation.rs
+++ b/crates/action/src/validation.rs
@@ -104,7 +104,7 @@ pub fn validate_action_package(
             && (port.name.trim().is_empty() || port.description.trim().is_empty())
         {
             errors.push(ActionPackageValidationError::InvalidSupportPort {
-                key: port.key.clone(),
+                key: port.key.to_string(),
             });
         }
     }
@@ -119,7 +119,7 @@ pub fn validate_action_package(
             && port.source_field.trim().is_empty()
         {
             errors.push(ActionPackageValidationError::InvalidDynamicPort {
-                key: port.key.clone(),
+                key: port.key.to_string(),
             });
         }
     }
@@ -136,7 +136,10 @@ mod tests {
     use nebula_core::action_key;
 
     use super::*;
-    use crate::port::{DynamicPort, SupportPort};
+    use crate::{
+        port::{DynamicPort, SupportPort},
+        port_key,
+    };
 
     fn valid_metadata() -> ActionMetadata {
         ActionMetadata::new(action_key!("test.action"), "Test", "desc")
@@ -151,8 +154,14 @@ mod tests {
     #[test]
     fn duplicate_ports_fail_validation() {
         let meta = ActionMetadata::new(action_key!("test.action"), "Test", "desc")
-            .with_inputs(vec![InputPort::flow("in"), InputPort::flow("in")])
-            .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("out")]);
+            .with_inputs(vec![
+                InputPort::flow(port_key!("in")),
+                InputPort::flow(port_key!("in")),
+            ])
+            .with_outputs(vec![
+                OutputPort::flow(port_key!("out")),
+                OutputPort::error(port_key!("out")),
+            ]);
 
         let err = validate_action_package(&meta).unwrap_err();
         assert!(err.errors().iter().any(|e| matches!(
@@ -169,7 +178,7 @@ mod tests {
     fn invalid_support_and_dynamic_ports_fail_validation() {
         let meta = ActionMetadata::new(action_key!("test.action"), "Test", "desc")
             .with_inputs(vec![InputPort::Support(SupportPort {
-                key: "tools".into(),
+                key: port_key!("tools"),
                 name: String::new(),
                 description: String::new(),
                 required: false,
@@ -177,7 +186,7 @@ mod tests {
                 filter: Default::default(),
             })])
             .with_outputs(vec![OutputPort::Dynamic(DynamicPort {
-                key: "rule".into(),
+                key: port_key!("rule"),
                 source_field: String::new(),
                 label_field: None,
                 include_fallback: false,

--- a/crates/action/tests/contracts.rs
+++ b/crates/action/tests/contracts.rs
@@ -8,8 +8,8 @@ use std::{collections::HashMap, time::Duration};
 
 use chrono::Utc;
 use nebula_action::{
-    ActionKind, ActionOutput, ActionResult, BreakReason, DynamicPort, FlowKind, InputPort,
-    OutputPort, SupportPort, TerminationReason, WaitCondition,
+    ActionKind, ActionOutput, ActionResult, BranchKey, BreakReason, DynamicPort, FlowKind,
+    InputPort, OutputPort, PortKey, SupportPort, TerminationReason, WaitCondition,
 };
 use nebula_core::id::ExecutionId;
 
@@ -49,7 +49,7 @@ fn flow_kind_serialization_contract() {
 #[test]
 fn support_port_serialization_contract() {
     let port = InputPort::Support(SupportPort {
-        key: "model".to_string(),
+        key: PortKey::new("model").expect("'model' is a valid port key"),
         name: "AI Model".to_string(),
         description: "Primary model input".to_string(),
         required: true,
@@ -68,7 +68,7 @@ fn support_port_serialization_contract() {
 #[test]
 fn dynamic_port_serialization_contract() {
     let port = OutputPort::Dynamic(DynamicPort {
-        key: "rule".to_string(),
+        key: PortKey::new("rule").expect("'rule' is a valid port key"),
         source_field: "rules".to_string(),
         label_field: Some("label".to_string()),
         include_fallback: true,
@@ -114,31 +114,31 @@ fn action_result_serialization_contract_all_variants_roundtrip() {
 
     let mut alternatives = HashMap::new();
     alternatives.insert(
-        "true".to_string(),
+        BranchKey::new("true").expect("'true' is a valid branch key"),
         ActionOutput::Value(serde_json::json!({"v": 1})),
     );
     alternatives.insert(
-        "false".to_string(),
+        BranchKey::new("false").expect("'false' is a valid branch key"),
         ActionOutput::Value(serde_json::json!({"v": 0})),
     );
     assert_result_roundtrip(ActionResult::Branch {
-        selected: "true".to_string(),
+        selected: BranchKey::new("true").expect("'true' is a valid branch key"),
         output: ActionOutput::Value(serde_json::json!({"selected": "true"})),
         alternatives,
     });
 
     assert_result_roundtrip(ActionResult::Route {
-        port: "main".to_string(),
+        port: PortKey::new("main").expect("'main' is a valid port key"),
         data: ActionOutput::Value(serde_json::json!({"routed": true})),
     });
 
     let mut outputs = HashMap::new();
     outputs.insert(
-        "main".to_string(),
+        PortKey::new("main").expect("'main' is a valid port key"),
         ActionOutput::Value(serde_json::json!({"main": true})),
     );
     outputs.insert(
-        "audit".to_string(),
+        PortKey::new("audit").expect("'audit' is a valid port key"),
         ActionOutput::Value(serde_json::json!({"audit": "ok"})),
     );
     assert_result_roundtrip(ActionResult::MultiOutput {

--- a/crates/action/tests/dx_control.rs
+++ b/crates/action/tests/dx_control.rs
@@ -19,8 +19,9 @@ use std::sync::{Arc, OnceLock};
 
 use nebula_action::{
     Action, ActionError, ActionKind, ActionMetadata, ActionOutput, ActionResult,
-    ActionRuntimeContext, ControlAction, ControlActionAdapter, ControlInput, ControlOutcome,
-    OutputPort, StatelessHandler, TerminationReason, ValidationReason, testing::TestContextBuilder,
+    ActionRuntimeContext, BranchKey, ControlAction, ControlActionAdapter, ControlInput,
+    ControlOutcome, OutputPort, StatelessHandler, TerminationReason, ValidationReason, port_key,
+    testing::TestContextBuilder,
 };
 use nebula_core::{Dependencies, action_key};
 use nebula_schema::{FieldCollector, HasSchema, Schema, StringBuilder, ValidSchema, field_key};
@@ -57,8 +58,10 @@ impl Action for DemoIf {
     type Output = serde_json::Value;
 
     fn metadata() -> ActionMetadata {
-        ActionMetadata::new(action_key!("demo.if"), "If", "Binary branch")
-            .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
+        ActionMetadata::new(action_key!("demo.if"), "If", "Binary branch").with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -74,9 +77,14 @@ impl ControlAction for DemoIf {
         _ctx: &(impl nebula_action::ActionContext + ?Sized),
     ) -> Result<ControlOutcome, ActionError> {
         let condition = input.get_bool("/condition")?;
-        let selected = if condition { "true" } else { "false" };
+        let selected = if condition {
+            BranchKey::new("true")
+        } else {
+            BranchKey::new("false")
+        }
+        .expect("'true'/'false' are valid branch key literals");
         Ok(ControlOutcome::Branch {
-            selected: selected.into(),
+            selected,
             output: input.into_value(),
         })
     }
@@ -94,7 +102,7 @@ async fn demo_if_routes_true() {
         ActionResult::Branch {
             selected, output, ..
         } => {
-            assert_eq!(selected, "true");
+            assert_eq!(selected.as_str(), "true");
             assert_eq!(
                 output.as_value(),
                 Some(&serde_json::json!({ "condition": true, "value": 42 }))
@@ -109,7 +117,7 @@ async fn demo_if_routes_false() {
     let adapter = ControlActionAdapter::new(DemoIf);
     let result = run(&adapter, serde_json::json!({ "condition": false })).await;
     match result {
-        ActionResult::Branch { selected, .. } => assert_eq!(selected, "false"),
+        ActionResult::Branch { selected, .. } => assert_eq!(selected.as_str(), "false"),
         _ => panic!("expected Branch"),
     }
 }
@@ -159,10 +167,10 @@ impl Action for DemoSwitch {
             "N-way branch by status field",
         )
         .with_outputs(vec![
-            OutputPort::flow("active"),
-            OutputPort::flow("pending"),
-            OutputPort::flow("archived"),
-            OutputPort::flow("default"),
+            OutputPort::flow(port_key!("active")),
+            OutputPort::flow(port_key!("pending")),
+            OutputPort::flow(port_key!("archived")),
+            OutputPort::flow(port_key!("default")),
         ])
     }
 
@@ -179,12 +187,14 @@ impl ControlAction for DemoSwitch {
         _ctx: &(impl nebula_action::ActionContext + ?Sized),
     ) -> Result<ControlOutcome, ActionError> {
         let status = input.get_str("/status")?;
-        let selected = match status {
+        let branch_name = match status {
             "active" | "pending" | "archived" => status,
             _ => "default",
         };
+        let selected =
+            BranchKey::new(branch_name).expect("switch branch names are valid key literals");
         Ok(ControlOutcome::Branch {
-            selected: selected.into(),
+            selected,
             output: input.into_value(),
         })
     }
@@ -195,7 +205,7 @@ async fn demo_switch_routes_known_case() {
     let adapter = ControlActionAdapter::new(DemoSwitch);
     let result = run(&adapter, serde_json::json!({ "status": "pending" })).await;
     match result {
-        ActionResult::Branch { selected, .. } => assert_eq!(selected, "pending"),
+        ActionResult::Branch { selected, .. } => assert_eq!(selected.as_str(), "pending"),
         _ => panic!("expected Branch"),
     }
 }
@@ -205,7 +215,7 @@ async fn demo_switch_falls_back_to_default() {
     let adapter = ControlActionAdapter::new(DemoSwitch);
     let result = run(&adapter, serde_json::json!({ "status": "unknown" })).await;
     match result {
-        ActionResult::Branch { selected, .. } => assert_eq!(selected, "default"),
+        ActionResult::Branch { selected, .. } => assert_eq!(selected.as_str(), "default"),
         _ => panic!("expected Branch"),
     }
 }
@@ -249,9 +259,9 @@ impl Action for DemoRouter {
     fn metadata() -> ActionMetadata {
         ActionMetadata::new(action_key!("demo.router"), "Router", "Multi-rule routing")
             .with_outputs(vec![
-                OutputPort::flow("high"),
-                OutputPort::flow("medium"),
-                OutputPort::flow("low"),
+                OutputPort::flow(port_key!("high")),
+                OutputPort::flow(port_key!("medium")),
+                OutputPort::flow(port_key!("low")),
             ])
     }
 
@@ -275,8 +285,10 @@ impl ControlAction for DemoRouter {
             }),
             (RouterMode::FirstMatch, _) => {
                 let value = input.into_value();
+                let selected =
+                    BranchKey::new(matches[0]).expect("router branch names are valid key literals");
                 Ok(ControlOutcome::Branch {
-                    selected: matches[0].into(),
+                    selected,
                     output: value,
                 })
             },
@@ -284,7 +296,11 @@ impl ControlAction for DemoRouter {
                 let value = input.into_value();
                 let ports: std::collections::HashMap<_, _> = matches
                     .iter()
-                    .map(|port| ((*port).to_string(), value.clone()))
+                    .map(|port_name| {
+                        let key = nebula_action::PortKey::new(*port_name)
+                            .expect("router port names are valid key literals");
+                        (key, value.clone())
+                    })
                     .collect();
                 Ok(ControlOutcome::Route { ports })
             },
@@ -297,7 +313,7 @@ async fn demo_router_first_match_picks_first_rule() {
     let adapter = ControlActionAdapter::new(DemoRouter::new(RouterMode::FirstMatch));
     let result = run(&adapter, serde_json::json!({ "priority": 150 })).await;
     match result {
-        ActionResult::Branch { selected, .. } => assert_eq!(selected, "high"),
+        ActionResult::Branch { selected, .. } => assert_eq!(selected.as_str(), "high"),
         _ => panic!("expected Branch"),
     }
 }
@@ -336,7 +352,7 @@ impl Action for NeverMatchRouter {
             "NeverMatchRouter",
             "Drops every input — used to test Drop code path",
         )
-        .with_outputs(vec![OutputPort::flow("out")])
+        .with_outputs(vec![OutputPort::flow(port_key!("out"))])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -381,7 +397,7 @@ impl Action for DemoFilter {
             "Filter",
             "Drop items below threshold",
         )
-        .with_outputs(vec![OutputPort::flow("out")])
+        .with_outputs(vec![OutputPort::flow(port_key!("out"))])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -794,7 +810,10 @@ impl Action for DemoTypedBranch {
             "TypedBranch",
             "Branch with typed output",
         )
-        .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
+        .with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -809,15 +828,17 @@ impl ControlAction for DemoTypedBranch {
         input: ControlInput,
         _ctx: &(impl nebula_action::ActionContext + ?Sized),
     ) -> Result<ControlOutcome, ActionError> {
-        let selected = if input.get_bool("/condition").unwrap_or(false) {
+        let branch_name = if input.get_bool("/condition").unwrap_or(false) {
             "true"
         } else {
             "false"
         };
+        let selected =
+            BranchKey::new(branch_name).expect("'true'/'false' are valid branch key literals");
         Ok(ControlOutcome::Branch {
-            selected: selected.into(),
+            selected,
             output: serde_json::to_value(TypedBranchOutput {
-                selected: selected.into(),
+                selected: branch_name.into(),
             })
             .unwrap_or_default(),
         })

--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use nebula_action::{
-    ActionError, action::Action, context::CredentialContextExt, metadata::ActionMetadata,
-    result::ActionResult, stateless::StatelessAction,
+    ActionError, BranchKey, action::Action, context::CredentialContextExt,
+    metadata::ActionMetadata, result::ActionResult, stateless::StatelessAction,
 };
 use nebula_core::{Dependencies, action_key, scope::Principal};
 use nebula_storage_port::StorageError;
@@ -727,7 +727,7 @@ impl StatelessAction for SkipHandler {
 }
 
 struct BranchHandler {
-    selected: String,
+    selected: BranchKey,
 }
 
 impl Action for BranchHandler {
@@ -771,7 +771,7 @@ async fn branch_workflow_only_selected_path_executes() {
     registry.register_stateless_instance(
         ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
         BranchHandler {
-            selected: "true".into(),
+            selected: nebula_action::branch_key!("true"),
         },
     );
 
@@ -3747,7 +3747,7 @@ async fn idempotency_replay_preserves_branch_routing() {
     registry.register_stateless_instance(
         ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
         BranchHandler {
-            selected: "true".into(),
+            selected: nebula_action::branch_key!("true"),
         },
     );
     registry.register_stateless_instance(

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -1705,7 +1705,7 @@ mod tests {
     async fn multi_output_fanout_port_respects_reject_limit() {
         use std::collections::HashMap;
 
-        use nebula_action::{PortKey, result::ActionResult as AR};
+        use nebula_action::{PortKey, port_key, result::ActionResult as AR};
 
         struct MultiOutAction;
         impl Action for MultiOutAction {
@@ -1735,7 +1735,7 @@ mod tests {
                 // a byte limit of 16.
                 let mut outputs: HashMap<PortKey, ActionOutput<serde_json::Value>> = HashMap::new();
                 outputs.insert(
-                    PortKey::from("big_port"),
+                    port_key!("big_port"),
                     ActionOutput::Value(serde_json::json!(
                         "this payload is definitely larger than the 16 byte limit"
                     )),
@@ -1814,13 +1814,14 @@ mod tests {
             ) -> Result<AR<<Self as Action>::Output>, ActionError> {
                 let mut alternatives = HashMap::new();
                 alternatives.insert(
-                    "else".to_string(),
+                    nebula_action::BranchKey::new("else").expect("'else' is a valid branch key"),
                     ActionOutput::Value(serde_json::json!(
                         "alternative branch holds way more than 16 bytes of data"
                     )),
                 );
                 Ok(AR::Branch {
-                    selected: "then".to_string(),
+                    selected: nebula_action::BranchKey::new("then")
+                        .expect("'then' is a valid branch key"),
                     output: ActionOutput::Value(serde_json::json!("ok")),
                     alternatives,
                 })

--- a/crates/plugin-core/src/actions/if_action.rs
+++ b/crates/plugin-core/src/actions/if_action.rs
@@ -80,9 +80,10 @@
 use std::sync::OnceLock;
 
 use nebula_action::{
-    ActionContext, ActionError, ActionMetadata,
+    ActionContext, ActionError, ActionMetadata, branch_key,
     control::{ControlAction, ControlInput, ControlOutcome},
     port::{OutputPort, default_input_ports},
+    port_key,
 };
 use nebula_core::action_key;
 use nebula_schema::HasSchema;
@@ -169,7 +170,10 @@ impl nebula_action::action::Action for CoreIf {
             "Routes execution to 'true' or 'false' port based on a field condition",
         )
         .with_inputs(default_input_ports())
-        .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
+        .with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ])
     }
 
     fn dependencies() -> &'static nebula_action::Dependencies {
@@ -215,10 +219,14 @@ impl ControlAction for CoreIf {
             ActionError::fatal(format!("core.if: {err}"))
         })?;
         let branch_taken = evaluate_condition(&data_object, &condition)?;
-        let selected_port = if branch_taken { "true" } else { "false" }.to_string();
+        let selected = if branch_taken {
+            branch_key!("true")
+        } else {
+            branch_key!("false")
+        };
 
         Ok(ControlOutcome::Branch {
-            selected: selected_port,
+            selected,
             output: data_object,
         })
     }
@@ -254,7 +262,8 @@ mod tests {
         match outcome {
             ControlOutcome::Branch { selected, .. } => {
                 assert_eq!(
-                    selected, expected_port,
+                    selected.as_str(),
+                    expected_port,
                     "expected port `{expected_port}`, got `{selected}`"
                 );
             },

--- a/crates/plugin-core/src/actions/switch_action.rs
+++ b/crates/plugin-core/src/actions/switch_action.rs
@@ -57,9 +57,10 @@
 use std::sync::OnceLock;
 
 use nebula_action::{
-    ActionContext, ActionError, ActionMetadata,
+    ActionContext, ActionError, ActionMetadata, branch_key,
     control::{ControlAction, ControlInput, ControlOutcome},
     port::{DynamicPort, OutputPort, default_input_ports},
+    port_key,
 };
 use nebula_core::action_key;
 use nebula_schema::HasSchema;
@@ -128,7 +129,7 @@ impl nebula_action::action::Action for CoreSwitch {
         )
         .with_inputs(default_input_ports())
         .with_outputs(vec![OutputPort::Dynamic(DynamicPort {
-            key: "case".into(),
+            key: port_key!("case"),
             source_field: "cases".into(),
             label_field: Some("port".into()),
             include_fallback: true,
@@ -183,8 +184,14 @@ impl ControlAction for CoreSwitch {
         // Evaluate cases in order. First-match-wins; Fatal propagates immediately.
         for case in &cases {
             if evaluate_condition(&data_object, &case.condition)? {
+                let selected =
+                    nebula_action::BranchKey::new(case.port.clone()).map_err(|validation_err| {
+                        ActionError::fatal(format!(
+                            "core.switch: case port name is invalid — {validation_err}"
+                        ))
+                    })?;
                 return Ok(ControlOutcome::Branch {
-                    selected: case.port.clone(),
+                    selected,
                     output: data_object,
                 });
             }
@@ -192,7 +199,7 @@ impl ControlAction for CoreSwitch {
 
         // No case matched (or cases list is empty) → route to "default".
         Ok(ControlOutcome::Branch {
-            selected: "default".to_string(),
+            selected: branch_key!("default"),
             output: data_object,
         })
     }
@@ -226,7 +233,8 @@ mod tests {
         match outcome {
             ControlOutcome::Branch { selected, .. } => {
                 assert_eq!(
-                    selected, expected_port,
+                    selected.as_str(),
+                    expected_port,
                     "expected port `{expected_port}`, got `{selected}`"
                 );
             },


### PR DESCRIPTION
## Summary

W0 port-seam plan **Unit U1** (ADR-0109 workstream A.2 / P0 — "land P0 first"). Converts the stringly `pub type PortKey = String` / `pub type BranchKey = String` aliases into **validated newtypes**, closing a serde phantom-port forgery backdoor.

**The vulnerability:** `ActionResult<T>` is `#[derive(Deserialize)] #[serde(tag="type")] #[non_exhaustive]`. Per ADR-0109 §3, a compile-time type witness dies at the `ActionResult<Value>` erasure boundary — the engine router, durable journal, editor, and TypeDAG all consume the post-erasure string-keyed result, which serde rehydrated `{"type":"Route","port":"phantom"}` **unchecked**. A bare `String` alias is a front-door lock on a house whose load-bearing door is serde.

## Fix

- **Bespoke validated newtypes** `PortKey` / `BranchKey` (kept distinct — `Route{port}` vs `Branch{selected}` are a type error to cross): charset `[a-zA-Z0-9_-]`, len 1..=64, no leading/trailing/consecutive `_`/`-`, case-sensitive. Shared `validate_key` + one `KeyValidationError` (`#[non_exhaustive]` kind).
- `#[serde(try_from = "String", into = "String")]` — deserialize routes through validation, so a forged/empty/malformed key is **rejected at the wire boundary** (the structural fix). Validated for the scalar `Route.port`/`Branch.selected` AND the `HashMap<PortKey,_>` / `HashMap<BranchKey,_>` map keys.
- `port_key!` / `branch_key!` const-checked macros (mirror `resource_key!`) — invalid literal = compile error; no `.unwrap()` in library paths. Constructors take the newtype directly (`OutputPort::flow(PortKey)`); runtime strings use the fallible `PortKey::new(s)?`.
- `Borrow<str>` + `AsRef<str>` + `Display` so `evaluate_edge`'s raw-string routing keeps compiling **with zero semantic change**.

## Scope boundary (U1 only)

Newtype + serde-validation + construction-site ripple. Does **not** change `evaluate_edge` routing semantics, add declared-port fail-closed checks, touch the `main`/`out` fork, or convert `Connection.from_port/to_port` (stays `Option<String>`) — those are U2/U5.

## Tests (red→green)

End-to-end `ActionResult` serde-rejection tests for forged `Route.port`, `Branch.selected`, `Branch.alternatives` map-key, and `MultiOutput.outputs` map-key (empty + invalid-char) — each RED on the old `String` alias, GREEN now. Plus newtype unit tests (every `KeyValidationErrorKind`, const-validator ↔ runtime agreement, `Borrow<str>` HashMap lookup).

## Semver

`OutputPort::flow`/`error`/`dynamic` + `InputPort::flow` signatures change (take `PortKey`). `PortKey`/`BranchKey` are NOT re-exported by `nebula-sdk` → no external surface; pre-1.0, breaking-OK. Impl modules are `pub(crate)` (sole public path is the crate-root re-export).

## Gate

`cargo check --workspace --all-targets` clean · `cargo clippy -p nebula-action -p nebula-engine -p nebula-plugin-core --all-targets -- -D warnings` clean · `cargo nextest run -p nebula-action` 518/518 (+ engine/plugin-core/workflow 925/925) · `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-action` clean · pre-push clippy-full + crate-diff-gate green.

Follow-ups (W0 plan): U3 (`output_port_keys()` accessor) + U2 (fail-closed declared-port routing + `main`/`out` canonicalization on `"out"`); U5 (per-field TypeDAG Reference-edge typing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)