### PR TITLE
fix(engine,workflow): W0 correctness floor — fail-closed port routing + per-field Reference typing

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1893,17 +1893,28 @@ impl WorkflowEngine {
     /// execution is starting under. The version-skew bug itself remains a
     /// follow-up, not solved here.
     ///
-    /// Two deliberate fail-open carve-outs (this is a strict improvement
+    /// Three deliberate fail-open carve-outs (this is a strict improvement
     /// over today's silent no-op, not full protection):
     /// - An unregistered source action skips validation — the registry has
     ///   nothing to check the wire against.
-    /// - A source action that declares any [`OutputPort::Dynamic`] port
+    /// - A node pinning `interface_version` to a version with no matching
+    ///   registered entry skips validation the same way, for the same
+    ///   reason — an actually-unresolvable pinned version still fails later,
+    ///   at dispatch, through `get_factory_versioned`'s own not-found error.
+    /// - A source action that declares any `OutputPort::Dynamic` port
     ///   skips validation for **all** of its outgoing connections. Dynamic
     ///   ports (e.g. `core.switch`) emit config-derived keys (`"a"`, `"b"`,
     ///   `"default"`, ...) that no static check here can enumerate; a
     ///   uniform check would hard-reject every legitimate Switch/Router
     ///   wire. Real protection for dynamic ports is the `DynamicPort`
     ///   concrete-key-expansion follow-up, not this pre-flight.
+    ///
+    /// Checks the SAME action version `ActionRegistry::get_factory_versioned`
+    /// will actually dispatch for a version-pinned node — via
+    /// `ActionRegistry::output_ports_versioned`, threaded through
+    /// `node.interface_version` — rather than always the latest registered
+    /// version. Checking against the wrong version could wrongly reject a
+    /// wire the pinned version supports, or wrongly pass one it doesn't.
     fn validate_declared_output_ports(
         &self,
         graph: &DependencyGraph,
@@ -1922,12 +1933,18 @@ impl WorkflowEngine {
                 continue;
             }
 
-            let Some(declared) = self.runtime.registry().output_ports(&node.action_key) else {
+            let Some(declared) = self
+                .runtime
+                .registry()
+                .output_ports_versioned(&node.action_key, node.interface_version.as_ref())
+            else {
                 tracing::warn!(
                     %source_id,
                     action_key = %node.action_key,
-                    "undeclared-output-port pre-flight: source action is not registered; \
-                     skipping validation for its outgoing connections (fail-open)"
+                    interface_version = ?node.interface_version,
+                    "undeclared-output-port pre-flight: source action is not registered (or its \
+                     pinned interface_version has no matching registered entry); skipping \
+                     validation for its outgoing connections (fail-open)"
                 );
                 continue;
             };

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1856,6 +1856,149 @@ impl WorkflowEngine {
         }))
     }
 
+    /// Pre-flight: reject any `Connection` whose `from_port` the source
+    /// action never declares.
+    ///
+    /// Called from two sites, both strictly *before* their caller creates
+    /// the execution row or acquires the execution lease — the placement is
+    /// load-bearing at both, not incidental: it is what makes a rejection
+    /// have zero execution side effects (nothing persisted, nothing leased,
+    /// no node dispatched) rather than orphaning a row under a held lease
+    /// that nothing ever tears down.
+    ///
+    /// - [`execute_workflow_scoped`](Self::execute_workflow_scoped), immediately
+    ///   after [`DependencyGraph::from_definition`] — before that function's
+    ///   `stores.execution.create` / `acquire_and_heartbeat_lease`. Reachable
+    ///   only from tests and direct-embed callers; production dispatch never
+    ///   calls it.
+    /// - [`resume_execution`](Self::resume_execution), gated on
+    ///   `is_first_attempt` (i.e. only on the cold-start branch where
+    ///   `node_states` was empty before seeding — see that function's `W0 U2`
+    ///   comment), immediately after that function's `node_map` is built —
+    ///   before its `acquire_and_heartbeat_lease`. This is production's ONLY
+    ///   path for validating a brand-new execution: `EngineControlDispatch`'s
+    ///   `dispatch_start` / `dispatch_resume` / `dispatch_restart` all
+    ///   converge on `resume_execution`, never on `execute_workflow_scoped`.
+    ///
+    /// Do not move either call site to after its lease acquisition.
+    ///
+    /// Deliberately **not** run on a genuine resume (non-empty `node_states`
+    /// on entry to `resume_execution`): that path reloads the *latest
+    /// published* workflow version rather than the version the execution
+    /// actually started under (a separate, pre-existing bug), so validating
+    /// there risks hard-failing an already in-flight execution over a
+    /// version mismatch its operator never had a chance to see. A true first
+    /// attempt carries no such risk — there is no prior in-flight state to
+    /// conflict with, and the loaded workflow version IS the version the
+    /// execution is starting under. The version-skew bug itself remains a
+    /// follow-up, not solved here.
+    ///
+    /// Two deliberate fail-open carve-outs (this is a strict improvement
+    /// over today's silent no-op, not full protection):
+    /// - An unregistered source action skips validation — the registry has
+    ///   nothing to check the wire against.
+    /// - A source action that declares any [`OutputPort::Dynamic`] port
+    ///   skips validation for **all** of its outgoing connections. Dynamic
+    ///   ports (e.g. `core.switch`) emit config-derived keys (`"a"`, `"b"`,
+    ///   `"default"`, ...) that no static check here can enumerate; a
+    ///   uniform check would hard-reject every legitimate Switch/Router
+    ///   wire. Real protection for dynamic ports is the `DynamicPort`
+    ///   concrete-key-expansion follow-up, not this pre-flight.
+    fn validate_declared_output_ports(
+        &self,
+        graph: &DependencyGraph,
+        node_map: &HashMap<NodeKey, &nebula_workflow::NodeDefinition>,
+    ) -> Result<(), EngineError> {
+        // `(from_node, to_node, port, declared)` per offending connection.
+        // Collected as plain data (not yet wrapped in `EngineError`) so it
+        // can be sorted below — `node_map` is a `HashMap`, so iterating it
+        // directly would make "the first offender" nondeterministic across
+        // runs when more than one connection is bad.
+        let mut offenders: Vec<(NodeKey, NodeKey, PortKey, Vec<PortKey>)> = Vec::new();
+
+        for (source_id, node) in node_map {
+            let outgoing = graph.outgoing_connections(source_id.clone());
+            if outgoing.is_empty() {
+                continue;
+            }
+
+            let Some(declared) = self.runtime.registry().output_ports(&node.action_key) else {
+                tracing::warn!(
+                    %source_id,
+                    action_key = %node.action_key,
+                    "undeclared-output-port pre-flight: source action is not registered; \
+                     skipping validation for its outgoing connections (fail-open)"
+                );
+                continue;
+            };
+
+            if declared.iter().any(nebula_action::OutputPort::is_dynamic) {
+                // Dynamic-port carve-out — see doc comment above.
+                continue;
+            }
+
+            for conn in outgoing {
+                let port = conn.effective_from_port();
+                let is_declared =
+                    port.as_str() == "error" || declared.iter().any(|p| p.key() == port.as_str());
+                if is_declared {
+                    continue;
+                }
+
+                let declared_keys: Vec<PortKey> = declared
+                    .iter()
+                    .filter_map(|p| match p {
+                        nebula_action::OutputPort::Flow { key, .. } => Some(key.clone()),
+                        // Dynamic ports were already ruled out above; any
+                        // future `OutputPort` variant fails safe to
+                        // "excluded" rather than panicking (the enum is
+                        // `#[non_exhaustive]`).
+                        _ => None,
+                    })
+                    .collect();
+                offenders.push((
+                    conn.from_node.clone(),
+                    conn.to_node.clone(),
+                    port.clone(),
+                    declared_keys,
+                ));
+            }
+        }
+
+        // Deterministic order: sort by (from_node, to_node, port) rendered
+        // as strings (`NodeKey`/`PortKey` have no `Ord` impl) so the
+        // "first" offender returned as the `Err` is stable across runs and
+        // hash-seed reseeds, not an artifact of `HashMap` iteration order.
+        offenders.sort_by(|a, b| {
+            (a.0.to_string(), a.1.to_string(), a.2.as_str()).cmp(&(
+                b.0.to_string(),
+                b.1.to_string(),
+                b.2.as_str(),
+            ))
+        });
+
+        for (from_node, to_node, port, declared) in &offenders {
+            tracing::error!(
+                %from_node,
+                %to_node,
+                %port,
+                ?declared,
+                "undeclared output port on connection"
+            );
+        }
+
+        let mut offenders = offenders.into_iter();
+        match offenders.next() {
+            Some((from_node, to_node, port, declared)) => Err(EngineError::UndeclaredOutputPort {
+                from_node,
+                to_node,
+                port,
+                declared,
+            }),
+            None => Ok(()),
+        }
+    }
+
     /// Execute a workflow from start to finish.
     ///
     /// Builds an execution plan for validation, then processes nodes
