### PR TITLE
feat(worker): run the durable-timer scanner in the worker runtime (Codex P1 on #933)

### DIFF
--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -1848,6 +1848,12 @@ impl ExecutionStore for FailAtCommitN {
         self.inner.release_lease(scope, id, token).await
     }
 
+    async fn list_all_running(
+        &self,
+    ) -> Result<Vec<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         self.inner.list_running(scope).await
     }
@@ -3942,6 +3948,12 @@ impl ExecutionStore for ExternalMutateBeforeN {
         token: nebula_storage_port::FencingToken,
     ) -> Result<bool, StorageError> {
         self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_all_running(
+        &self,
+    ) -> Result<Vec<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
     }
 
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {

--- a/crates/engine/src/engine/timer_scan.rs
+++ b/crates/engine/src/engine/timer_scan.rs
@@ -36,8 +36,9 @@ use super::*;
 pub const DEFAULT_TIMER_SCAN_INTERVAL: Duration = Duration::from_secs(30);
 
 impl WorkflowEngine {
-    /// Re-drive every `Running` execution that has an overdue parked timer but
-    /// no live owner, firing the wake the crashed runner would have fired.
+    /// Re-drive every `Running` execution across ALL tenant scopes that has an
+    /// overdue parked timer but no live owner, firing the wake the crashed runner
+    /// would have fired.
     ///
     /// The execution lease is the dead-vs-live oracle: a live owner holds it
     /// (`resume_execution` → [`EngineError::Leased`] → skipped, no double-drive);
@@ -47,32 +48,29 @@ impl WorkflowEngine {
     /// Timeout`) whose deadline is overdue is correctly fired down its timeout
     /// (fail) branch, exactly as a live runner would.
     ///
+    /// Each row is re-driven under its OWN persisted scope so multi-tenant
+    /// workers need no per-scope wiring — a single sweep covers all tenants.
+    ///
     /// Returns the number of executions re-driven. Per-execution errors are
     /// logged and never abort the sweep.
     ///
     /// # Errors
     ///
     /// Returns [`EngineError::PlanningFailed`] only if the initial
-    /// `list_running` storage call fails; individual execution failures are
+    /// `list_all_running` storage call fails; individual execution failures are
     /// absorbed so one bad row cannot wedge the sweep.
-    pub async fn sweep_overdue_timers(&self, scope: &Scope) -> Result<usize, EngineError> {
+    pub async fn sweep_overdue_timers(&self) -> Result<usize, EngineError> {
         let Some(stores) = self.stores.clone() else {
             // No durable store wired (library mode) — nothing to scan.
             return Ok(0);
         };
         let now = self.clock.now();
-        let running =
-            stores.execution.list_running(scope).await.map_err(|e| {
-                EngineError::PlanningFailed(format!("timer-scan list_running: {e}"))
-            })?;
+        let all_records = stores.execution.list_all_running().await.map_err(|e| {
+            EngineError::PlanningFailed(format!("timer-scan list_all_running: {e}"))
+        })?;
 
         let mut redriven = 0usize;
-        for id in running {
-            let Ok(Some(record)) = stores.execution.get(scope, &id).await else {
-                // Storage blip or the row vanished between list and get — the
-                // next sweep retries.
-                continue;
-            };
+        for record in all_records {
             // `from_str` (not `from_value`): `ExecutionState` carries a borrowing
             // field that `serde_json::from_value` cannot deserialize from an owned
             // `Value`, so round-trip through the string form (the same convention
@@ -87,15 +85,15 @@ impl WorkflowEngine {
             if !has_overdue_timer {
                 continue;
             }
-            let Ok(execution_id) = id.parse::<ExecutionId>() else {
+            let Ok(execution_id) = record.id.parse::<ExecutionId>() else {
                 tracing::warn!(
                     target = "engine::timer_scan",
-                    execution_id = %id,
+                    execution_id = %record.id,
                     "unparseable execution id in running set; skipping"
                 );
                 continue;
             };
-            match self.resume_execution(scope, execution_id).await {
+            match self.resume_execution(&record.scope, execution_id).await {
                 Ok(_) => {
                     redriven += 1;
                     tracing::debug!(
@@ -122,14 +120,13 @@ impl WorkflowEngine {
     /// Spawn the durable-timer wake scanner as a background task.
     ///
     /// Ticks every `interval`, calling [`sweep_overdue_timers`](Self::sweep_overdue_timers)
-    /// for `scope`, until `shutdown` is cancelled. Mirrors the control-queue
-    /// reclaim sweep's plain-task model (a missed tick is delayed, not bursted).
-    /// The composition root owns the cadence; [`DEFAULT_TIMER_SCAN_INTERVAL`] is
-    /// a sane default.
+    /// across ALL tenant scopes, until `shutdown` is cancelled. Mirrors the
+    /// control-queue reclaim sweep's plain-task model (a missed tick is delayed,
+    /// not bursted). The composition root owns the cadence;
+    /// [`DEFAULT_TIMER_SCAN_INTERVAL`] is a sane default.
     #[must_use = "the returned JoinHandle owns the scanner task; dropping it detaches the loop"]
     pub fn spawn_timer_scanner(
         self: Arc<Self>,
-        scope: Scope,
         interval: Duration,
         shutdown: CancellationToken,
     ) -> JoinHandle<()> {
@@ -151,7 +148,7 @@ impl WorkflowEngine {
                         return;
                     }
                     _ = ticker.tick() => {
-                        match self.sweep_overdue_timers(&scope).await {
+                        match self.sweep_overdue_timers().await {
                             Ok(n) if n > 0 => tracing::info!(
                                 target = "engine::timer_scan",
                                 redriven = n,

--- a/crates/engine/tests/resume_token_revoke.rs
+++ b/crates/engine/tests/resume_token_revoke.rs
@@ -253,6 +253,10 @@ impl ExecutionStore for ArmableConflictStore {
         self.inner.release_lease(scope, id, token).await
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         self.inner.list_running(scope).await
     }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -47,7 +47,7 @@ use nebula_metrics::MetricsRegistry;
 use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
 use nebula_storage_port::{
     FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome,
-    dto::WorkflowVersionRecord,
+    dto::{ExecutionRecord, WorkflowVersionRecord},
     store::{ExecutionStore, WorkflowVersionStore},
 };
 use nebula_workflow::{
@@ -1279,11 +1279,7 @@ impl ExecutionStore for CommitFenceInterceptor {
             .await
     }
 
-    async fn get(
-        &self,
-        scope: &Scope,
-        id: &str,
-    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
         self.inner.get(scope, id).await
     }
 
@@ -1326,6 +1322,10 @@ impl ExecutionStore for CommitFenceInterceptor {
         token: FencingToken,
     ) -> Result<bool, StorageError> {
         self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
     }
 
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
@@ -1565,11 +1565,7 @@ impl ExecutionStore for CancelDuringSatisfyInterceptor {
             .await
     }
 
-    async fn get(
-        &self,
-        scope: &Scope,
-        id: &str,
-    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
         let rec = self.inner.get(scope, id).await?;
         // Inject the concurrent cancel only on the under-lease reload (after
         // acquire_lease), and only once.
@@ -1627,6 +1623,10 @@ impl ExecutionStore for CancelDuringSatisfyInterceptor {
         token: FencingToken,
     ) -> Result<bool, StorageError> {
         self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
     }
 
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
@@ -2056,11 +2056,7 @@ impl ExecutionStore for LeaseFailAfterArmInterceptor {
             .await
     }
 
-    async fn get(
-        &self,
-        scope: &Scope,
-        id: &str,
-    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
         self.inner.get(scope, id).await
     }
 
@@ -2103,6 +2099,10 @@ impl ExecutionStore for LeaseFailAfterArmInterceptor {
         token: FencingToken,
     ) -> Result<bool, StorageError> {
         self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
     }
 
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
@@ -2370,11 +2370,7 @@ impl ExecutionStore for CommitStatusRecorder {
             .await
     }
 
-    async fn get(
-        &self,
-        scope: &Scope,
-        id: &str,
-    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
         self.inner.get(scope, id).await
     }
 
@@ -2431,6 +2427,10 @@ impl ExecutionStore for CommitStatusRecorder {
         token: FencingToken,
     ) -> Result<bool, StorageError> {
         self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
     }
 
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {

--- a/crates/engine/tests/timer_wait_crash_recovery.rs
+++ b/crates/engine/tests/timer_wait_crash_recovery.rs
@@ -527,14 +527,10 @@ async fn durable_timer_scanner_recovers_crashed_timer_without_resume() {
             .with_lease_ttl(LEASE_TTL)
             .with_lease_heartbeat_interval(HEARTBEAT),
     );
-    let scope = nebula_engine::store_seam::single_tenant_scope();
-    let redriven = tokio::time::timeout(
-        Duration::from_secs(10),
-        engine_b.sweep_overdue_timers(&scope),
-    )
-    .await
-    .expect("the scanner must settle within 10s")
-    .expect("the scanner sweep must not error");
+    let redriven = tokio::time::timeout(Duration::from_secs(10), engine_b.sweep_overdue_timers())
+        .await
+        .expect("the scanner must settle within 10s")
+        .expect("the scanner sweep must not error");
 
     assert_eq!(
         redriven, 1,

--- a/crates/engine/tests/wait_recovery.rs
+++ b/crates/engine/tests/wait_recovery.rs
@@ -138,6 +138,10 @@ impl ExecutionStore for FaultInjectingExecutionStore {
         self.inner.release_lease(scope, id, token).await
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         self.inner.list_running(scope).await
     }

--- a/crates/engine/tests/wait_timeout.rs
+++ b/crates/engine/tests/wait_timeout.rs
@@ -670,6 +670,10 @@ impl ExecutionStore for FenceArmStore {
         self.inner.release_lease(scope, id, token).await
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        self.inner.list_all_running().await
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         self.inner.list_running(scope).await
     }

--- a/crates/storage-port/src/store/execution.rs
+++ b/crates/storage-port/src/store/execution.rs
@@ -61,6 +61,18 @@ pub trait ExecutionStore: Send + Sync + std::fmt::Debug {
         token: FencingToken,
     ) -> Result<bool, StorageError>;
 
+    /// List every execution row across ALL tenant scopes.
+    ///
+    /// Used by the durable-timer wake scanner to find parked timers with no live
+    /// owner regardless of tenant. Returns full [`ExecutionRecord`]s (scope + state)
+    /// so the caller applies its own predicate and re-drives under each row's own
+    /// scope. MVP: returns all active rows; a backend-side overdue-timer pushdown
+    /// (e.g. a Postgres JSONB predicate) is a follow-up optimization.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] on a backend failure.
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError>;
+
     /// List running execution ids in `scope`.
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError>;
 

--- a/crates/storage-port/tests/conformance_contract.rs
+++ b/crates/storage-port/tests/conformance_contract.rs
@@ -84,6 +84,10 @@ impl ExecutionStore for StubExecutionStore {
         Ok(false)
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        Ok(vec![])
+    }
+
     async fn list_running(&self, _scope: &Scope) -> Result<Vec<String>, StorageError> {
         Ok(vec![])
     }

--- a/crates/storage/src/inmem/execution.rs
+++ b/crates/storage/src/inmem/execution.rs
@@ -401,6 +401,26 @@ impl ExecutionStore for InMemoryExecutionStore {
         Ok(true)
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        let st = self.inner.lock();
+        Ok(st
+            .rows
+            .iter()
+            .map(|(id, row)| ExecutionRecord {
+                id: id.clone(),
+                workflow_id: row.workflow_id.clone(),
+                scope: row.scope.clone(),
+                version: row.version,
+                status: row.status.clone(),
+                state: row.state.clone(),
+                lease_holder: row.lease_holder.clone(),
+                fencing: Some(row.fencing_generation),
+                created_at: String::new(),
+                updated_at: String::new(),
+            })
+            .collect())
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         let st = self.inner.lock();
         Ok(st

--- a/crates/storage/src/postgres/execution.rs
+++ b/crates/storage/src/postgres/execution.rs
@@ -433,6 +433,41 @@ impl ExecutionStore for PgExecutionStore {
         Ok(res.rows_affected() == 1)
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT id, workspace_id, org_id, workflow_id, status, state, version, \
+                    lease_holder, fencing_generation, created_at, updated_at \
+             FROM port_executions",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        rows.into_iter()
+            .map(|row| {
+                let created: DateTime<Utc> = row.try_get("created_at").map_err(conn_err)?;
+                let updated: DateTime<Utc> = row.try_get("updated_at").map_err(conn_err)?;
+                Ok(ExecutionRecord {
+                    id: row.try_get("id").map_err(conn_err)?,
+                    workflow_id: row.try_get("workflow_id").map_err(conn_err)?,
+                    scope: Scope::new(
+                        row.try_get::<String, _>("workspace_id").map_err(conn_err)?,
+                        row.try_get::<String, _>("org_id").map_err(conn_err)?,
+                    ),
+                    version: row.try_get::<i64, _>("version").map_err(conn_err)? as u64,
+                    status: row.try_get("status").map_err(conn_err)?,
+                    state: row.try_get("state").map_err(conn_err)?,
+                    lease_holder: row.try_get("lease_holder").map_err(conn_err)?,
+                    fencing: Some(
+                        row.try_get::<i64, _>("fencing_generation")
+                            .map_err(conn_err)? as u64,
+                    ),
+                    created_at: created.to_rfc3339(),
+                    updated_at: updated.to_rfc3339(),
+                })
+            })
+            .collect()
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         let rows =
             sqlx::query("SELECT id FROM port_executions WHERE workspace_id = $1 AND org_id = $2")

--- a/crates/storage/src/sqlite/execution.rs
+++ b/crates/storage/src/sqlite/execution.rs
@@ -427,6 +427,41 @@ impl ExecutionStore for SqliteExecutionStore {
         Ok(res.rows_affected() == 1)
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        let rows = sqlx::query(
+            "SELECT id, workspace_id, org_id, workflow_id, status, state, version, \
+                    lease_holder, fencing_generation, created_at, updated_at \
+             FROM port_executions",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        rows.into_iter()
+            .map(|row| {
+                let state_str: String = row.try_get("state").map_err(conn_err)?;
+                let state: serde_json::Value = serde_json::from_str(&state_str)?;
+                Ok(ExecutionRecord {
+                    id: row.try_get("id").map_err(conn_err)?,
+                    workflow_id: row.try_get("workflow_id").map_err(conn_err)?,
+                    scope: Scope::new(
+                        row.try_get::<String, _>("workspace_id").map_err(conn_err)?,
+                        row.try_get::<String, _>("org_id").map_err(conn_err)?,
+                    ),
+                    version: row.try_get::<i64, _>("version").map_err(conn_err)? as u64,
+                    status: row.try_get("status").map_err(conn_err)?,
+                    state,
+                    lease_holder: row.try_get("lease_holder").map_err(conn_err)?,
+                    fencing: Some(
+                        row.try_get::<i64, _>("fencing_generation")
+                            .map_err(conn_err)? as u64,
+                    ),
+                    created_at: row.try_get("created_at").map_err(conn_err)?,
+                    updated_at: row.try_get("updated_at").map_err(conn_err)?,
+                })
+            })
+            .collect()
+    }
+
     async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
         let rows =
             sqlx::query("SELECT id FROM port_executions WHERE workspace_id = ? AND org_id = ?")

--- a/crates/tenancy/src/decorator/execution.rs
+++ b/crates/tenancy/src/decorator/execution.rs
@@ -136,6 +136,12 @@ impl ExecutionStore for ScopedExecutionStore {
         self.inner.release_lease(&self.bound, id, token).await
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        // No scope filter: cross-tenant scan is the point of this method.
+        // The caller (timer scanner) re-drives each row under its own scope.
+        self.inner.list_all_running().await
+    }
+
     async fn list_running(&self, _scope: &Scope) -> Result<Vec<String>, StorageError> {
         self.inner.list_running(&self.bound).await
     }

--- a/crates/tenancy/tests/cross_tenant_denial.rs
+++ b/crates/tenancy/tests/cross_tenant_denial.rs
@@ -158,6 +158,10 @@ impl ExecutionStore for MockExecStore {
         Ok(true)
     }
 
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        Ok(vec![])
+    }
+
     async fn list_running(&self, _scope: &Scope) -> Result<Vec<String>, StorageError> {
         Ok(vec![])
     }
@@ -973,6 +977,10 @@ impl ExecutionStore for TokenCapturingExecStore {
         _token: FencingToken,
     ) -> Result<bool, StorageError> {
         Ok(true)
+    }
+
+    async fn list_all_running(&self) -> Result<Vec<ExecutionRecord>, StorageError> {
+        Ok(vec![])
     }
 
     async fn list_running(&self, _scope: &Scope) -> Result<Vec<String>, StorageError> {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -40,7 +40,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use nebula_core::PluginKey;
-use nebula_engine::{EngineExecutionSink, ExecutionStores, WorkflowEngine};
+use nebula_engine::{
+    DEFAULT_TIMER_SCAN_INTERVAL, EngineExecutionSink, ExecutionStores, WorkflowEngine,
+};
 use nebula_metrics::MetricsRegistry;
 use nebula_orchestrator::Orchestrator;
 use nebula_storage_port::store::JobDispatchQueue;
@@ -64,11 +66,14 @@ pub enum WorkerBuildError {
 /// An assembled, ready-to-run worker runtime.
 ///
 /// Holds the [`Orchestrator`] configured with an [`EngineExecutionSink`]
-/// connected to the provided engine and execution store.
+/// connected to the provided engine and execution store, plus the engine
+/// reference needed to spawn the durable-timer wake scanner.
 ///
 /// Obtain via [`WorkerRuntimeBuilder::build`].
 #[must_use = "call .run() or .spawn() to start the pull loop"]
 pub struct WorkerRuntime {
+    engine: Arc<WorkflowEngine>,
+    timer_scan_interval: Duration,
     orchestrator: Orchestrator,
     processor_id: [u8; 16],
     available_plugins_count: usize,
@@ -84,7 +89,11 @@ impl std::fmt::Debug for WorkerRuntime {
 }
 
 impl WorkerRuntime {
-    /// Run the claim-loop on the current task until `shutdown` is cancelled.
+    /// Run the claim-loop and durable-timer scanner on the current task until
+    /// `shutdown` is cancelled.
+    ///
+    /// The timer scanner runs as a sibling background task sharing the same
+    /// shutdown token so it stops when the worker stops.
     ///
     /// Prefer [`spawn`](Self::spawn) unless integrating into a custom task structure.
     ///
@@ -99,21 +108,25 @@ impl WorkerRuntime {
             available_plugins = self.available_plugins_count,
             "worker runtime starting (ADR-0095 D1)"
         );
+        let _scanner = Arc::clone(&self.engine)
+            .spawn_timer_scanner(self.timer_scan_interval, shutdown.clone());
         self.orchestrator.run(shutdown).await;
     }
 
-    /// Spawn the claim-loop as a Tokio task.
+    /// Spawn the claim-loop and durable-timer scanner as a single Tokio task.
     ///
     /// Returns a [`JoinHandle`] that completes when `shutdown` is cancelled.
-    /// The caller owns signal→[`CancellationToken`] wiring; this crate provides
-    /// no `tokio::signal` integration so it composes into any shutdown strategy.
+    /// Both the orchestrator and the timer scanner share the same shutdown token
+    /// so they stop together. The caller owns signal→[`CancellationToken`] wiring;
+    /// this crate provides no `tokio::signal` integration so it composes into any
+    /// shutdown strategy.
     pub fn spawn(self, shutdown: CancellationToken) -> JoinHandle<()> {
         tracing::info!(
             processor = %hex_id(&self.processor_id),
             available_plugins = self.available_plugins_count,
             "worker runtime spawning (ADR-0095 D1)"
         );
-        self.orchestrator.spawn(shutdown)
+        tokio::spawn(async move { self.run(shutdown).await })
     }
 }
 
@@ -135,6 +148,8 @@ pub struct WorkerRuntimeBuilder {
     reclaim_interval: Option<Duration>,
     max_reclaim_count: Option<u32>,
     metrics: Option<MetricsRegistry>,
+    // Optional timer scanner override — None means DEFAULT_TIMER_SCAN_INTERVAL.
+    timer_scan_interval: Option<Duration>,
 }
 
 impl WorkerRuntimeBuilder {
@@ -184,6 +199,7 @@ impl WorkerRuntimeBuilder {
             reclaim_interval: None,
             max_reclaim_count: None,
             metrics: None,
+            timer_scan_interval: None,
         }
     }
 
@@ -226,6 +242,16 @@ impl WorkerRuntimeBuilder {
     /// counters reach the Prometheus scrape endpoint.
     pub fn with_metrics(mut self, m: MetricsRegistry) -> Self {
         self.metrics = Some(m);
+        self
+    }
+
+    /// Override the durable-timer scanner cadence (default:
+    /// [`DEFAULT_TIMER_SCAN_INTERVAL`] = 30 s).
+    ///
+    /// Shorter intervals reduce recovery latency for stranded timers at the
+    /// cost of more storage reads per unit time.
+    pub fn with_timer_scan_interval(mut self, d: Duration) -> Self {
+        self.timer_scan_interval = Some(d);
         self
     }
 
@@ -272,6 +298,10 @@ impl WorkerRuntimeBuilder {
         }
 
         Ok(WorkerRuntime {
+            engine: Arc::clone(&self.engine),
+            timer_scan_interval: self
+                .timer_scan_interval
+                .unwrap_or(DEFAULT_TIMER_SCAN_INTERVAL),
             orchestrator,
             processor_id: self.processor_id,
             available_plugins_count,


### PR DESCRIPTION
Addresses the **Codex P1** on [#933](https://github.com/vanyastaff/nebula/pull/933): the durable-timer scanner landed as an engine *capability* but was never wired into the shipped worker, so `sweep_overdue_timers` was never invoked in production — a stranded crashed-runner timer stayed stranded. This wires it.

## Why it needed more than a one-liner
The worker is **multi-tenant** — the sink (`EngineExecutionSink::dispatch`) drives each job under its per-message `JobDispatchMsg.scope`. A single-scope `sweep_overdue_timers(scope)` does not fit. So the sweep is made **scope-agnostic**.

## Changes
- **storage-port**: new required `ExecutionStore::list_all_running() -> Vec<ExecutionRecord>` — lists every active row across **all** tenant scopes (mirrors the existing `WebhookActivationStore::list_all_active`). Implemented in inmem / sqlite / postgres (full record incl. `scope` + `state`, no scope predicate), the tenancy `ScopedExecutionStore` decorator (delegates **without** applying its bound scope — cross-tenant is the point), and the test doubles.
- **engine**: `sweep_overdue_timers` drops the `scope` param and iterates `list_all_running()`, re-driving each overdue row under its **own** `record.scope`; `spawn_timer_scanner` drops `scope` too. (No external consumers existed — #933 merged this session — so reshaping to the correct surface is clean, not a break.)
- **worker**: `WorkerRuntime` retains the engine `Arc` + a `timer_scan_interval` (builder override `with_timer_scan_interval`, default `DEFAULT_TIMER_SCAN_INTERVAL`). `run()` spawns the scanner before the orchestrator under the **same** shutdown token; `spawn()` routes through `run()` so one `JoinHandle` owns both and both stop on shutdown.

## Scale note
`list_all_running` returns all active rows; the engine filters the overdue-timer predicate in-process. A backend-side pushdown (Postgres JSONB predicate on `next_attempt_at`) is a follow-up optimization, **not** a correctness gap.

## Verification
`cargo check --workspace --all-features --all-targets` clean. Pre-push gate green: clippy-full, nextest (843 tests across the changed crates, 0 skipped), `crate-diff-gate` (`rustdoc -D warnings` on storage-port / storage / engine / tenancy / worker). `timer_wait_crash_recovery` (both tests) + nebula-worker integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)