@@ -1941,6 +2084,25 @@ impl WorkflowEngine {
         // 2. Build dependency graph
         let graph = DependencyGraph::from_definition(workflow)
             .map_err(|e| EngineError::PlanningFailed(e.to_string()))?;
+
+        // 2a. Build node lookup map. Built here (rather than immediately
+        // before the frontier loop) so the pre-flight below can consult it
+        // before anything is persisted or leased — see that call's comment.
+        let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
+            workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
+
+        // 2b. Fresh-execution-only pre-flight: reject connections wired to
+        // an output port the source action never declared (W0 U2). MUST run
+        // here, before the execution row is created (`stores.execution.create`
+        // below) and before the lease is acquired (`acquire_and_heartbeat_lease`
+        // below) — nothing has been persisted or leased yet at this point, so
+        // an `Err` here requires zero teardown. (An earlier version of this
+        // check ran after both, whose `?` skipped this function's only
+        // `persist_final_state` / `guard.shutdown()` call sites and orphaned
+        // the execution row `Running` with a held lease — caught in review.)
+        // Not run on the resume path — see `validate_declared_output_ports`
+        // doc comment.
+        self.validate_declared_output_ports(&graph, &node_map)?;
 
         // 3. Validate action key mappings exist for all nodes
         // 4. Initialize execution state
@@ -2035,9 +2197,8 @@ impl WorkflowEngine {
         // 6. Record start metric
         self.workflow_executions_started.inc();
 
-        // 7. Build node lookup map
-        let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
-            workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
+        // 7. `node_map` was built in step 2a (before persistence/lease, for
+        // the pre-flight); reused here for the frontier loop.
 
         // 8. Shared output storage (concurrent access from worker tasks)
         let outputs: Arc<DashMap<NodeKey, serde_json::Value>> = Arc::new(DashMap::new());

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -135,7 +135,16 @@ impl WorkflowEngine {
         // frontier seeder below treats graph entry nodes as the natural starting
         // set. A warm resume (post-crash, with persisted per-node state) skips
         // this branch untouched.
-        if exec_state.node_states.is_empty() {
+        //
+        // Captured before the seeding mutation below so the W0 U2 pre-flight
+        // further down (`validate_declared_output_ports`) can tell a genuine
+        // first attempt (production `Start` traffic — this is production's
+        // ONLY entry point for a brand-new execution; `execute_workflow_scoped`
+        // is reachable only from tests/direct-embed callers) from an actual
+        // resume of an already-in-progress execution, after this same check
+        // has already emptied the condition it reads.
+        let is_first_attempt = exec_state.node_states.is_empty();
+        if is_first_attempt {
             for node in &workflow.nodes {
                 exec_state.set_node_state(
                     node.id.clone(),
@@ -198,6 +207,38 @@ impl WorkflowEngine {
         //    it evaluates edges from the frontier.
         let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
             workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
+
+        // W0 U2 fresh-execution-only pre-flight, gated on `is_first_attempt`
+        // (captured above, before the cold-start seed emptied the condition
+        // it was read from): reject connections wired to an output port the
+        // source action never declared. This is production's ONLY path for
+        // validating a brand-new execution — `execute_workflow_scoped` (which
+        // runs the same check) is never reached from production dispatch;
+        // production `Start`/`Resume`/`Restart` all converge on this function
+        // via `EngineControlDispatch::drive` → `resume_execution`.
+        //
+        // Runs ONLY on a genuine first attempt, never on an actual resume of
+        // an already-in-progress execution: re-validating a resumed run
+        // against `resume_execution`'s reloaded *latest published* workflow
+        // version (rather than the version the execution actually started
+        // under — a separate, pre-existing bug, see the module-level
+        // rationale on `validate_declared_output_ports`) could hard-fail an
+        // in-flight execution over a version mismatch its operator never had
+        // a chance to see. A true first attempt carries no such risk: there
+        // is no prior in-flight state to conflict with, and the workflow
+        // version it loads here IS the version it is starting under.
+        //
+        // Placement is load-bearing, same principle as `execute_workflow_scoped`:
+        // this must run before the execution lease is acquired below
+        // (`acquire_and_heartbeat_lease`, ~100 lines down) — verified by
+        // reading every intervening line: nothing between here and the lease
+        // acquire persists anything (`resume_execution` never creates the
+        // execution row itself; the API's start handler already did, before
+        // this function was ever called) or takes a lease, so a rejection
+        // here requires zero teardown.
+        if is_first_attempt {
+            self.validate_declared_output_ports(&graph, &node_map)?;
+        }
 
         let mut activated_edges: HashMap<NodeKey, HashSet<NodeKey>> = HashMap::new();
         let mut resolved_edges: HashMap<NodeKey, usize> = HashMap::new();

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -236,8 +236,29 @@ impl WorkflowEngine {
         // execution row itself; the API's start handler already did, before
         // this function was ever called) or takes a lease, so a rejection
         // here requires zero teardown.
-        if is_first_attempt {
-            self.validate_declared_output_ports(&graph, &node_map)?;
+        if is_first_attempt
+            && let Err(reject) = self.validate_declared_output_ports(&graph, &node_map)
+        {
+            // Production's ONLY entry point for a brand-new execution — the
+            // API start handler already durably created this `Created` row
+            // before `resume_execution` was ever called (see the seam
+            // comment above). A bare `?` here would return before this
+            // function's own `persist_final_state` call ever runs (it is
+            // reached only via the frontier loop below), leaving that row
+            // orphaned in `Created` forever with no visible failure
+            // anywhere — `EngineControlDispatch::drive` only marks the
+            // CONTROL-QUEUE row failed, never the execution row itself.
+            // Durably fail the execution row before propagating so the
+            // rejection is actually observable.
+            self.fail_cold_start_preflight(
+                scope,
+                execution_id,
+                exec_state,
+                repo_version_loaded,
+                &reject,
+            )
+            .await;
+            return Err(reject);
         }
 
         let mut activated_edges: HashMap<NodeKey, HashSet<NodeKey>> = HashMap::new();
@@ -545,6 +566,161 @@ impl WorkflowEngine {
             duration: elapsed,
             termination_reason: termination_reason.clone(),
         })
+    }
+
+    /// Durably fail a freshly-`Created` execution row when the W0 U2
+    /// cold-start pre-flight (`validate_declared_output_ports`) rejects it
+    /// inside [`Self::resume_execution`]'s `is_first_attempt` branch.
+    ///
+    /// `resume_execution` never creates its own execution row — production's
+    /// API start handler already durably persisted this row as `Created`
+    /// before `resume_execution` was ever invoked. That makes this call site
+    /// unique: unlike `execute_workflow_scoped` (which runs the same
+    /// pre-flight *before* it creates its own row, so a rejection there
+    /// requires zero teardown), a rejection here must actively transition an
+    /// already-existing row, or it is orphaned in `Created` forever — nothing
+    /// downstream (`EngineControlDispatch::drive`, `ControlConsumer::mark_failed`)
+    /// ever marks the execution row itself, only the control-queue row.
+    ///
+    /// Mirrors [`nebula_execution::state::ExecutionState::mark_setup_failed`]'s
+    /// record-then-fail pattern (used by the frontier loop for a single
+    /// node's setup failure), applied at the execution level: the offending
+    /// node is recorded as `Failed` with the rejection reason so it surfaces
+    /// through the normal per-node error-message read path, then the
+    /// execution status is driven `Created → Running → Failed` (direct
+    /// `Created → Failed` is not a valid transition) and committed with the
+    /// version this call loaded — nothing else has written to the row since.
+    ///
+    /// Best-effort by design: on a lease conflict or CAS race this logs and
+    /// returns without transitioning. The caller still propagates the
+    /// original `EngineError` regardless of whether this durable mark
+    /// succeeds, so no rejection is ever silently swallowed — a row left
+    /// stuck in `Created` after a failed best-effort attempt remains
+    /// reachable by the existing crash-recovery reclaim path.
+    async fn fail_cold_start_preflight(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        mut exec_state: ExecutionState,
+        repo_version: u64,
+        reject: &EngineError,
+    ) {
+        let Some(stores) = &self.stores else {
+            // Library mode (no storage) — no durable row to repair.
+            return;
+        };
+
+        let id = execution_id.to_string();
+        let holder = self.instance_id.to_string();
+
+        let lease_token = match stores
+            .execution
+            .acquire_lease(scope, &id, &holder, self.lease_ttl)
+            .await
+        {
+            Ok(Some(token)) => token,
+            Ok(None) => {
+                tracing::warn!(
+                    %execution_id,
+                    error = %reject,
+                    "cold-start preflight rejection: execution lease held by another runner; \
+                     leaving the execution row for that runner to resolve"
+                );
+                return;
+            },
+            Err(e) => {
+                tracing::warn!(
+                    %execution_id,
+                    error = %e,
+                    reject = %reject,
+                    "cold-start preflight rejection: failed to acquire lease; the execution row \
+                     remains Created (recoverable via reclaim)"
+                );
+                return;
+            },
+        };
+
+        if let EngineError::UndeclaredOutputPort { from_node, .. } = reject {
+            let _ = exec_state.mark_setup_failed(from_node.clone(), reject.to_string());
+        }
+        if exec_state.status == ExecutionStatus::Created {
+            let _ = exec_state.transition_status(ExecutionStatus::Running);
+        }
+        if !exec_state.status.is_terminal() {
+            let _ = exec_state.transition_status(ExecutionStatus::Failed);
+        }
+
+        let commit_outcome = async {
+            let state_json =
+                serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {
+                    node_key: final_state_node_key(),
+                    reason: format!("cold-start preflight rejection: serialise failed state: {e}"),
+                })?;
+            let batch = nebula_storage_port::TransitionBatch::builder()
+                .scope(scope.clone())
+                .execution_id(&id)
+                .expected_version(repo_version)
+                .fencing(lease_token)
+                .new_state(state_json)
+                .build()
+                .map_err(|e| EngineError::CheckpointFailed {
+                    node_key: final_state_node_key(),
+                    reason: format!("cold-start preflight rejection: build batch: {e}"),
+                })?;
+            stores
+                .execution
+                .commit(batch)
+                .await
+                .map_err(|e| EngineError::CheckpointFailed {
+                    node_key: final_state_node_key(),
+                    reason: format!("cold-start preflight rejection: store commit: {e}"),
+                })
+        }
+        .await;
+
+        match commit_outcome {
+            Ok(nebula_storage_port::TransitionOutcome::Applied { new_version }) => {
+                tracing::error!(
+                    %execution_id,
+                    new_version,
+                    error = %reject,
+                    "cold-start preflight rejected the execution; marked the execution row \
+                     Failed instead of leaving it orphaned in Created (W0 U2 gap fix)"
+                );
+                revoke_resume_tokens_best_effort(stores, scope, &id).await;
+            },
+            Ok(other) => {
+                tracing::warn!(
+                    %execution_id,
+                    outcome = ?other,
+                    error = %reject,
+                    "cold-start preflight rejection: CAS did not apply while marking the \
+                     execution row Failed; row may remain Created (recoverable via reclaim)"
+                );
+            },
+            Err(e) => {
+                tracing::warn!(
+                    %execution_id,
+                    error = %e,
+                    reject = %reject,
+                    "cold-start preflight rejection: failed to persist Failed status; the \
+                     execution row remains Created (recoverable via reclaim)"
+                );
+            },
+        }
+
+        if let Err(e) = stores
+            .execution
+            .release_lease(scope, &id, lease_token)
+            .await
+        {
+            tracing::warn!(
+                %execution_id,
+                error = %e,
+                "cold-start preflight rejection: best-effort lease release failed (will expire \
+                 at TTL)"
+            );
+        }
     }
 
     /// Durably satisfy all signal-driven waits on a `Paused` execution.

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -640,6 +640,24 @@ impl WorkflowEngine {
             },
         };
 
+        // `mark_setup_failed` and each `transition_status` call bump
+        // `exec_state.version` internally (one per logical mutation — up to
+        // two here: the setup-failure record and the `Failed` transition),
+        // so the serialized blob's `version` can end up higher than
+        // `repo_version + 1`, the row version this commit's CAS will
+        // actually produce. That is expected, not a bug to normalize away:
+        // `ExecutionState::version` is write-time-only bookkeeping of how
+        // many logical mutations were applied to this snapshot (see the
+        // per-call-site asserts in `crates/execution/src/state.rs`, e.g.
+        // "must be bumped" / "must NOT bump version" on no-op paths) — no
+        // reader anywhere deserializes the blob and trusts its `version`
+        // against the row; every CAS (`expected_version`/`new_version`) is
+        // sourced exclusively from the storage row's own counter
+        // (`ExecutionRecord::version`, tracked here as `repo_version`).
+        // `persist_final_state_port` and `checkpoint_node_port` commit the
+        // same way — never normalizing `exec_state.version` to the row
+        // version — and `satisfy_signal_waits` documents the identical
+        // rationale for its own direct-mutation bump.
         if let EngineError::UndeclaredOutputPort { from_node, .. } = reject {
             let _ = exec_state.mark_setup_failed(from_node.clone(), reject.to_string());
         }

--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -1596,9 +1596,15 @@ async fn resume_executes_remaining_nodes_after_crash() {
 /// exercises that real path directly: a `Created` row with empty
 /// `node_states` (the exact cold-start shape the API's start handler
 /// persists) wired with an undeclared, non-error output port must be
-/// rejected before any node dispatches — and must leave the row exactly as
-/// injected (no lease taken, no version bump), the same zero-teardown
-/// guarantee `execute_workflow_scoped` provides.
+/// rejected before any node dispatches.
+///
+/// Unlike `execute_workflow_scoped` (which rejects *before* it creates its
+/// own row, so a rejection there requires zero teardown), `resume_execution`
+/// never creates this row itself — the API start handler already did. A
+/// rejection here must therefore durably transition that pre-existing row to
+/// `Failed` (the W0 U2 orphaned-row fix) rather than leave it stranded in
+/// `Created` forever with no visible failure anywhere. The lease taken to
+/// perform that transition must not be left held afterward.
 #[tokio::test]
 async fn resume_execution_rejects_undeclared_port_on_genuine_first_attempt() {
     let registry = Arc::new(ActionRegistry::new());
@@ -1641,17 +1647,42 @@ async fn resume_execution_rejects_undeclared_port_on_genuine_first_attempt() {
         "expected UndeclaredOutputPort, got {result:?}"
     );
 
-    // No lease was taken and the row was never advanced past its injected
-    // version — the rejection ran before `acquire_and_heartbeat_lease`.
-    let (version, _) = stores
+    // The row must exist and be durably `Failed` — not stranded in
+    // `Created` (the W0 U2 orphaned-row bug this test guards against). The
+    // version must have advanced past the injected baseline: unlike
+    // `execute_workflow_scoped`'s zero-teardown rejection (which never
+    // creates a row), this path must actively commit the Failed transition
+    // to the row the API's start handler already persisted.
+    let (version, state_json) = stores
         .get_state(execution_id)
         .await
         .unwrap()
         .expect("row must still exist — a rejection must not delete it");
-    assert_eq!(
-        version, 0,
-        "a pre-flight rejection must not persist any state change"
+    assert!(
+        version > 0,
+        "the Failed transition must be durably committed, bumping the row version"
     );
+    // Deserialize via JSON string, not `serde_json::from_value` — `Key<D>`
+    // types expect a borrowed string, which only `from_str` provides (see
+    // `resume_execution`'s own state-deserialize comment for the same
+    // workaround).
+    let state_str = serde_json::to_string(&state_json).unwrap();
+    let persisted: ExecutionState = serde_json::from_str(&state_str).unwrap();
+    assert_eq!(
+        persisted.status,
+        ExecutionStatus::Failed,
+        "a cold-start pre-flight rejection must leave the execution row Failed, \
+         not orphaned in Created"
+    );
+    assert_eq!(
+        persisted.node_states.get(&a).map(|ns| ns.state),
+        Some(NodeState::Failed),
+        "the offending node must record the rejection, mirroring mark_setup_failed's \
+         node-level record-then-fail pattern"
+    );
+
+    // The lease taken to perform the transition must be released afterward,
+    // not left held.
     let rows = stores.execution.list_all_running().await.unwrap();
     let row = rows
         .iter()
@@ -1659,7 +1690,7 @@ async fn resume_execution_rejects_undeclared_port_on_genuine_first_attempt() {
         .expect("row must still exist");
     assert!(
         row.lease_holder.is_none(),
-        "a pre-flight rejection must not leave the row leased"
+        "the lease taken to mark the row Failed must be released afterward"
     );
 }
 
@@ -5957,4 +5988,145 @@ async fn unresolvable_action_fails_open() {
         outcome.is_ok(),
         "an unregistered source action must fail open, not reject: {outcome:?}"
     );
+}
+
+/// Finding 2 follow-up: the pre-flight must validate a version-pinned node's
+/// outgoing connections against the SAME version `get_factory_versioned`
+/// will actually dispatch, not always the latest registered version. v1 and
+/// v2 here declare deliberately disjoint output ports so an always-latest
+/// bug is directly observable: v1 declares only `"legacy"`, v2 declares only
+/// `"out"`. A source node pinned to v1 and wired on `"legacy"` must pass —
+/// an always-latest check (against v2's ports) would wrongly reject it.
+#[tokio::test]
+async fn preflight_accepts_a_port_only_the_pinned_version_declares() {
+    use semver::Version;
+
+    let registry = Arc::new(ActionRegistry::new());
+    let v1 = Version::new(1, 0, 0);
+    let v2 = Version::new(2, 0, 0);
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("versioned_ports"), "V1", "v1")
+            .with_version_full(v1.clone())
+            .with_outputs(vec![OutputPort::flow(port_key!("legacy"))]),
+        EchoHandler,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("versioned_ports"), "V2", "v2")
+            .with_version_full(v2)
+            .with_outputs(vec![OutputPort::flow(port_key!("out"))]),
+        EchoHandler,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "versioned_ports")
+                .unwrap()
+                .with_interface_version(v1),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a, b).with_from_port(port_key!("legacy"))],
+    );
+
+    // Exercise `validate_declared_output_ports` directly (mirrors
+    // `unresolvable_action_fails_open`'s pattern) rather than a full
+    // `execute_workflow` run: a plain (non-branching) `EchoHandler` success
+    // always activates the default `"out"` edge at dispatch time regardless
+    // of what the source action *declares* — that is a separate runtime
+    // concern from this pre-flight, which only checks the connection's port
+    // against the action's DECLARED ports before any node ever dispatches.
+    let graph = DependencyGraph::from_definition(&wf).unwrap();
+    let node_map: HashMap<NodeKey, &NodeDefinition> =
+        wf.nodes.iter().map(|n| (n.id.clone(), n)).collect();
+    let outcome = engine.validate_declared_output_ports(&graph, &node_map);
+    assert!(
+        outcome.is_ok(),
+        "a wire on a port the PINNED v1 declares must pass the pre-flight, even though v2 \
+         (latest) does not declare it — checking always-latest would wrongly reject this: \
+         {outcome:?}"
+    );
+}
+
+/// Mirror of `preflight_accepts_a_port_only_the_pinned_version_declares`:
+/// a source node pinned to v1 (declares only `"legacy"`) wired on `"out"` —
+/// a port only v2 (latest) declares — must be REJECTED. An always-latest
+/// check (against v2's ports, which does declare `"out"`) would wrongly pass
+/// this wire even though the pinned v1 that actually dispatches never
+/// declares it.
+#[tokio::test]
+async fn preflight_rejects_a_port_the_pinned_version_lacks_even_if_latest_declares_it() {
+    use semver::Version;
+
+    let registry = Arc::new(ActionRegistry::new());
+    let v1 = Version::new(1, 0, 0);
+    let v2 = Version::new(2, 0, 0);
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("versioned_ports"), "V1", "v1")
+            .with_version_full(v1.clone())
+            .with_outputs(vec![OutputPort::flow(port_key!("legacy"))]),
+        EchoHandler,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("versioned_ports"), "V2", "v2")
+            .with_version_full(v2)
+            .with_outputs(vec![OutputPort::flow(port_key!("out"))]),
+        EchoHandler,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "versioned_ports")
+                .unwrap()
+                .with_interface_version(v1),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        // "out" is declared by v2 (latest) but NOT by the pinned v1.
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("out"))],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await;
+
+    match result.expect_err(
+        "a wire on a port only the LATEST version declares must be rejected when the source \
+         node is pinned to a version that lacks it",
+    ) {
+        EngineError::UndeclaredOutputPort {
+            from_node,
+            to_node,
+            port,
+            declared,
+        } => {
+            assert_eq!(from_node, a);
+            assert_eq!(to_node, b);
+            assert_eq!(port.as_str(), "out");
+            assert_eq!(
+                declared,
+                vec![port_key!("legacy")],
+                "the offender's declared-ports diagnostic must reflect the PINNED v1's ports"
+            );
+        },
+        other => panic!("expected EngineError::UndeclaredOutputPort, got {other:?}"),
+    }
 }

--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use nebula_action::{
-    ActionError, BranchKey, action::Action, context::CredentialContextExt,
+    ActionError, BranchKey, OutputPort, action::Action, context::CredentialContextExt,
     metadata::ActionMetadata, result::ActionResult, stateless::StatelessAction,
 };
 use nebula_core::{Dependencies, action_key, port_key, scope::Principal};
@@ -769,7 +769,13 @@ async fn branch_workflow_only_selected_path_executes() {
         EchoHandler,
     );
     registry.register_stateless_instance(
-        ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
+        // Declares the "true"/"false" branch ports it actually routes on —
+        // required since W0 U2's undeclared-output-port pre-flight now
+        // rejects connections wired to a flow-only action's undeclared port.
+        ActionMetadata::new(action_key!("branch"), "Branch", "branches").with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ]),
         BranchHandler {
             selected: nebula_action::branch_key!("true"),
         },
@@ -1580,6 +1586,164 @@ async fn resume_executes_remaining_nodes_after_crash() {
     assert!(
         result.node_output(&n3).is_some(),
         "n3 should have been re-executed"
+    );
+}
+
+/// Production's ONLY entry point for validating a brand-new execution is
+/// `resume_execution`'s first-attempt branch — `execute_workflow_scoped` is
+/// never reached from production dispatch (`EngineControlDispatch::dispatch_start`
+/// always calls `resume_execution`, not `execute_workflow_scoped`). This
+/// exercises that real path directly: a `Created` row with empty
+/// `node_states` (the exact cold-start shape the API's start handler
+/// persists) wired with an undeclared, non-error output port must be
+/// rejected before any node dispatches — and must leave the row exactly as
+/// injected (no lease taken, no version bump), the same zero-teardown
+/// guarantee `execute_workflow_scoped` provides.
+#[tokio::test]
+async fn resume_execution_rejects_undeclared_port_on_genuine_first_attempt() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let stores = TestStores::new();
+    let (engine, _) = make_engine(registry);
+    let engine = stores.attach(engine);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("typo_port"))],
+    );
+    stores.save_workflow(&wf).await;
+
+    // The cold-start shape the API's start handler persists: `Created`
+    // status, no per-node entries (`ExecutionState::new(.., &[])`).
+    let execution_id = ExecutionId::new();
+    let exec_state = ExecutionState::new(execution_id, wf.id, &[]);
+    assert!(
+        exec_state.node_states.is_empty(),
+        "sanity: a cold-start row has no per-node entries"
+    );
+    let state_json = serde_json::to_value(&exec_state).unwrap();
+    stores.inject_state(execution_id, wf.id, state_json).await;
+
+    let scope = crate::store_seam::single_tenant_scope();
+    let result = engine.resume_execution(&scope, execution_id).await;
+
+    assert!(
+        matches!(result, Err(EngineError::UndeclaredOutputPort { .. })),
+        "expected UndeclaredOutputPort, got {result:?}"
+    );
+
+    // No lease was taken and the row was never advanced past its injected
+    // version — the rejection ran before `acquire_and_heartbeat_lease`.
+    let (version, _) = stores
+        .get_state(execution_id)
+        .await
+        .unwrap()
+        .expect("row must still exist — a rejection must not delete it");
+    assert_eq!(
+        version, 0,
+        "a pre-flight rejection must not persist any state change"
+    );
+    let rows = stores.execution.list_all_running().await.unwrap();
+    let row = rows
+        .iter()
+        .find(|r| r.id == execution_id)
+        .expect("row must still exist");
+    assert!(
+        row.lease_holder.is_none(),
+        "a pre-flight rejection must not leave the row leased"
+    );
+}
+
+/// The `is_first_attempt` gate must not retroactively enforce the W0 U2
+/// pre-flight on a genuine resume. Mirrors
+/// `resume_execution_rejects_undeclared_port_on_genuine_first_attempt`'s
+/// workflow (same undeclared `"typo_port"` wire) but with a real
+/// crash-resume shape — node A already `Completed` in the injected state,
+/// which is the `node_states.is_empty() == false` case the gate must skip.
+/// B still runs here via `resume_execution`'s own documented port-blind edge
+/// rebuild (every outgoing edge from a terminal node activates, regardless
+/// of port name) — proving the new gate adds no new rejection on this path,
+/// not merely that the workflow happens to succeed.
+#[tokio::test]
+async fn resume_execution_does_not_validate_ports_on_genuine_resume() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let stores = TestStores::new();
+    let (engine, _) = make_engine(registry);
+    let engine = stores.attach(engine);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        // Undeclared, non-error port on a flow-only action — rejected on a
+        // first attempt (see the sibling test), must NOT be rejected here.
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("typo_port"))],
+    );
+    stores.save_workflow(&wf).await;
+
+    // A genuine crash-resume shape: per-node state already exists (A
+    // completed before the crash) — unlike the empty-`node_states`
+    // cold-start row the sibling test injects.
+    let execution_id = ExecutionId::new();
+    let node_ids = vec![a.clone(), b.clone()];
+    let mut exec_state = ExecutionState::new(execution_id, wf.id, &node_ids);
+    exec_state
+        .transition_status(ExecutionStatus::Running)
+        .unwrap();
+    exec_state
+        .node_states
+        .get_mut(&a)
+        .unwrap()
+        .transition_to(NodeState::Ready)
+        .unwrap();
+    exec_state
+        .node_states
+        .get_mut(&a)
+        .unwrap()
+        .transition_to(NodeState::Running)
+        .unwrap();
+    exec_state
+        .node_states
+        .get_mut(&a)
+        .unwrap()
+        .transition_to(NodeState::Completed)
+        .unwrap();
+    assert!(
+        !exec_state.node_states.is_empty(),
+        "sanity: a genuine resume has per-node state on entry"
+    );
+
+    let state_json = serde_json::to_value(&exec_state).unwrap();
+    stores.inject_state(execution_id, wf.id, state_json).await;
+    stores
+        .inject_node_output(execution_id, a.clone(), serde_json::json!("from_a"))
+        .await;
+
+    let scope = crate::store_seam::single_tenant_scope();
+    let result = engine.resume_execution(&scope, execution_id).await.unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&b).is_some(),
+        "B must still run on a genuine resume — the pre-flight gate must not \
+         retroactively enforce on an already-in-progress execution"
     );
 }
 
@@ -2527,7 +2691,17 @@ async fn credential_refresh_hook_is_called_before_node_dispatch() {
 async fn multi_edge_from_same_source_executes_target() {
     let registry = Arc::new(ActionRegistry::new());
     registry.register_stateless_instance(
-        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        // Declares "alt" alongside the default "out" — required since W0
+        // U2's undeclared-output-port pre-flight now rejects connections
+        // wired to a flow-only action's undeclared port. The edge-count
+        // regression this test guards fires either way (both edges are
+        // counted as resolved regardless of which port activates); "alt"
+        // just needs to be a *declared* port to pass the pre-flight, not one
+        // `EchoHandler` ever actually produces output on.
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input").with_outputs(vec![
+            OutputPort::flow(port_key!("out")),
+            OutputPort::flow(port_key!("alt")),
+        ]),
         EchoHandler,
     );
     let (engine, _) = make_engine(registry);
@@ -2536,7 +2710,11 @@ async fn multi_edge_from_same_source_executes_target() {
     let b = node_key!("b");
 
     // Two distinct (non-identical) edges from A to B: one unconditional,
-    // one via a named source port. Both activate on success.
+    // one via a named source port. Both are counted as resolved edges (the
+    // regression this test guards, see doc comment above); only the "out"
+    // edge actually activates on `Success` (evaluate_edge only fires named
+    // ports for Branch/Route/MultiOutput results) — B still runs via that
+    // edge.
     let wf = make_workflow(
         vec![
             NodeDefinition::new(a.clone(), "A", "core", "echo").unwrap(),
@@ -3751,7 +3929,13 @@ async fn panicked_task_reports_real_node_id() {
 async fn idempotency_replay_preserves_branch_routing() {
     let registry = Arc::new(ActionRegistry::new());
     registry.register_stateless_instance(
-        ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
+        // Declares the "true"/"false" branch ports it actually routes on —
+        // required since W0 U2's undeclared-output-port pre-flight now
+        // rejects connections wired to a flow-only action's undeclared port.
+        ActionMetadata::new(action_key!("branch"), "Branch", "branches").with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ]),
         BranchHandler {
             selected: nebula_action::branch_key!("true"),
         },
@@ -5408,5 +5592,369 @@ fn with_clock_builder_wires_injected_clock_into_engine() {
         engine.clock_now(),
         pinned_instant,
         "engine must read from the injected PinnedClock, not SystemClock"
+    );
+}
+
+// ── W0 U2: undeclared-output-port pre-flight ──────────────────────────
+//
+// `validate_declared_output_ports` rejects a `Connection` wired to a flow
+// port its source action never declares (and isn't `"error"`), before
+// `run_frontier` dispatches any node. Two deliberate fail-open carve-outs
+// (unregistered source action; any declared `OutputPort::Dynamic`) keep
+// this a strict improvement over the prior silent-no-op behavior rather
+// than full protection — see the pre-flight's doc comment in `engine.rs`.
+
+/// A → B on a port A never declares (and isn't `"error"`) must fail the
+/// execution before any node dispatches — the exact correctness gap U2
+/// closes. Confirmed RED before the fix: without
+/// `validate_declared_output_ports` wired into `execute_workflow_scoped`,
+/// this connection silently never fires (`evaluate_edge` never matches
+/// `"typo_port"`), B is skipped, and `execute_workflow` returns `Ok` instead
+/// of surfacing the misconfiguration.
+#[tokio::test]
+async fn undeclared_flow_port_rejected_before_execution() {
+    use std::sync::atomic::{AtomicU32, Ordering as AOrdering};
+
+    // Proves no node dispatches: if either A or B ran, this would be > 0.
+    let dispatch_count = Arc::new(AtomicU32::new(0));
+
+    struct CountingHandler {
+        count: Arc<AtomicU32>,
+    }
+
+    impl Action for CountingHandler {
+        type Input = serde_json::Value;
+        type Output = serde_json::Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("counting.static"), "Counting", "counts calls")
+        }
+        fn dependencies() -> &'static Dependencies {
+            static D: OnceLock<Dependencies> = OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl StatelessAction for CountingHandler {
+        async fn execute(
+            &self,
+            input: <Self as Action>::Input,
+            _ctx: &(impl nebula_action::ActionContext + ?Sized),
+        ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+            self.count.fetch_add(1, AOrdering::Relaxed);
+            Ok(ActionResult::success(input))
+        }
+    }
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        // Only declares the default "out" port.
+        ActionMetadata::new(action_key!("counting"), "Counting", "counts calls"),
+        CountingHandler {
+            count: dispatch_count.clone(),
+        },
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "counting").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "counting").unwrap(),
+        ],
+        vec![
+            // "typo_port" is declared by neither the action's metadata nor
+            // the `∪ {"error"}` carve-out.
+            Connection::new(a.clone(), b.clone()).with_from_port(port_key!("typo_port")),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await;
+
+    let err = result.expect_err(
+        "a connection on an undeclared, non-error output port must fail before execution",
+    );
+    match err {
+        EngineError::UndeclaredOutputPort {
+            from_node,
+            to_node,
+            port,
+            declared,
+        } => {
+            assert_eq!(from_node, a);
+            assert_eq!(to_node, b);
+            assert_eq!(port.as_str(), "typo_port");
+            assert_eq!(declared, vec![port_key!("out")]);
+        },
+        other => panic!("expected EngineError::UndeclaredOutputPort, got {other:?}"),
+    }
+
+    assert_eq!(
+        dispatch_count.load(AOrdering::Relaxed),
+        0,
+        "neither A nor B may dispatch — the pre-flight runs before run_frontier starts"
+    );
+}
+
+/// Regression guard for a placement bug caught in review: an earlier version
+/// of the pre-flight ran after `stores.execution.create` and
+/// `acquire_and_heartbeat_lease`, so its `?` early-return skipped
+/// `execute_workflow_scoped`'s only `persist_final_state`/`guard.shutdown()`
+/// call sites — orphaning the execution row permanently `Running` under a
+/// held-but-unrenewed lease. A rejection must leave zero durable trace: no
+/// execution row created, no lease taken out.
+#[tokio::test]
+async fn undeclared_flow_port_rejection_persists_no_row_and_takes_no_lease() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let stores = TestStores::new();
+    let (engine, _) = make_engine(registry);
+    let engine = engine.with_execution_stores(stores.execution_stores());
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("typo_port"))],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await;
+    assert!(
+        matches!(result, Err(EngineError::UndeclaredOutputPort { .. })),
+        "expected UndeclaredOutputPort, got {result:?}"
+    );
+
+    let scope = crate::store_seam::single_tenant_scope();
+    let row_count = stores.execution.count(&scope, None).await.unwrap();
+    assert_eq!(
+        row_count, 0,
+        "a pre-flight rejection must run before `stores.execution.create` — \
+         no execution row may exist afterward"
+    );
+
+    // `acquire_lease` requires an existing row (`Err(not_found)` otherwise —
+    // see `InMemoryExecutionStore::acquire_lease`), so `row_count == 0`
+    // already implies no lease was taken out. `list_all_running` double-checks
+    // directly: no row means nothing can appear as leased/Running.
+    let running = stores.execution.list_all_running().await.unwrap();
+    assert!(
+        running.is_empty(),
+        "a pre-flight rejection must not leave any row leased or Running"
+    );
+}
+
+/// Regression guard for the design this plan avoided: a Switch/Router-style
+/// action that declares a single `OutputPort::Dynamic` template (mirroring
+/// `core.switch`'s `"case"` key) but emits an arbitrary config-derived port
+/// key (`"a"`) at runtime must still execute normally. A uniform undeclared-
+/// port check would hard-reject every such wire; the pre-flight's
+/// dynamic-port carve-out skips validation for the whole source instead.
+#[tokio::test]
+async fn switch_dynamic_port_wire_not_rejected() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("switch"), "Switch", "routes by config")
+            .with_outputs(vec![OutputPort::dynamic(port_key!("case"), "cases")]),
+        BranchHandler {
+            // A config-derived key never present in the declared "case"
+            // template — exactly what `core.switch` produces at runtime.
+            selected: nebula_action::branch_key!("a"),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let switch_node = node_key!("switch_node");
+    let target = node_key!("target");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(switch_node.clone(), "Switch", "core", "switch").unwrap(),
+            NodeDefinition::new(target.clone(), "Target", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(switch_node.clone(), target.clone()).with_from_port(port_key!("a"))],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&target).is_some(),
+        "target must execute — the dynamic-port carve-out must not reject this wire"
+    );
+}
+
+/// An `If`-style action declaring `true`/`false` flow ports must route on
+/// either declared port without tripping the pre-flight, regardless of
+/// which branch fires at runtime.
+#[tokio::test]
+async fn if_true_false_declared_routes() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("if"), "If", "branches on a boolean").with_outputs(vec![
+            OutputPort::flow(port_key!("true")),
+            OutputPort::flow(port_key!("false")),
+        ]),
+        BranchHandler {
+            selected: nebula_action::branch_key!("false"),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let cond = node_key!("cond");
+    let then_branch = node_key!("then_branch");
+    let else_branch = node_key!("else_branch");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(cond.clone(), "Cond", "core", "if").unwrap(),
+            NodeDefinition::new(then_branch.clone(), "Then", "core", "echo").unwrap(),
+            NodeDefinition::new(else_branch.clone(), "Else", "core", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(cond.clone(), then_branch.clone()).with_from_port(port_key!("true")),
+            Connection::new(cond.clone(), else_branch.clone()).with_from_port(port_key!("false")),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&else_branch).is_some(),
+        "false branch is declared and selected — must execute"
+    );
+    assert!(
+        result.node_output(&then_branch).is_none(),
+        "true branch is declared but not selected — must be skipped, not executed"
+    );
+}
+
+/// A source action with no declared `"error"` port, routed on failure, must
+/// still pass the pre-flight — the `∪ {"error"}` rule always allows the
+/// error port regardless of declaration.
+#[tokio::test]
+async fn error_port_allowed_without_declaration() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        // Declares only the default "out" port — no "error" port.
+        ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
+        FailHandler,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "fail").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("error"))],
+    );
+
+    let result = engine
+        .execute_workflow(
+            &crate::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("input"),
+            ExecutionBudget::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_success(),
+        "error routing must not trip the undeclared-output-port pre-flight"
+    );
+    assert!(
+        result.node_output(&b).is_some(),
+        "B must run via the error port even though A never declares it"
+    );
+}
+
+/// Unit test of `validate_declared_output_ports` directly: an unregistered
+/// source action must fail OPEN (warn + proceed), not reject. This is a
+/// documented limitation, not new protection — an actually-unresolvable
+/// action still fails later, at dispatch, through its own action-not-found
+/// error.
+#[tokio::test]
+async fn unresolvable_action_fails_open() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "totally.unregistered").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a, b).with_from_port(port_key!("whatever"))],
+    );
+
+    let graph = DependencyGraph::from_definition(&wf).unwrap();
+    let node_map: HashMap<NodeKey, &NodeDefinition> =
+        wf.nodes.iter().map(|n| (n.id.clone(), n)).collect();
+
+    let outcome = engine.validate_declared_output_ports(&graph, &node_map);
+    assert!(
+        outcome.is_ok(),
+        "an unregistered source action must fail open, not reject: {outcome:?}"
     );
 }

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -1,7 +1,7 @@
 //! Engine error types.
 
 use nebula_action::ActionError;
-use nebula_core::{NodeKey, id::ExecutionId};
+use nebula_core::{NodeKey, PortKey, id::ExecutionId};
 use nebula_expression::ExpressionError;
 use nebula_workflow::NodeState;
 
@@ -76,6 +76,30 @@ pub enum EngineError {
         to_node: NodeKey,
         /// The underlying error.
         error: String,
+    },
+
+    /// A connection routes to an output port the source action never declared.
+    ///
+    /// Raised by the fresh-execution pre-flight (`validate_declared_output_ports`)
+    /// before any node dispatches, so a mistyped/undeclared `from_port` fails
+    /// the execution loudly instead of silently never firing. Fail-open by
+    /// design when the source action is unregistered or declares a dynamic
+    /// port — see the pre-flight's doc comment for why.
+    #[error(
+        "node {from_node} routes to {to_node} on undeclared output port \
+         {port}; source action declares [{}]", declared.join(", ")
+    )]
+    UndeclaredOutputPort {
+        /// Source node of the offending connection.
+        from_node: NodeKey,
+        /// Target node of the offending connection.
+        to_node: NodeKey,
+        /// The connection's effective source port, not declared by the
+        /// source action (and not `"error"`).
+        port: PortKey,
+        /// The source action's actually-declared output-port keys, for
+        /// operator diagnostics.
+        declared: Vec<PortKey>,
     },
 
     /// A budget limit was exceeded.
@@ -224,7 +248,8 @@ impl nebula_error::Classify for EngineError {
             Self::PlanningFailed(_)
             | Self::ParameterResolution { .. }
             | Self::ParameterValidation { .. }
-            | Self::EdgeEvaluationFailed { .. } => nebula_error::ErrorCategory::Validation,
+            | Self::EdgeEvaluationFailed { .. }
+            | Self::UndeclaredOutputPort { .. } => nebula_error::ErrorCategory::Validation,
             Self::NodeFailed { .. }
             | Self::TaskPanicked(_)
             | Self::FrontierIntegrity { .. }
@@ -252,6 +277,7 @@ impl nebula_error::Classify for EngineError {
             Self::ParameterResolution { .. } => "ENGINE:PARAM_RESOLUTION",
             Self::ParameterValidation { .. } => "ENGINE:PARAM_VALIDATION",
             Self::EdgeEvaluationFailed { .. } => "ENGINE:EDGE_EVAL",
+            Self::UndeclaredOutputPort { .. } => "ENGINE:UNDECLARED_OUTPUT_PORT",
             Self::BudgetExceeded(_) => "ENGINE:BUDGET_EXCEEDED",
             Self::Runtime(e) => return nebula_error::Classify::code(e),
             Self::Execution(e) => return nebula_error::Classify::code(e),

--- a/crates/engine/src/resolver.rs
+++ b/crates/engine/src/resolver.rs
@@ -178,6 +178,8 @@ fn navigate_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use nebula_core::node_key;
+    use nebula_schema::{Field, FieldKey, PathWalk, Schema, ValidSchema};
+    use proptest::prelude::*;
     use serde_json::json;
 
     use super::*;
@@ -472,5 +474,77 @@ mod tests {
             (&err as &dyn StdError).source().is_none(),
             "std::error::Error::source() must return None for reference failures"
         );
+    }
+
+    // -- walk_authored_path vs. navigate_path tripwire (ADR-0100 TypeDAG, W0 U5) --
+    //
+    // `nebula_schema::ValidSchema::walk_authored_path` is a validation-time,
+    // schema-only walk; `navigate_path` above is the runtime, value-only
+    // navigator. This crate is the one place both are reachable together
+    // (`navigate_path` is private to this module; `nebula-schema` cannot depend
+    // on `nebula-engine` to call it, and vice versa this crate already depends
+    // on `nebula-schema`) — see the W0 U5 plan's "Option B" on why the two are
+    // deliberately NOT unified into shared code.
+
+    /// A fully-closed schema for the tripwire: `items: List<Object { name:
+    /// String }>` — matches the plan's example paths (`items.0.name` /
+    /// `$.items.0.name`) exactly.
+    fn tripwire_schema() -> ValidSchema {
+        Schema::builder()
+            .add(
+                Field::list(FieldKey::new("items").unwrap()).item(
+                    Field::object(FieldKey::new("item").unwrap())
+                        .add(Field::string(FieldKey::new("name").unwrap())),
+                ),
+            )
+            .build()
+            .unwrap()
+    }
+
+    /// A value conforming to [`tripwire_schema`]: two items, indices 0 and 1
+    /// resolve to a real (non-`Null`) `name`.
+    fn tripwire_conforming_value() -> serde_json::Value {
+        json!({"items": [{"name": "a"}, {"name": "b"}]})
+    }
+
+    proptest! {
+        /// Tripwire, not a completeness proof (framed per the W0 U5 plan): over a
+        /// fully-closed `(schema, conforming value)` fixture, `walk_authored_path`
+        /// must never claim a path is a PROVABLE MISTAKE
+        /// (`PathWalk::Unresolved`) when the runtime `navigate_path` actually
+        /// resolves that SAME authored path to a real (non-`Null`) value. A
+        /// divergence here would mean the walk hard-rejects a `Reference` the
+        /// engine would happily resolve at runtime — exactly the false-positive
+        /// class the four review rounds were about.
+        ///
+        /// Runtime output is never validated against its declared schema
+        /// (`engine.rs:2565-2567`), so the two navigators CAN legitimately
+        /// diverge outside the cases this design already excludes (this fixture
+        /// is fully closed by construction, so no such divergence is expected
+        /// here — the property still only asserts the one-directional
+        /// implication, not full agreement).
+        #[test]
+        fn walk_never_unresolved_where_navigate_path_resolves(
+            index in 0usize..6,
+            dollar_prefix in any::<bool>(),
+        ) {
+            let schema = tripwire_schema();
+            let value = tripwire_conforming_value();
+            let path = if dollar_prefix {
+                format!("$.items.{index}.name")
+            } else {
+                format!("items.{index}.name")
+            };
+
+            let runtime = navigate_path(&value, &path);
+            if runtime != serde_json::Value::Null {
+                let walked = schema.walk_authored_path(&path);
+                prop_assert!(
+                    !matches!(walked, PathWalk::Unresolved(_)),
+                    "navigate_path resolved `{path}` to {runtime:?}, but walk_authored_path \
+                     claimed it was unresolvable: {walked:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -228,14 +228,44 @@ impl ActionRegistry {
 
     /// Declared output ports for the latest registered version of `key`.
     ///
-    /// Returns `None` if no factory is registered for `key`. Used by the
-    /// engine's undeclared-output-port pre-flight to validate `Connection`
-    /// wires against the source action's declared ports.
+    /// Returns `None` if no factory is registered for `key`. Callers that
+    /// know the node's pinned `interface_version` (if any) should prefer
+    /// [`Self::output_ports_versioned`] — this unpinned form always answers
+    /// against the latest version, which is wrong for a node pinned to an
+    /// older one.
     #[must_use]
     pub fn output_ports(&self, key: &ActionKey) -> Option<Vec<OutputPort>> {
+        self.output_ports_versioned(key, None)
+    }
+
+    /// Declared output ports for `key`, pinned to `interface_version` when
+    /// given.
+    ///
+    /// `Some(version)` mirrors [`Self::get_factory_versioned`]'s exact-match
+    /// lookup: if no entry at that exact version is registered, returns
+    /// `None` (fail-open at the call site, same as an unregistered action —
+    /// deliberately does NOT fall back to latest, since that would silently
+    /// reintroduce the mismatch this method exists to avoid). `None` returns
+    /// the latest registered version's ports, mirroring [`Self::get_factory`].
+    ///
+    /// Used by the engine's undeclared-output-port pre-flight
+    /// (`validate_declared_output_ports`) to validate a `Connection` wire
+    /// against the SAME action version [`Self::get_factory_versioned`] will
+    /// actually dispatch for a version-pinned node — checking against the
+    /// latest version instead could wrongly reject a wire the pinned version
+    /// supports, or wrongly pass one it doesn't.
+    #[must_use]
+    pub fn output_ports_versioned(
+        &self,
+        key: &ActionKey,
+        interface_version: Option<&Version>,
+    ) -> Option<Vec<OutputPort>> {
         let entries = self.factories.get(key)?;
-        let last = entries.last()?;
-        Some(last.metadata.outputs.clone())
+        let entry = match interface_version {
+            Some(v) => entries.iter().find(|e| e.metadata.base.version == *v)?,
+            None => entries.last()?,
+        };
+        Some(entry.metadata.outputs.clone())
     }
 
     /// Look up a factory by key and exact version.
@@ -466,6 +496,79 @@ mod tests {
             keys,
             vec!["out", "error"],
             "must report the latest registered version's declared ports, not v1's"
+        );
+    }
+
+    /// W0 U2 follow-up (finding 2): `output_ports_versioned` must answer
+    /// against the EXACT pinned version, not always the latest — v1 and v2
+    /// here declare different ports on purpose so a version-blind lookup
+    /// would silently return the wrong set for either pin.
+    #[test]
+    fn output_ports_versioned_pins_to_the_requested_version() {
+        let registry = ActionRegistry::new();
+        registry.register_stateless_instance(
+            meta_with("test.noop", 1, 0)
+                .with_outputs(vec![OutputPort::flow(nebula_core::port_key!("legacy"))]),
+            NoopAction,
+        );
+        registry.register_stateless_instance(
+            meta_with("test.noop", 2, 0)
+                .with_outputs(vec![OutputPort::flow(nebula_core::port_key!("out"))]),
+            NoopAction,
+        );
+
+        let key = ActionKey::new("test.noop").unwrap();
+        let v1 = Version::new(1, 0, 0);
+        let v2 = Version::new(2, 0, 0);
+
+        let v1_ports = registry
+            .output_ports_versioned(&key, Some(&v1))
+            .expect("v1 is registered");
+        assert_eq!(
+            v1_ports.iter().map(OutputPort::key).collect::<Vec<_>>(),
+            vec!["legacy"],
+            "a node pinned to v1 must see v1's ports, not v2's"
+        );
+
+        let v2_ports = registry
+            .output_ports_versioned(&key, Some(&v2))
+            .expect("v2 is registered");
+        assert_eq!(
+            v2_ports.iter().map(OutputPort::key).collect::<Vec<_>>(),
+            vec!["out"],
+            "a node pinned to v2 must see v2's ports, not v1's"
+        );
+
+        let unpinned = registry
+            .output_ports_versioned(&key, None)
+            .expect("action is registered");
+        assert_eq!(
+            unpinned.iter().map(OutputPort::key).collect::<Vec<_>>(),
+            vec!["out"],
+            "an unpinned lookup must fall back to the latest version, mirroring get_factory"
+        );
+    }
+
+    /// A pinned version with no matching registered entry must fail OPEN
+    /// (return `None`, skipping pre-flight validation), not silently fall
+    /// back to the latest registered version — falling back would
+    /// reintroduce the exact always-latest bug this method exists to fix.
+    #[test]
+    fn output_ports_versioned_pinned_to_unregistered_version_fails_open() {
+        let registry = ActionRegistry::new();
+        registry.register_stateless_instance(
+            meta_with("test.noop", 1, 0)
+                .with_outputs(vec![OutputPort::flow(nebula_core::port_key!("out"))]),
+            NoopAction,
+        );
+
+        let key = ActionKey::new("test.noop").unwrap();
+        let unregistered_pin = Version::new(9, 0, 0);
+        assert!(
+            registry
+                .output_ports_versioned(&key, Some(&unregistered_pin))
+                .is_none(),
+            "a pin with no matching entry must return None, not the latest version's ports"
         );
     }
 }

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -24,8 +24,8 @@ use nebula_action::{
     Action, ActionError, ActionFactory, ActionMetadata, AgentAction, ControlAction,
     FromWorkflowNode, GenericAgentFactory, GenericControlFactory, GenericResourceFactory,
     GenericStatefulFactory, GenericStatelessFactory, GenericStreamFactory, GenericTriggerFactory,
-    InstanceFactory, ResourceAction, StatefulAction, StatelessAction, StreamAction, TriggerAction,
-    WebhookActionFactory,
+    InstanceFactory, OutputPort, ResourceAction, StatefulAction, StatelessAction, StreamAction,
+    TriggerAction, WebhookActionFactory,
 };
 use nebula_core::ActionKey;
 use semver::Version;
@@ -226,6 +226,18 @@ impl ActionRegistry {
         Some((last.metadata.clone(), Arc::clone(&last.factory)))
     }
 
+    /// Declared output ports for the latest registered version of `key`.
+    ///
+    /// Returns `None` if no factory is registered for `key`. Used by the
+    /// engine's undeclared-output-port pre-flight to validate `Connection`
+    /// wires against the source action's declared ports.
+    #[must_use]
+    pub fn output_ports(&self, key: &ActionKey) -> Option<Vec<OutputPort>> {
+        let entries = self.factories.get(key)?;
+        let last = entries.last()?;
+        Some(last.metadata.outputs.clone())
+    }
+
     /// Look up a factory by key and exact version.
     #[must_use]
     pub fn get_factory_versioned(
@@ -421,6 +433,39 @@ mod tests {
         assert_eq!(
             meta.base.version, v2,
             "get_factory returns the latest version"
+        );
+    }
+
+    #[test]
+    fn output_ports_returns_none_for_unregistered_key() {
+        let registry = ActionRegistry::new();
+        let key = ActionKey::new("test.never_registered").unwrap();
+        assert!(registry.output_ports(&key).is_none());
+    }
+
+    #[test]
+    fn output_ports_returns_declared_ports_for_latest_version() {
+        let registry = ActionRegistry::new();
+        registry.register_stateless_instance(
+            meta_with("test.noop", 1, 0)
+                .with_outputs(vec![OutputPort::flow(nebula_core::port_key!("out"))]),
+            NoopAction,
+        );
+        registry.register_stateless_instance(
+            meta_with("test.noop", 2, 0).with_outputs(vec![
+                OutputPort::flow(nebula_core::port_key!("out")),
+                OutputPort::error(nebula_core::port_key!("error")),
+            ]),
+            NoopAction,
+        );
+
+        let key = ActionKey::new("test.noop").unwrap();
+        let ports = registry.output_ports(&key).expect("action is registered");
+        let keys: Vec<&str> = ports.iter().map(OutputPort::key).collect();
+        assert_eq!(
+            keys,
+            vec!["out", "error"],
+            "must report the latest registered version's declared ports, not v1's"
         );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -269,16 +269,36 @@ pub fn explain_assignable(producer: &OutputSchema, consumer: &InputSchema) -> As
 /// schemas).
 ///
 /// Internally wraps each field into a synthetic one-field schema (both under
-/// `consumer_leaf`'s key, so the two pair up — see
-/// [`ValidSchema::single_field`]), tags them `Output`/`Input`, and runs the
+/// `consumer_leaf`'s key, so the two pair up — see the crate-private
+/// `ValidSchema::single_field`), tags them `Output`/`Input`, and runs the
 /// exact same [`explain_assignable`] the schema-level check uses. Those
 /// synthetic schemas are built, compared, and dropped entirely inside this
 /// function — never handed back to the caller, so the bypassed-lint,
-/// bypassed-index construction [`ValidSchema::single_field`] performs never
+/// bypassed-index construction `ValidSchema::single_field` performs never
 /// crosses a crate boundary as a value someone could mistake for a
 /// fully-built schema.
+///
+/// A [`Field::Unknown`] leaf is handled BEFORE that synthetic-schema
+/// machinery runs, not after: `ValidSchema::single_field`'s re-keying
+/// (`rekeyed`) cannot rewrite an `Unknown` field's private key (see its own
+/// doc comment), so a `Field::Unknown` producer or consumer leaf whose
+/// original key differs from the other side's key would fail to pair up
+/// under the shared synthetic key — surfacing as a spurious
+/// `No(MissingRequiredField)` (required consumer field) or a spurious `Yes`
+/// (optional consumer field), rather than the correct "this version cannot
+/// reason about an unrecognized field kind" verdict.
 #[must_use]
 pub fn explain_field_assignable(producer_leaf: &Field, consumer_leaf: &Field) -> Assignability {
+    // `Field::Unknown` is opaque on either side (mirrors `collect_pair`'s own
+    // same-key `Field::Unknown` handling a few lines below) — decide this
+    // before building any synthetic schema, since the re-key that machinery
+    // relies on cannot reach an `Unknown` field's key.
+    if matches!(producer_leaf, Field::Unknown(_)) || matches!(consumer_leaf, Field::Unknown(_)) {
+        return Assignability::Unknown(vec![UnknownReason::OpaqueFieldKind {
+            key: consumer_leaf.key().clone(),
+        }]);
+    }
+
     let key = consumer_leaf.key().clone();
     let producer = OutputSchema::new(ValidSchema::single_field(
         key.clone(),
@@ -1977,6 +1997,41 @@ mod tests {
         assert_eq!(
             explain_field_assignable(&producer_leaf, &consumer_leaf),
             Assignability::Unknown(vec![UnknownReason::NumberWidening { key: fk("qty") }])
+        );
+    }
+
+    /// A `Field::Unknown` producer leaf at a key DIFFERENT from the required
+    /// consumer leaf it is checked against must still report
+    /// `Unknown(OpaqueFieldKind)` — not a spurious `No(MissingRequiredField)`.
+    ///
+    /// `ValidSchema::single_field`'s re-key (`rekeyed`) cannot rewrite an
+    /// `Unknown` field's private key, so without the early `Field::Unknown`
+    /// check in `explain_field_assignable`, the producer's synthetic
+    /// one-field schema would keep the leaf's ORIGINAL key (`"bio"`) instead
+    /// of the consumer's key (`"recipient_email"`) — the two synthetic
+    /// schemas would fail to pair up, and `collect_fields` would read that as
+    /// the required consumer field being entirely absent from the producer.
+    #[test]
+    fn field_assignable_unknown_producer_leaf_mismatched_key_is_unknown_not_missing() {
+        let unknown_schema: ValidSchema =
+            serde_json::from_value(json!({"fields": [{"type": "richtext", "key": "bio"}]}))
+                .expect("Unknown producer schema");
+        let producer_leaf = unknown_schema.fields()[0].clone();
+        assert!(
+            matches!(producer_leaf, Field::Unknown(_)),
+            "sanity: leaf must be Field::Unknown"
+        );
+        assert_eq!(producer_leaf.key().as_str(), "bio");
+
+        let consumer_leaf: Field = Field::string(fk("recipient_email")).required().into();
+
+        assert_eq!(
+            explain_field_assignable(&producer_leaf, &consumer_leaf),
+            Assignability::Unknown(vec![UnknownReason::OpaqueFieldKind {
+                key: fk("recipient_email")
+            }]),
+            "an Unknown producer leaf at a different key must report OpaqueFieldKind, not \
+             silently fail to pair up as a spurious MissingRequiredField"
         );
     }
 }

--- a/crates/schema/src/compat.rs
+++ b/crates/schema/src/compat.rs
@@ -261,6 +261,33 @@ pub fn explain_assignable(producer: &OutputSchema, consumer: &InputSchema) -> As
     explain_assignable_core(producer.as_schema(), consumer.as_schema())
 }
 
+/// Field-granularity counterpart to [`explain_assignable`]: is `producer_leaf`
+/// assignable where `consumer_leaf` is expected, when a caller has two
+/// individual resolved [`Field`]s in hand rather than two whole schemas (e.g.
+/// `nebula-workflow`'s per-field `Reference`-parameter check, which resolves a
+/// single producer field and a single consumer field, not their enclosing
+/// schemas).
+///
+/// Internally wraps each field into a synthetic one-field schema (both under
+/// `consumer_leaf`'s key, so the two pair up — see
+/// [`ValidSchema::single_field`]), tags them `Output`/`Input`, and runs the
+/// exact same [`explain_assignable`] the schema-level check uses. Those
+/// synthetic schemas are built, compared, and dropped entirely inside this
+/// function — never handed back to the caller, so the bypassed-lint,
+/// bypassed-index construction [`ValidSchema::single_field`] performs never
+/// crosses a crate boundary as a value someone could mistake for a
+/// fully-built schema.
+#[must_use]
+pub fn explain_field_assignable(producer_leaf: &Field, consumer_leaf: &Field) -> Assignability {
+    let key = consumer_leaf.key().clone();
+    let producer = OutputSchema::new(ValidSchema::single_field(
+        key.clone(),
+        producer_leaf.clone(),
+    ));
+    let consumer = InputSchema::new(ValidSchema::single_field(key, consumer_leaf.clone()));
+    explain_assignable(&producer, &consumer)
+}
+
 /// The three-valued (Cue/GraphQL-style) assignability verdict: a producer
 /// schema is provably assignable, provably not, or **not statically decidable**.
 ///
@@ -1901,6 +1928,55 @@ mod tests {
                 producer: SchemaKind::Union,
                 consumer: SchemaKind::Record,
             }),
+        );
+    }
+
+    // ── explain_field_assignable (field-granularity, W0 U5) ────────────────────
+
+    /// A producer leaf's own key differs from the consumer field it is being
+    /// checked against (`email` vs. `recipient`) — `explain_field_assignable`
+    /// must re-key both to the same synthetic key internally so the pairing
+    /// succeeds, exactly as it would if the two keys already matched.
+    #[test]
+    fn field_assignable_pairs_leaves_under_different_keys() {
+        let producer_leaf: Field = Field::string(fk("email")).required().into();
+        let consumer_leaf: Field = Field::string(fk("recipient")).required().into();
+
+        assert_eq!(
+            explain_field_assignable(&producer_leaf, &consumer_leaf),
+            Assignability::Yes
+        );
+    }
+
+    /// A provable type mismatch between the two leaves is `No`, carrying a
+    /// `FieldTypeMismatch` under the consumer's own key.
+    #[test]
+    fn field_assignable_type_mismatch_is_no() {
+        let producer_leaf: Field = Field::number(fk("age")).into();
+        let consumer_leaf: Field = Field::string(fk("name")).required().into();
+
+        match explain_field_assignable(&producer_leaf, &consumer_leaf) {
+            Assignability::No(incompats) => {
+                assert!(incompats.iter().any(|i| matches!(
+                    i,
+                    SchemaIncompat::FieldTypeMismatch { key, .. } if key.as_str() == "name"
+                )));
+            },
+            other => panic!("expected No(FieldTypeMismatch), got {other:?}"),
+        }
+    }
+
+    /// A float producer feeding an integer consumer is `Unknown` (possible
+    /// precision loss, not a provable conflict) — the same `NumberWidening`
+    /// leniency the schema-level check applies.
+    #[test]
+    fn field_assignable_float_to_int_is_unknown() {
+        let producer_leaf: Field = Field::number(fk("amount")).into();
+        let consumer_leaf: Field = Field::integer(fk("qty")).required().into();
+
+        assert_eq!(
+            explain_field_assignable(&producer_leaf, &consumer_leaf),
+            Assignability::Unknown(vec![UnknownReason::NumberWidening { key: fk("qty") }])
         );
     }
 }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -232,7 +232,8 @@ pub use builder::{
 };
 pub use commitment::{CommitmentId, CommitmentKey};
 pub use compat::{
-    Assignability, SchemaIncompat, UnknownReason, explain_assignable, is_assignable_schema,
+    Assignability, SchemaIncompat, UnknownReason, explain_assignable, explain_field_assignable,
+    is_assignable_schema,
 };
 pub use directed::{DirectedSchema, Input, InputSchema, Output, OutputSchema, Polarity};
 pub use error::{
@@ -297,8 +298,8 @@ pub use schema::{Schema, SchemaBuilder};
 pub use secret::{SECRET_REDACTED, SecretBytes, SecretString, SecretValue, SecretWire};
 pub use transformer::Transformer;
 pub use validated::{
-    FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, SchemaKind, SerdeTagging,
-    ValidSchema, ValidValues,
+    FieldHandle, PathResolveError, PathWalk, ResolvedLookup, ResolvedValues, SchemaFlags,
+    SchemaKind, SerdeTagging, ValidSchema, ValidValues, is_opaque_field_node,
 };
 pub use value::{ContentId, EXPRESSION_KEY, FieldValue, FieldValues, VALUE_CANON_VERSION};
 pub use widget::{

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -724,6 +724,156 @@ impl ValidSchema {
         Some(cur)
     }
 
+    /// Walk an authored `Reference` parameter's `output_path` through this
+    /// schema's field tree, gating on field **opacity** at every step (ADR-0100
+    /// TypeDAG, W0 U5).
+    ///
+    /// Uses the SAME grammar the runtime resolver's `navigate_path`
+    /// (`crates/engine/src/resolver.rs` — deliberately not touched by this
+    /// walk) uses: an optional leading `$.`/bare `$` root is stripped, the
+    /// remainder is split on `.`, and a segment against a [`Field::List`] parses
+    /// as a `usize` index. This is intentionally **not** [`Self::find_by_path`]
+    /// (which index-jumps straight to a leaf and conflates "absent" with "under
+    /// an opaque node") — it re-walks field-by-field so opacity can be checked at
+    /// every intermediate node, not just the destination.
+    ///
+    /// # Design: three-valued, not two
+    ///
+    /// A `Reference`'s path is only checkable end-to-end when *every* node from
+    /// root to leaf is **closed** (provably, exhaustively typed). Real producer
+    /// shapes are routinely partly opaque (a `serde_json::Value` sub-field, a
+    /// `Select`/`File` that may emit an array, an adjacent-tagged enum), so a
+    /// binary resolve/fail-to-resolve verdict would either hard-reject those
+    /// legitimate workflows or silently stop checking anything. [`PathWalk`]
+    /// instead separates "provably wrong" ([`PathWalk::Unresolved`]) from "hit
+    /// something we cannot reason about" ([`PathWalk::Opaque`], the caller's
+    /// fail-open exit) — only the former is ever a hard error.
+    ///
+    /// ## Field classification (exhaustive — every arm is deliberate)
+    ///
+    /// - **Closed scalar leaf** — `String`/`Secret`/`Number`/`Boolean`/`Code`. A
+    ///   further segment past one of these is provably wrong:
+    ///   [`PathResolveError::DescendPastLeaf`].
+    /// - **`Select`/`File`/`Notice` — opaque, NOT scalar.** A `multiple` `Select`
+    ///   or `File` yields a JSON array, and a `Select` option value or a single
+    ///   `File` value is commonly an object; `Notice` produces no runtime value
+    ///   at all. None is safe to treat as a childless terminal the way the closed
+    ///   scalars are.
+    /// - **Non-empty `Object`** — closed *only* for descending into a key that is
+    ///   actually declared; a missing key is [`PathWalk::Opaque`], **never** a
+    ///   hard error. [`HasSchema`](crate::HasSchema) is a public, **unsealed**
+    ///   trait with real hand-written impls in the tree, and [`Field::Object`]
+    ///   carries no exhaustiveness marker distinguishing a derive-guaranteed-
+    ///   complete object from a possibly-incomplete hand-written one — so a
+    ///   non-empty `Object` cannot be trusted as an exhaustive declaration of
+    ///   every key the real value may carry. Treating a missing key as "unknown"
+    ///   rather than "wrong" is the load-bearing, deliberately conservative
+    ///   choice here.
+    /// - **Empty `Object`** — opaque (the dominant real shape for a nested
+    ///   `serde_json::Value` field, which derives to a fieldless `Object`, not
+    ///   `Any`).
+    /// - **`List`** — closed *for the node itself* (a numeric-index segment is
+    ///   required: [`PathResolveError::NonIndexOnList`] otherwise), but its
+    ///   `item` is reclassified at the descent step: `None` (untyped) or an
+    ///   opaque item (e.g. `Vec<serde_json::Value>`) → [`PathWalk::Opaque`].
+    /// - **`Mode`/`Dynamic`/`Computed`/`Unknown`, or any `Field` variant this
+    ///   version does not yet know about** — opaque, via an explicit wildcard
+    ///   arm so a future variant defaults to opaque rather than silently
+    ///   becoming hard-errorable.
+    ///
+    /// # Returns
+    ///
+    /// - [`PathWalk::Opaque`] — the root schema is not a concrete
+    ///   [`SchemaKind::Record`] (an `Any`/`Union`/future kind), the tokenized
+    ///   path is empty (bare `$`/`""`), the root segment names no declared
+    ///   field, or the walk hit an opaque node / missing key at any later step.
+    /// - [`PathWalk::Unresolved`] — a non-numeric segment against a `List`, or a
+    ///   segment past a closed scalar leaf, on a path that was otherwise
+    ///   fully-closed up to that point.
+    /// - [`PathWalk::Resolved`] — every node from root to leaf was closed; the
+    ///   leaf field the path resolves to.
+    #[must_use]
+    pub fn walk_authored_path(&self, authored: &str) -> PathWalk<'_> {
+        // 1. Root kind gate: only a concrete Record's field tree is walkable.
+        if self.0.kind != SchemaKind::Record {
+            return PathWalk::Opaque;
+        }
+
+        // 2. Tokenize — identical grammar to the runtime navigator.
+        let stripped = authored
+            .strip_prefix("$.")
+            .unwrap_or_else(|| authored.strip_prefix('$').unwrap_or(authored));
+        if stripped.is_empty() {
+            return PathWalk::Opaque;
+        }
+        let mut segments = stripped.split('.');
+
+        // 3. Root segment: absent from the root Record's fields → opaque.
+        let Some(root_key) = segments.next() else {
+            // `stripped` is non-empty, so `split('.')` always yields at least one
+            // item; this arm is unreachable in practice but is a safe fallback,
+            // never a panic.
+            return PathWalk::Opaque;
+        };
+        let Some(root_field) = self.0.fields.iter().find(|f| f.key().as_str() == root_key) else {
+            return PathWalk::Opaque;
+        };
+
+        // 4. Walk each remaining segment, gating opacity at every step.
+        let mut current = root_field;
+        for segment in segments {
+            match walk_step(current, segment) {
+                PathStep::Advance(next) => current = next,
+                PathStep::Opaque => return PathWalk::Opaque,
+                PathStep::Unresolved(err) => return PathWalk::Unresolved(err),
+            }
+        }
+
+        // 5. Classify the final leaf the same way as every intermediate node.
+        if is_opaque_field_node(current) {
+            PathWalk::Opaque
+        } else {
+            PathWalk::Resolved(current)
+        }
+    }
+
+    /// Wrap a single `Field` under a synthetic `key` into a one-field schema, so
+    /// [`explain_assignable`](crate::explain_assignable) — which pairs a
+    /// producer/consumer field by [`Field::key`] equality — can be reused at
+    /// **field granularity**. Crate-private: the only caller is
+    /// [`explain_field_assignable`](crate::compat::explain_field_assignable),
+    /// which builds these, compares them, and discards them within the same
+    /// function call — this bypassed-pipeline schema is never handed back to
+    /// an outside caller (see that function's docs for why that matters).
+    ///
+    /// `field` is **re-keyed** to `key`, not merely wrapped under it: a
+    /// producer's resolved path leaf carries its own intrinsic key (the last
+    /// path segment — e.g. `"email"` for `$.contact.email`), which need not equal
+    /// the consumer parameter key the caller is checking it against. Re-keying
+    /// both the producer leaf and the consumer field to the same synthetic key
+    /// is what lets the assignability check's key-based field pairing match them
+    /// up. (`Field::Unknown`'s key is private to this module and is left
+    /// un-rekeyed; harmless because every caller gates on the field being
+    /// non-opaque first, and `Field::Unknown` is always opaque — see
+    /// [`Self::walk_authored_path`].)
+    ///
+    /// Bypasses the full lint / index-build pipeline `SchemaBuilder::build` runs
+    /// (mirrors [`Self::empty`]/[`Self::any`]): `field` was already lint-clean
+    /// inside its source schema, and the assignability check reads only
+    /// [`Self::fields`]/[`Self::kind`] — never the path index or build-time
+    /// flags — so an empty index and default flags are safe for this narrow,
+    /// internal, single-comparison use.
+    pub(crate) fn single_field(key: FieldKey, field: Field) -> ValidSchema {
+        Self::from_inner(ValidSchemaInner {
+            kind: SchemaKind::Record,
+            serde_tagging: None,
+            fields: vec![rekeyed(field, key)],
+            index: IndexMap::new(),
+            flags: SchemaFlags::default(),
+            root_rules: Vec::new(),
+        })
+    }
+
     /// Resolve dynamic options for a select field through loader registry.
     ///
     /// Same error taxonomy as [`crate::Schema::load_select_options`], but this
@@ -945,6 +1095,169 @@ impl ValidSchema {
         let canonical = canonicalize_aliases(values, &self.0.fields);
         project_level(&self.0.fields, canonical.as_map())
     }
+}
+
+// ── Reference-path opacity walk (ADR-0100 TypeDAG, W0 U5) ───────────────────
+
+/// The result of [`ValidSchema::walk_authored_path`] — see that method for the
+/// full field-opacity classification.
+///
+/// Three-valued rather than a plain `Option`/`Result`: [`Opaque`](Self::Opaque)
+/// (hit something unknowable — the caller must fail open, not reject) is a
+/// distinct outcome from [`Unresolved`](Self::Unresolved) (a provable mistake on
+/// an otherwise fully-closed path — the caller hard-errors).
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathWalk<'a> {
+    /// Every node from root to leaf was closed (fully, provably typed); here is
+    /// the resolved leaf field.
+    Resolved(&'a Field),
+    /// A provable structural mistake on an otherwise fully-closed path.
+    Unresolved(PathResolveError),
+    /// The walk hit an opaque node, a missing `Object` key, or an untyped/opaque
+    /// `List` item before it could prove or refute anything — the caller must
+    /// treat the reference as unchecked, not invalid.
+    Opaque,
+}
+
+/// Why an authored path is provably wrong on an otherwise fully-closed walk
+/// (see [`ValidSchema::walk_authored_path`]). Never returned for a missing
+/// `Object` key or any other opaque node — those are
+/// [`PathWalk::Opaque`], not this.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PathResolveError {
+    /// A `List` step's segment does not parse as a `usize` index.
+    #[error("path segment `{segment}` is not a valid list index")]
+    NonIndexOnList {
+        /// The offending non-numeric segment.
+        segment: String,
+    },
+    /// A further segment appears after a closed scalar leaf
+    /// (`String`/`Secret`/`Number`/`Boolean`/`Code`), which has no children to
+    /// descend into.
+    #[error("path segment `{segment}` appears after a scalar leaf, which has no children")]
+    DescendPastLeaf {
+        /// The segment with nowhere to go.
+        segment: String,
+    },
+}
+
+/// Outcome of classifying one further path `segment` against `current` in
+/// [`ValidSchema::walk_authored_path`].
+enum PathStep<'a> {
+    /// Advance the walk into this child field.
+    Advance(&'a Field),
+    /// Opacity (or a missing key) — the caller fails open.
+    Opaque,
+    /// A provable structural mistake.
+    Unresolved(PathResolveError),
+}
+
+/// Whether `field` is opaque **as a landing node** — unknowable without a
+/// runtime value in hand. This is the exhaustive classification
+/// [`ValidSchema::walk_authored_path`] documents in full; the wildcard arm here
+/// is deliberate (not `todo!()`/`unreachable!()`): any `Field` variant this
+/// version does not yet recognize defaults to opaque rather than silently
+/// becoming hard-errorable when a new variant is added.
+///
+/// - Closed scalar (`String`/`Secret`/`Number`/`Boolean`/`Code`): not opaque.
+/// - `List`: not opaque as the node itself — its `item` is reclassified at the
+///   descent step in [`walk_step`], never here.
+/// - Non-empty `Object`: not opaque (closed for descending into a key that is
+///   actually declared).
+/// - Everything else — empty `Object`, `Select`, `File`, `Notice`, `Mode`,
+///   `Dynamic`, `Computed`, `Unknown`, any future variant — is opaque.
+///
+/// Public because a caller that already has a single resolved [`Field`] in
+/// hand (not a whole schema) needs the SAME classification to decide whether
+/// that field is determinable on its own — e.g. `nebula-workflow`'s
+/// `check_reference_edges` applies this to a consumer's declared parameter
+/// field to decide whether the per-field type check
+/// ([`explain_field_assignable`](crate::compat::explain_field_assignable)) can
+/// run at all, or must fail open. Exposing this `&Field -> bool` predicate
+/// (rather than routing through a synthetic schema) keeps that reuse honest:
+/// no impostor [`ValidSchema`] ever needs to leave this crate for it.
+#[must_use]
+pub fn is_opaque_field_node(field: &Field) -> bool {
+    match field {
+        Field::Object(obj) => obj.fields.is_empty(),
+        Field::String(_)
+        | Field::Secret(_)
+        | Field::Number(_)
+        | Field::Boolean(_)
+        | Field::Code(_)
+        | Field::List(_) => false,
+        _ => true,
+    }
+}
+
+/// Classify one further path `segment` against `current`, dispatching on
+/// `current`'s kind. See [`ValidSchema::walk_authored_path`] for the full
+/// rationale of each arm.
+fn walk_step<'a>(current: &'a Field, segment: &str) -> PathStep<'a> {
+    match current {
+        Field::Object(obj) if !obj.fields.is_empty() => {
+            match obj.fields.iter().find(|f| f.key().as_str() == segment) {
+                Some(next) => PathStep::Advance(next),
+                // A missing key fails open rather than hard-erroring: `HasSchema`
+                // is unsealed, so a non-empty `Object` cannot be trusted as an
+                // exhaustive declaration of every key the real value may carry.
+                None => PathStep::Opaque,
+            }
+        },
+        Field::List(list) => {
+            if segment.parse::<usize>().is_err() {
+                return PathStep::Unresolved(PathResolveError::NonIndexOnList {
+                    segment: segment.to_owned(),
+                });
+            }
+            match list.item.as_deref() {
+                Some(item) if !is_opaque_field_node(item) => PathStep::Advance(item),
+                // `None` (untyped item) or an opaque item type (e.g. a
+                // `Vec<serde_json::Value>`, which derives to an opaque item field).
+                _ => PathStep::Opaque,
+            }
+        },
+        Field::String(_)
+        | Field::Secret(_)
+        | Field::Number(_)
+        | Field::Boolean(_)
+        | Field::Code(_) => PathStep::Unresolved(PathResolveError::DescendPastLeaf {
+            segment: segment.to_owned(),
+        }),
+        // Empty `Object`, `Select`, `File`, `Notice`, `Mode`, `Dynamic`,
+        // `Computed`, `Unknown`, or any future `Field` variant: opaque.
+        _ => PathStep::Opaque,
+    }
+}
+
+/// Re-key `field` to `key`, preserving everything else about it. See
+/// [`ValidSchema::single_field`] for why the caller needs this rather than a
+/// plain wrap.
+fn rekeyed(mut field: Field, key: FieldKey) -> Field {
+    match &mut field {
+        Field::String(f) => f.key = key,
+        Field::Secret(f) => f.key = key,
+        Field::Number(f) => f.key = key,
+        Field::Boolean(f) => f.key = key,
+        Field::Select(f) => f.key = key,
+        Field::Object(f) => f.key = key,
+        Field::List(f) => f.key = key,
+        Field::Mode(f) => f.key = key,
+        Field::Code(f) => f.key = key,
+        Field::File(f) => f.key = key,
+        Field::Computed(f) => f.key = key,
+        Field::Dynamic(f) => f.key = key,
+        Field::Notice(f) => f.key = key,
+        // `UnknownField.key` is private to this crate's `field` module, so it
+        // cannot be rewritten from here — left as its original key. Never
+        // reached in practice: every caller of `single_field` gates on the
+        // field being non-opaque first, and `Field::Unknown` is always opaque
+        // (see `is_opaque_field_node`).
+        Field::Unknown(_) => {},
+    }
+    field
 }
 
 /// Project one field-scope level: schema-declared fields (`emit_as` remaps applied,
@@ -3305,5 +3618,203 @@ mod tests {
         let values = FieldValues::from_json(json!({"config": {"enabled": false}})).unwrap();
         let report = schema.validate(&values).expect_err("object rule must fail");
         assert!(report.errors().any(|e| e.code == "one_of"));
+    }
+
+    // ── walk_authored_path / single_field (ADR-0100 TypeDAG, W0 U5) ────────────
+
+    #[test]
+    fn select_field_reference_fails_open() {
+        // `Select` may carry an array (`multiple`) or an arbitrary option value —
+        // never a safe scalar terminal, so a reference into it is opaque.
+        let schema = Schema::builder()
+            .add(Field::select(field_key!("country")))
+            .build()
+            .unwrap();
+        assert_eq!(schema.walk_authored_path("country"), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn file_field_reference_fails_open() {
+        let schema = Schema::builder()
+            .add(Field::file(field_key!("attachment")))
+            .build()
+            .unwrap();
+        assert_eq!(schema.walk_authored_path("attachment"), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn notice_field_reference_fails_open() {
+        // `Notice` produces no runtime value at all.
+        let schema = Schema::builder()
+            .add(Field::notice(field_key!("banner")))
+            .build()
+            .unwrap();
+        assert_eq!(schema.walk_authored_path("banner"), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn untyped_list_item_reference_fails_open() {
+        // An item that is itself opaque (e.g. what a `Vec<serde_json::Value>`
+        // derives to: an empty `Field::Object`) is opaque, not resolved — a
+        // valid numeric index still fails open, it never becomes
+        // `NonIndexOnList` just because the item is opaque.
+        let opaque_item = Schema::builder()
+            .add(Field::list(field_key!("items")).item(Field::object(field_key!("item"))))
+            .build()
+            .unwrap();
+        assert_eq!(opaque_item.walk_authored_path("items.0"), PathWalk::Opaque);
+
+        // `item: None` (truly untyped) is rejected by the builder's own lint
+        // (`missing_item_schema` — a `List` must always declare an item schema
+        // to pass `SchemaBuilder::build`), so it can never reach a real
+        // `ValidSchema` through the public API. `walk_step` still has to
+        // handle it defensively (the field is a plain `Option`) — construct
+        // the otherwise-unreachable shape directly via the crate-private
+        // `from_inner` to prove that defensive arm, rather than asserting on
+        // dead code.
+        let untyped = ValidSchema::from_inner(ValidSchemaInner {
+            kind: SchemaKind::Record,
+            serde_tagging: None,
+            fields: vec![Field::from(Field::list(field_key!("items")))],
+            index: IndexMap::new(),
+            flags: SchemaFlags::default(),
+            root_rules: Vec::new(),
+        });
+        assert_eq!(untyped.walk_authored_path("items.0"), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn missing_object_key_is_opaque_not_an_error() {
+        // A declared-absent key under a non-empty `Object` fails open — `HasSchema`
+        // is unsealed, so a non-empty `Object` cannot be trusted as exhaustive.
+        let schema = Schema::builder()
+            .add(Field::object(field_key!("contact")).add(Field::string(field_key!("email"))))
+            .build()
+            .unwrap();
+        assert_eq!(schema.walk_authored_path("contact.phone"), PathWalk::Opaque);
+        // The declared key still resolves.
+        assert!(matches!(
+            schema.walk_authored_path("contact.email"),
+            PathWalk::Resolved(Field::String(_))
+        ));
+    }
+
+    #[test]
+    fn non_index_on_list_hard_rejected() {
+        let schema = Schema::builder()
+            .add(Field::list(field_key!("items")).item(Field::string(field_key!("item"))))
+            .build()
+            .unwrap();
+        assert_eq!(
+            schema.walk_authored_path("items.first"),
+            PathWalk::Unresolved(PathResolveError::NonIndexOnList {
+                segment: "first".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn descend_past_scalar_hard_rejected() {
+        let schema = Schema::builder()
+            .add(Field::string(field_key!("name")))
+            .build()
+            .unwrap();
+        assert_eq!(
+            schema.walk_authored_path("name.first"),
+            PathWalk::Unresolved(PathResolveError::DescendPastLeaf {
+                segment: "first".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn bare_dollar_root_is_opaque() {
+        let schema = Schema::builder()
+            .add(Field::string(field_key!("name")))
+            .build()
+            .unwrap();
+        assert_eq!(schema.walk_authored_path("$"), PathWalk::Opaque);
+        assert_eq!(schema.walk_authored_path(""), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn any_and_union_roots_are_opaque() {
+        assert_eq!(
+            ValidSchema::any().walk_authored_path("anything"),
+            PathWalk::Opaque
+        );
+        let u = sample_union(SerdeTagging::External);
+        assert_eq!(u.walk_authored_path("oauth"), PathWalk::Opaque);
+    }
+
+    #[test]
+    fn walk_agrees_with_find_by_path_on_plain_paths() {
+        let schema = Schema::builder()
+            .add(
+                Field::object(field_key!("contact"))
+                    .add(Field::string(field_key!("email")).required()),
+            )
+            .build()
+            .unwrap();
+        let walked = schema.walk_authored_path("contact.email");
+        let found = schema
+            .find_by_path(
+                &FieldPath::root()
+                    .join(field_key!("contact"))
+                    .join(field_key!("email")),
+            )
+            .expect("plain path resolves via find_by_path");
+        assert_eq!(walked, PathWalk::Resolved(found));
+
+        // The `$.` root prefix is accepted identically.
+        assert_eq!(schema.walk_authored_path("$.contact.email"), walked);
+    }
+
+    #[test]
+    fn single_field_rekeys_producer_leaf_so_explain_assignable_can_pair_it() {
+        // The producer leaf's own key (`email`) differs from the consumer
+        // parameter key (`recipient`) it is being checked against; `single_field`
+        // must re-key both to the SAME key so `explain_assignable`'s key-based
+        // pairing matches them up (a `FieldTypeMismatch`/`Yes`, never a spurious
+        // `MissingRequiredField` from a key mismatch).
+        let producer_leaf: Field = Field::string(field_key!("email")).required().into();
+        let consumer_field: Field = Field::string(field_key!("recipient")).required().into();
+
+        let output = crate::OutputSchema::new(ValidSchema::single_field(
+            field_key!("recipient"),
+            producer_leaf,
+        ));
+        let input = crate::InputSchema::new(ValidSchema::single_field(
+            field_key!("recipient"),
+            consumer_field,
+        ));
+
+        assert_eq!(
+            crate::explain_assignable(&output, &input),
+            crate::Assignability::Yes
+        );
+    }
+
+    #[test]
+    fn single_field_type_mismatch_is_reported_under_the_shared_key() {
+        let producer_leaf: Field = Field::number(field_key!("age")).into();
+        let consumer_field: Field = Field::string(field_key!("name")).required().into();
+
+        let output =
+            crate::OutputSchema::new(ValidSchema::single_field(field_key!("name"), producer_leaf));
+        let input = crate::InputSchema::new(ValidSchema::single_field(
+            field_key!("name"),
+            consumer_field,
+        ));
+
+        match crate::explain_assignable(&output, &input) {
+            crate::Assignability::No(incompats) => {
+                assert!(incompats.iter().any(|i| matches!(
+                    i,
+                    crate::SchemaIncompat::FieldTypeMismatch { key, .. } if key.as_str() == "name"
+                )));
+            },
+            other => panic!("expected No(FieldTypeMismatch), got {other:?}"),
+        }
     }
 }

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -1163,7 +1163,7 @@ enum PathStep<'a> {
 ///
 /// - Closed scalar (`String`/`Secret`/`Number`/`Boolean`/`Code`): not opaque.
 /// - `List`: not opaque as the node itself — its `item` is reclassified at the
-///   descent step in [`walk_step`], never here.
+///   descent step in `walk_step`, never here.
 /// - Non-empty `Object`: not opaque (closed for descending into a key that is
 ///   actually declared).
 /// - Everything else — empty `Object`, `Select`, `File`, `Notice`, `Mode`,
@@ -1233,7 +1233,7 @@ fn walk_step<'a>(current: &'a Field, segment: &str) -> PathStep<'a> {
 }
 
 /// Re-key `field` to `key`, preserving everything else about it. See
-/// [`ValidSchema::single_field`] for why the caller needs this rather than a
+/// `ValidSchema::single_field` for why the caller needs this rather than a
 /// plain wrap.
 fn rekeyed(mut field: Field, key: FieldKey) -> Field {
     match &mut field {

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -195,7 +195,7 @@ pub enum WorkflowError {
     /// through the producer node's output schema, on a path that walked
     /// through only **closed** (fully-typed) nodes right up to the failure
     /// point (ADR-0100 TypeDAG, W0 U5 — correctness only; see
-    /// [`crate::validate::check_reference_edges`]).
+    /// `crate::validate::check_reference_edges`).
     ///
     /// Emitted only for [`nebula_schema::PathResolveError::NonIndexOnList`] /
     /// [`nebula_schema::PathResolveError::DescendPastLeaf`] — a missing

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -190,6 +190,52 @@ pub enum WorkflowError {
         /// Why the config is invalid.
         reason: String,
     },
+
+    /// A `ParamValue::Reference`'s `output_path` provably fails to resolve
+    /// through the producer node's output schema, on a path that walked
+    /// through only **closed** (fully-typed) nodes right up to the failure
+    /// point (ADR-0100 TypeDAG, W0 U5 — correctness only; see
+    /// [`crate::validate::check_reference_edges`]).
+    ///
+    /// Emitted only for [`nebula_schema::PathResolveError::NonIndexOnList`] /
+    /// [`nebula_schema::PathResolveError::DescendPastLeaf`] — a missing
+    /// `Object` key, or any opaque node encountered along the way, fails open
+    /// instead (never this variant). Fires in **both**
+    /// [`SchemaCheckMode`](crate::validate::SchemaCheckMode)s: it is a provable
+    /// structural mistake, not an undecidable verdict.
+    ///
+    /// This is a **correctness-only** check: a `Reference` into a
+    /// `Field::Secret` producer field is not distinguished from any other
+    /// reference here (see the W0 U5 plan's framing — secret exfiltration via
+    /// parameter references is a separate, filed, not-yet-built initiative).
+    ///
+    /// The payload is `Box`ed for the same `clippy::result_large_err` reason as
+    /// [`Self::PortSchemaIncompatible`].
+    #[classify(category = "validation", code = "WORKFLOW:REFERENCE_PATH_UNRESOLVED")]
+    #[error("reference path unresolved: {0}")]
+    ReferencePathUnresolved(Box<ReferencePathUnresolvedDetails>),
+
+    /// A `ParamValue::Reference`'s `output_path` resolves through the
+    /// producer's output schema (a fully-closed path —
+    /// [`nebula_schema::PathWalk::Resolved`]), but the resolved leaf field is
+    /// provably **not assignable** to the consumer parameter's expected field
+    /// ([`nebula_schema::Assignability::No`]). Classified consistently with
+    /// [`Self::PortSchemaIncompatible`] (always a hard error, both modes).
+    ///
+    /// The payload is `Box`ed for the same `clippy::result_large_err` reason as
+    /// [`Self::PortSchemaIncompatible`].
+    #[classify(category = "validation", code = "WORKFLOW:REFERENCE_TYPE_INCOMPATIBLE")]
+    #[error("reference type incompatible: {0}")]
+    ReferenceTypeIncompatible(Box<ReferenceTypeIncompatDetails>),
+
+    /// Like [`Self::ReferenceTypeIncompatible`], but the assignability verdict
+    /// was [`nebula_schema::Assignability::Unknown`] — classified consistently
+    /// with [`Self::PortSchemaUndecidable`]: blocked only under
+    /// [`SchemaCheckMode::Strict`](crate::validate::SchemaCheckMode::Strict);
+    /// `Gradual` warns-and-passes.
+    #[classify(category = "validation", code = "WORKFLOW:REFERENCE_TYPE_UNDECIDABLE")]
+    #[error("reference type undecidable: {0}")]
+    ReferenceTypeUndecidable(Box<ReferenceTypeUndecidableDetails>),
 }
 
 /// Join a slice of `Display` items with `"; "` (shared by the two payload
@@ -287,6 +333,103 @@ impl std::fmt::Display for PortSchemaUndecidableDetails {
             from_port,
             self.to_node,
             to_port,
+            join_display(&self.reasons)
+        )
+    }
+}
+
+/// Payload for [`WorkflowError::ReferencePathUnresolved`].
+///
+/// Kept separate and `Box`ed on the enum to satisfy `clippy::result_large_err`,
+/// mirroring [`PortSchemaIncompatDetails`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ReferencePathUnresolvedDetails {
+    /// The node whose parameter carries the unresolved reference.
+    pub consumer_node: NodeKey,
+    /// The parameter key on `consumer_node`.
+    pub param_key: String,
+    /// The referenced producer node.
+    pub producer_node: NodeKey,
+    /// The authored `output_path` that failed to resolve.
+    pub output_path: String,
+    /// The rendered [`nebula_schema::PathResolveError`].
+    pub reason: String,
+}
+
+impl std::fmt::Display for ReferencePathUnresolvedDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "node {} parameter `{}` references {}.{}, which does not resolve: {}",
+            self.consumer_node, self.param_key, self.producer_node, self.output_path, self.reason
+        )
+    }
+}
+
+/// Payload for [`WorkflowError::ReferenceTypeIncompatible`].
+///
+/// Kept separate and `Box`ed on the enum to satisfy `clippy::result_large_err`,
+/// mirroring [`PortSchemaIncompatDetails`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ReferenceTypeIncompatDetails {
+    /// The node whose parameter carries the reference.
+    pub consumer_node: NodeKey,
+    /// The parameter key on `consumer_node`.
+    pub param_key: String,
+    /// The referenced producer node.
+    pub producer_node: NodeKey,
+    /// The authored `output_path` the reference resolved through.
+    pub output_path: String,
+    /// Every incompatibility found between the resolved producer leaf field and
+    /// the consumer's expected field, structured for programmatic inspection.
+    pub incompatibilities: Vec<nebula_schema::SchemaIncompat>,
+}
+
+impl std::fmt::Display for ReferenceTypeIncompatDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}.{} \u{2190} {}.{}: {}",
+            self.consumer_node,
+            self.param_key,
+            self.producer_node,
+            self.output_path,
+            join_display(&self.incompatibilities)
+        )
+    }
+}
+
+/// Payload for [`WorkflowError::ReferenceTypeUndecidable`].
+///
+/// Kept separate and `Box`ed on the enum for the same `clippy::result_large_err`
+/// reason as [`ReferenceTypeIncompatDetails`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ReferenceTypeUndecidableDetails {
+    /// The node whose parameter carries the reference.
+    pub consumer_node: NodeKey,
+    /// The parameter key on `consumer_node`.
+    pub param_key: String,
+    /// The referenced producer node.
+    pub producer_node: NodeKey,
+    /// The authored `output_path` the reference resolved through.
+    pub output_path: String,
+    /// Every reason the reference's assignability is undecidable, structured so
+    /// a policy can route on them without string-parsing.
+    pub reasons: Vec<nebula_schema::UnknownReason>,
+}
+
+impl std::fmt::Display for ReferenceTypeUndecidableDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}.{} \u{2190} {}.{}: {}",
+            self.consumer_node,
+            self.param_key,
+            self.producer_node,
+            self.output_path,
             join_display(&self.reasons)
         )
     }

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -393,7 +393,7 @@ pub fn validate_workflow_with_resolver_mode(
 /// - the referenced producer node is missing from `node_by_id`, or either
 ///   endpoint's schema does not resolve (`resolver.io_schemas` returns
 ///   `None`) — mirrors the main-flow edge check's fail-open contract;
-/// - [`ValidSchema::walk_authored_path`] returns [`PathWalk::Opaque`] — an
+/// - `ValidSchema::walk_authored_path` returns [`PathWalk::Opaque`] — an
 ///   opaque node, a missing `Object` key, or an untyped `List` item anywhere
 ///   along the walk (never provably wrong, see the schema crate's opacity
 ///   classification);
@@ -1789,6 +1789,19 @@ mod tests {
     /// `Reference` to node `a`'s output at `output_path`, with a coincident
     /// connection (so the structural `ReferenceWithoutConnection` check does
     /// not also fire and muddy the assertions).
+    ///
+    /// The connection is wired to a named, non-default `to_port` ("params")
+    /// rather than the default main-flow `to_port: None` — deliberately so
+    /// the separate main-flow port-schema check (`validate_workflow_with_resolver_mode`'s
+    /// own loop, which only type-checks `to_port: None` edges) never fires on
+    /// it. `ReferenceWithoutConnection` only requires the (from, to) node
+    /// pair to be connected, port-agnostic, so this does not weaken that
+    /// guard. Without this, a test asserting only `assert_no_reference_errors`
+    /// could stay spuriously green off an unrelated `PortSchemaIncompatible`
+    /// masking a broken reference check, or a producer/consumer pairing
+    /// crafted to make the reference check pass could incidentally also trip
+    /// the main-flow check — either way conflating two independent checks
+    /// under one assertion.
     fn two_node_reference_def(
         param_key: &str,
         output_path: &str,
@@ -1810,7 +1823,7 @@ mod tests {
                 NodeDefinition::new(a.clone(), "Producer", "core", "producer.action").unwrap(),
                 consumer,
             ],
-            vec![Connection::new(a.clone(), b.clone())],
+            vec![Connection::new(a.clone(), b.clone()).with_to_port(port_key!("params"))],
         );
         (def, a, b)
     }
@@ -1993,7 +2006,19 @@ mod tests {
 
         for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
             let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
-            assert_no_reference_errors(&errors, &format!("{mode:?}"));
+            // Assert the WHOLE validation succeeds (not merely that no
+            // reference-specific error fired): `two_node_reference_def`'s
+            // connection is wired to a named `to_port`, so the separate
+            // main-flow port-schema check never runs on it, and this test's
+            // producer/consumer schemas carry no other error source — an
+            // `assert_no_reference_errors`-only check here would stay green
+            // even if the reference check were broken, as long as nothing
+            // else happened to fail too.
+            assert!(
+                errors.is_empty(),
+                "{mode:?}: expected zero errors for a fully-resolved, assignable reference; \
+                 got: {errors:?}"
+            );
         }
     }
 

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -2,7 +2,10 @@
 
 use std::collections::HashSet;
 
-use nebula_schema::{Assignability, explain_assignable};
+use nebula_schema::{
+    Assignability, FieldKey, PathWalk, explain_assignable, explain_field_assignable,
+    is_opaque_field_node,
+};
 
 use crate::{
     definition::{CURRENT_SCHEMA_VERSION, RetryConfig, WorkflowDefinition},
@@ -370,7 +373,154 @@ pub fn validate_workflow_with_resolver_mode(
         }
     }
 
+    check_reference_edges(definition, resolver, mode, &node_by_id, &mut errors);
+
     errors
+}
+
+/// Type-check each node's per-field `ParamValue::Reference` edges against the
+/// producer's output schema (ADR-0100 TypeDAG, W0 U5 — **correctness only**,
+/// see the crate's W0 U5 plan; this does *not* close any secret-exfiltration
+/// surface — `Expression`/`Template` parameters already read every prior
+/// node's raw output through the identical runtime path).
+///
+/// Complements the main-flow port check above: that loop only type-checks the
+/// *default* `"out"` connection edge, whereas a `Reference` parameter can pull
+/// from **any** node's output through an arbitrary authored dotted path,
+/// entirely outside the main-flow port shape.
+///
+/// Fail-open (no error pushed) when:
+/// - the referenced producer node is missing from `node_by_id`, or either
+///   endpoint's schema does not resolve (`resolver.io_schemas` returns
+///   `None`) — mirrors the main-flow edge check's fail-open contract;
+/// - [`ValidSchema::walk_authored_path`] returns [`PathWalk::Opaque`] — an
+///   opaque node, a missing `Object` key, or an untyped `List` item anywhere
+///   along the walk (never provably wrong, see the schema crate's opacity
+///   classification);
+/// - the consumer's expected field is undeterminable — `param_key` is not a
+///   valid [`FieldKey`], no such field is declared on the consumer's input
+///   schema, or the declared field is itself opaque. Only the *type* check is
+///   skipped in this case; a hard error from the walk above still stands.
+///
+/// Hard errors (both [`SchemaCheckMode`]s) when the walk returns
+/// [`PathWalk::Unresolved`] — a non-numeric `List` index, or a segment past a
+/// scalar leaf — via [`WorkflowError::ReferencePathUnresolved`]. When the walk
+/// resolves and the leaf is provably not assignable to the consumer's expected
+/// field ([`Assignability::No`]), pushes
+/// [`WorkflowError::ReferenceTypeIncompatible`] (both modes);
+/// [`Assignability::Unknown`] pushes [`WorkflowError::ReferenceTypeUndecidable`]
+/// only under [`SchemaCheckMode::Strict`].
+fn check_reference_edges(
+    definition: &WorkflowDefinition,
+    resolver: &dyn NodeSchemaResolver,
+    mode: SchemaCheckMode,
+    node_by_id: &std::collections::HashMap<&nebula_core::NodeKey, &crate::node::NodeDefinition>,
+    errors: &mut Vec<WorkflowError>,
+) {
+    for consumer_node in &definition.nodes {
+        for (param_key, param_value) in &consumer_node.parameters {
+            let ParamValue::Reference {
+                node_key: producer_key,
+                output_path,
+            } = param_value
+            else {
+                continue;
+            };
+
+            // Fail-open: unknown producer (already reported structurally), or
+            // either endpoint's schema does not resolve from the catalog.
+            let Some(producer_node) = node_by_id.get(producer_key) else {
+                continue;
+            };
+            let Some(producer_schemas) = resolver.io_schemas(
+                &producer_node.action_key,
+                producer_node.interface_version.as_ref(),
+            ) else {
+                continue;
+            };
+            let Some(consumer_schemas) = resolver.io_schemas(
+                &consumer_node.action_key,
+                consumer_node.interface_version.as_ref(),
+            ) else {
+                continue;
+            };
+
+            // Opacity-gated path walk: `Opaque` fails open; `Unresolved` is a
+            // provable mistake on an otherwise fully-closed path (hard error in
+            // both modes); `Resolved` hands back the leaf field to type-check.
+            let producer_leaf = match producer_schemas
+                .output
+                .as_schema()
+                .walk_authored_path(output_path)
+            {
+                PathWalk::Opaque => continue,
+                PathWalk::Unresolved(reason) => {
+                    errors.push(WorkflowError::ReferencePathUnresolved(Box::new(
+                        crate::error::ReferencePathUnresolvedDetails {
+                            consumer_node: consumer_node.id.clone(),
+                            param_key: param_key.clone(),
+                            producer_node: producer_key.clone(),
+                            output_path: output_path.clone(),
+                            reason: reason.to_string(),
+                        },
+                    )));
+                    continue;
+                },
+                PathWalk::Resolved(leaf) => leaf.clone(),
+                // `PathWalk` is `#[non_exhaustive]`: a future verdict variant
+                // defaults to fail-open, the same posture as `Opaque`, never a
+                // silent hard error.
+                _ => continue,
+            };
+
+            // Resolve the consumer's expected field for this parameter. The
+            // parameter key equals the consumer `InputSchema` field key by
+            // construction (schema keys mirror serde wire keys, including
+            // `#[serde(rename)]`ed fields — see the derive macro's own test
+            // suite). Undeterminable (invalid key, no such field, or the field
+            // is itself opaque per the same classification the walk above
+            // uses) → fail-open, skip only the type check; the walk's
+            // `Resolved` verdict above already stands on its own.
+            let Ok(consumer_key) = FieldKey::new(param_key.as_str()) else {
+                continue;
+            };
+            let Some(consumer_field) = consumer_schemas.input.as_schema().find(&consumer_key)
+            else {
+                continue;
+            };
+            if is_opaque_field_node(consumer_field) {
+                continue;
+            }
+
+            match explain_field_assignable(&producer_leaf, consumer_field) {
+                Assignability::No(incompatibilities) => {
+                    errors.push(WorkflowError::ReferenceTypeIncompatible(Box::new(
+                        crate::error::ReferenceTypeIncompatDetails {
+                            consumer_node: consumer_node.id.clone(),
+                            param_key: param_key.clone(),
+                            producer_node: producer_key.clone(),
+                            output_path: output_path.clone(),
+                            incompatibilities,
+                        },
+                    )));
+                },
+                Assignability::Unknown(reasons) if mode == SchemaCheckMode::Strict => {
+                    errors.push(WorkflowError::ReferenceTypeUndecidable(Box::new(
+                        crate::error::ReferenceTypeUndecidableDetails {
+                            consumer_node: consumer_node.id.clone(),
+                            param_key: param_key.clone(),
+                            producer_node: producer_key.clone(),
+                            output_path: output_path.clone(),
+                            reasons,
+                        },
+                    )));
+                },
+                // `Yes`, an `Unknown` in Gradual mode, or any future verdict
+                // variant (the enum is `#[non_exhaustive]`): pass the reference.
+                _ => {},
+            }
+        }
+    }
 }
 
 /// A [`WorkflowDefinition`] proven to pass [`validate_workflow`] with zero
@@ -481,7 +631,7 @@ mod tests {
 
     use chrono::Utc;
     use nebula_core::{ActionKey, NodeKey, WorkflowId, node_key, port_key};
-    use nebula_schema::{Field, FieldKey, Schema, ValidSchema};
+    use nebula_schema::{Field, FieldKey, Schema, ValidSchema, schema_of};
 
     use super::*;
     use crate::{
@@ -1625,5 +1775,361 @@ mod tests {
                 .any(|e| matches!(e, WorkflowError::PortSchemaUndecidable(_))),
             "expected PortSchemaUndecidable; got: {errors:?}"
         );
+    }
+
+    // ── check_reference_edges: per-field Reference type check (W0 U5) ────────
+    //
+    // Tests 1/2/6 in the plan MUST use real `#[derive(Schema)]`-produced
+    // structs, not hand-built `ValidSchema` fixtures — these are the exact
+    // regressions the four adversarial review rounds were about (a hand-built
+    // fixture can't prove what the derive macro actually emits for
+    // `serde_json::Value` / an enum).
+
+    /// Build a two-node workflow where node `b`'s `param_key` parameter is a
+    /// `Reference` to node `a`'s output at `output_path`, with a coincident
+    /// connection (so the structural `ReferenceWithoutConnection` check does
+    /// not also fire and muddy the assertions).
+    fn two_node_reference_def(
+        param_key: &str,
+        output_path: &str,
+    ) -> (WorkflowDefinition, NodeKey, NodeKey) {
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let mut consumer =
+            NodeDefinition::new(b.clone(), "Consumer", "core", "consumer.action").unwrap();
+        consumer.parameters.insert(
+            param_key.to_owned(),
+            ParamValue::Reference {
+                node_key: a.clone(),
+                output_path: output_path.to_owned(),
+            },
+        );
+        let def = make_definition(
+            "reference-edge-test",
+            vec![
+                NodeDefinition::new(a.clone(), "Producer", "core", "producer.action").unwrap(),
+                consumer,
+            ],
+            vec![Connection::new(a.clone(), b.clone())],
+        );
+        (def, a, b)
+    }
+
+    /// A `MapResolver` with `producer.action`'s output and `consumer.action`'s
+    /// input set to the given schemas (the other polarity on each side is
+    /// `ValidSchema::empty()` — irrelevant to `check_reference_edges`).
+    fn resolver_with(producer_output: ValidSchema, consumer_input: ValidSchema) -> MapResolver {
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "producer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty().into(),
+                output: producer_output.into(),
+            },
+        );
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: consumer_input.into(),
+                output: ValidSchema::empty().into(),
+            },
+        );
+        MapResolver(schemas)
+    }
+
+    fn assert_no_reference_errors(errors: &[WorkflowError], context: &str) {
+        assert!(
+            !errors.iter().any(|e| matches!(
+                e,
+                WorkflowError::ReferencePathUnresolved(_)
+                    | WorkflowError::ReferenceTypeIncompatible(_)
+                    | WorkflowError::ReferenceTypeUndecidable(_)
+            )),
+            "{context}: expected zero reference errors; got: {errors:?}"
+        );
+    }
+
+    /// The round-2 regression, pinned against real derive output: a nested
+    /// `serde_json::Value` field derives to an EMPTY `Field::Object`, not
+    /// `Any` — the outer producer is still "concretely typed", so a naive
+    /// root-only check would never fire. `$.data.foo` must fail open in both
+    /// modes.
+    #[test]
+    fn nested_value_field_reference_fails_open() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            status: String,
+            data: serde_json::Value,
+        }
+
+        let (def, _, _) = two_node_reference_def("value", "$.data.foo");
+        let resolver = resolver_with(schema_of::<Resp>(), ValidSchema::empty());
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            assert_no_reference_errors(&errors, &format!("{mode:?}"));
+        }
+    }
+
+    /// An Adjacent-tagged enum producer field is a `SchemaKind::Union` root —
+    /// opaque outright (step 1 of the walk), regardless of the authored path.
+    #[test]
+    fn adjacent_tagged_enum_reference_fails_open() {
+        #[derive(nebula_schema::Schema, serde::Serialize)]
+        #[serde(tag = "type", content = "data")]
+        #[expect(dead_code, reason = "variants exercised via derive")]
+        enum Event {
+            Click { x: i64 },
+            Noop,
+        }
+
+        let (def, _, _) = two_node_reference_def("value", "$.x");
+        let resolver = resolver_with(schema_of::<Event>(), ValidSchema::empty());
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            assert_no_reference_errors(&errors, &format!("{mode:?}"));
+        }
+    }
+
+    /// Even serde's default (External) tagging fails open — the conservative
+    /// `Mode` rule applies to every union regardless of tagging, since
+    /// `ModeField` itself carries no tagging discriminant to reason about.
+    #[test]
+    fn external_tagged_enum_reference_fails_open() {
+        #[derive(nebula_schema::Schema, serde::Serialize)]
+        #[expect(dead_code, reason = "variants exercised via derive")]
+        enum Auth {
+            ApiKey { key: String },
+            None,
+        }
+
+        let (def, _, _) = two_node_reference_def("value", "$.key");
+        let resolver = resolver_with(schema_of::<Auth>(), ValidSchema::empty());
+
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+        assert_no_reference_errors(&errors, "Gradual");
+    }
+
+    /// A reference to a key the producer's real (non-empty) `Object` does not
+    /// declare fails open in both modes — never a hard error. `HasSchema` is
+    /// unsealed, so a non-empty `Object` cannot be trusted as exhaustive.
+    #[test]
+    fn missing_object_key_fails_open() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Contact {
+            email: String,
+        }
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            contact: Contact,
+        }
+
+        let (def, _, _) = two_node_reference_def("value", "$.contact.phone");
+        let resolver = resolver_with(schema_of::<Resp>(), ValidSchema::empty());
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            assert_no_reference_errors(&errors, &format!("{mode:?}"));
+        }
+    }
+
+    /// End-to-end wiring proof (not just a fail-open assertion): a non-numeric
+    /// `List` index on an otherwise fully-closed path is a hard
+    /// `ReferencePathUnresolved` in both modes.
+    #[test]
+    fn non_index_on_list_reference_hard_rejected() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            items: Vec<String>,
+        }
+
+        let (def, a, b) = two_node_reference_def("value", "$.items.first");
+        let resolver = resolver_with(schema_of::<Resp>(), ValidSchema::empty());
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            let unresolved: Vec<_> = errors
+                .iter()
+                .filter_map(|e| match e {
+                    WorkflowError::ReferencePathUnresolved(details) => Some(details),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                unresolved.len(),
+                1,
+                "{mode:?}: expected exactly one ReferencePathUnresolved; got: {errors:?}"
+            );
+            assert_eq!(unresolved[0].consumer_node, b, "{mode:?}");
+            assert_eq!(unresolved[0].producer_node, a, "{mode:?}");
+        }
+    }
+
+    /// A reference through only closed nodes, assignable at the leaf → zero
+    /// errors (the happy path the whole check exists to allow through).
+    #[test]
+    fn valid_reference_typechecks_and_passes() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Contact {
+            email: String,
+        }
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            contact: Contact,
+        }
+
+        let (def, _, _) = two_node_reference_def("recipient_email", "$.contact.email");
+        let resolver = resolver_with(
+            schema_of::<Resp>(),
+            single_field_schema("recipient_email", true),
+        );
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            assert_no_reference_errors(&errors, &format!("{mode:?}"));
+        }
+    }
+
+    /// A fully-resolved path whose leaf is providably NOT assignable to the
+    /// consumer's expected field is a hard `ReferenceTypeIncompatible` in
+    /// both modes (it is never merely undecidable).
+    #[test]
+    fn reference_type_incompatible_rejected() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            name: String,
+        }
+
+        let consumer_input = Schema::builder()
+            .add(Field::boolean(FieldKey::new("greeting").unwrap()).required())
+            .build()
+            .unwrap();
+
+        let (def, a, b) = two_node_reference_def("greeting", "$.name");
+        let resolver = resolver_with(schema_of::<Resp>(), consumer_input);
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            let incompatible: Vec<_> = errors
+                .iter()
+                .filter_map(|e| match e {
+                    WorkflowError::ReferenceTypeIncompatible(details) => Some(details),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                incompatible.len(),
+                1,
+                "{mode:?}: expected exactly one ReferenceTypeIncompatible; got: {errors:?}"
+            );
+            assert_eq!(incompatible[0].consumer_node, b, "{mode:?}");
+            assert_eq!(incompatible[0].producer_node, a, "{mode:?}");
+        }
+    }
+
+    /// A float→int narrowing at a fully-resolved leaf is `Unknown`, not `No`:
+    /// Gradual warns-and-passes, Strict blocks with `ReferenceTypeUndecidable`.
+    #[test]
+    fn reference_type_undecidable_gradual_vs_strict() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            amount: f64,
+        }
+
+        let consumer_input = Schema::builder()
+            .add(Field::integer(FieldKey::new("qty").unwrap()).required())
+            .build()
+            .unwrap();
+
+        let (def, _, _) = two_node_reference_def("qty", "$.amount");
+        let resolver = resolver_with(schema_of::<Resp>(), consumer_input);
+
+        let gradual_errors = validate_workflow_with_resolver(&def, &resolver);
+        assert_no_reference_errors(&gradual_errors, "Gradual");
+
+        let strict_errors =
+            validate_workflow_with_resolver_mode(&def, &resolver, SchemaCheckMode::Strict);
+        assert!(
+            strict_errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::ReferenceTypeUndecidable(_))),
+            "strict mode must block the undecidable (float\u{2192}int) reference; got: {strict_errors:?}"
+        );
+        assert!(
+            !strict_errors
+                .iter()
+                .any(|e| matches!(e, WorkflowError::ReferenceTypeIncompatible(_))),
+            "a float\u{2192}int narrowing is undecidable, not a provable conflict; got: {strict_errors:?}"
+        );
+    }
+
+    /// T3.2 parity: when the referenced producer's action is unregistered
+    /// (`resolver.io_schemas` returns `None`), the reference is skipped —
+    /// fail-open, same posture as the main-flow port check.
+    #[test]
+    fn reference_producer_unregistered_fails_open() {
+        let (def, _, _) = two_node_reference_def("value", "$.anything");
+        // Only the consumer resolves; the producer action is absent from the map.
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "consumer.action".to_owned(),
+            NodeIoSchemas {
+                input: ValidSchema::empty().into(),
+                output: ValidSchema::empty().into(),
+            },
+        );
+        let resolver = MapResolver(schemas);
+
+        let errors = validate_workflow_with_resolver(&def, &resolver);
+        assert_no_reference_errors(&errors, "unresolvable producer");
+    }
+
+    /// The consumer field is bound by its serde WIRE key (`"to"`), not the
+    /// Rust field identifier (`recipient`) — guards the Q2 binding
+    /// (`consumer_schemas.input.as_schema().find(&FieldKey::new(param_key))`)
+    /// against regression. The consumer field's type is deliberately wrong
+    /// (`bool` vs. the producer's `String`) so a successful wire-key lookup
+    /// PRODUCES a hard error: if the binding ever regressed to look up the
+    /// Rust field name instead, the lookup would silently miss and this test
+    /// would go quiet (fail-open) rather than red.
+    #[test]
+    fn renamed_consumer_field_binds_by_wire_key() {
+        #[derive(nebula_schema::Schema)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct Resp {
+            name: String,
+        }
+
+        #[derive(nebula_schema::Schema, serde::Deserialize)]
+        #[expect(dead_code, reason = "fields exercised via derive")]
+        struct ConsumerParams {
+            #[serde(rename = "to")]
+            recipient: bool,
+        }
+
+        let (def, _, _) = two_node_reference_def("to", "$.name");
+        let resolver = resolver_with(schema_of::<Resp>(), schema_of::<ConsumerParams>());
+
+        for mode in [SchemaCheckMode::Gradual, SchemaCheckMode::Strict] {
+            let errors = validate_workflow_with_resolver_mode(&def, &resolver, mode);
+            let incompatible = errors
+                .iter()
+                .filter(|e| matches!(e, WorkflowError::ReferenceTypeIncompatible(_)))
+                .count();
+            assert_eq!(
+                incompatible, 1,
+                "{mode:?}: the reference must bind the consumer field by its wire key `to`, not \
+                 the Rust field name `recipient` — got: {errors:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes out the W0 "correctness floor" wave (owner-approved vault plan, ADR-0109-A seam reconciliation) with its last two units:

- **W0 U2** — `crates/engine`: fail-closed routing when a workflow `Connection` targets an output port its source action never declared. A one-time pre-flight (`validate_declared_output_ports`) rejects the misconfiguration before any execution state is persisted or leased, on both the fresh-execute path and the real production `Start` path (`resume_execution`'s cold-start branch — `execute_workflow_scoped` alone is unreachable outside tests). Fails open on any action declaring a dynamic output port (e.g. `core.switch`), so Switch/Router workflows are never falsely rejected.

- **W0 U5** — `crates/schema` + `crates/workflow`: correctness-only type-check for parameter `Reference { node_key, output_path }` edges, previously checked only structurally (target exists + coincident connection, #910). A deliberately conservative opacity-gated schema walk (`ValidSchema::walk_authored_path`) hard-errors only for a non-numeric list index, a segment past a scalar leaf, or a genuine type mismatch on a fully-resolved path — everything ambiguous (empty/opaque Object, Select/File/Notice, all Mode/union tagging styles, untyped list items, even a missing Object key) fails open. Ships correctness-only; secret exfiltration via parameter references remains an open, separately-filed gap (`Expression`/`Template` parameters already read every prior node's raw output through the same path a `Reference` does — closing that needs redaction at the engine's value boundary, not a validator check).

Both units went through multiple rounds of adversarial review (harsh-critic, security-auditor, api-design-lead, async-systems-lead) that caught and reshaped real design flaws before merge — see commit bodies for the reasoning trail.

## Test plan

- [x] `cargo test -p nebula-action -p nebula-engine -p nebula-schema -p nebula-workflow` — all green, including new red→green regression tests
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace --all-targets` — clean (cross-crate ripple check)
- [x] Regression sweep of existing tests/fixtures for latent undeclared-port and invalid-reference wires — fixed 3 found in U2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger workflow pre-flight validation that rejects connections to undeclared output ports, while allowing dynamic ports and the special error port.
  * Enhanced parameter validation with more granular reference-path and type-compatibility/undecidability diagnostics.
  * Introduced improved authored-path walk opacity/unresolved detection for schema validation.
* **Bug Fixes**
  * Prevents invalid executions from being created or leased when targeting undeclared ports.
  * Resume now correctly distinguishes genuine first attempts, durably failing failed cold-start attempts to avoid orphaned “Created” states.
* **Tests**
  * Updated and expanded coverage for validation, resume behavior, replay/routing correctness, and schema path-walking consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->