### PR TITLE
fix(resource)!: cancel-safety leak closure, real PoolStrategy, gate jitter + tokio-grade docs

### DIFF
--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -67,10 +67,16 @@ insta = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 trybuild = "1.0"
-criterion = { workspace = true }
+# `async_tokio` for `Bencher::to_async` — the acquire bench drives the real
+# Manager acquire loop on a tokio runtime.
+criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]
 name = "slotcell"
+harness = false
+
+[[bench]]
+name = "acquire"
 harness = false
 
 [package.metadata.docs.rs]

--- a/crates/resource/benches/acquire.rs
+++ b/crates/resource/benches/acquire.rs
@@ -1,0 +1,252 @@
+//! Acquire hot-path benchmarks over the framework acquire loop.
+//!
+//! The perf research (2026-06) flagged the acquire cache-hit branch as the
+//! path that must stay allocation-lean: reserve → fenced checkout → accept →
+//! prepare → guard build, with the boxed release future deferred to guard
+//! drop. This bench pins that path so a future "optimization" (or an
+//! accidental clone/box on the hit branch) shows up as a regression on
+//! CodSpeed rather than in production:
+//!
+//! - `pooled_hit` — idle-hit acquire → explicit `release` (recycle back to
+//!   the idle queue). The steady-state pool cycle.
+//! - `pooled_create_destroy` — idle-miss acquire (create) → discarding
+//!   release (destroy). The cold path, for the hit/miss ratio.
+//! - `resident_hit` — acquire of the shared resident instance (clone) →
+//!   drop. The cheapest lease the framework hands out.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nebula_resource::{
+    AcquireOptions, Error, HasCredentialSlots, Manager, PoolConfig, Pooled, Provider,
+    RegistrationSpec, Resident, ResidentConfig, ResourceConfig, ResourceContext, ResourceKey,
+    ScopeLevel, SlotIdentity,
+    resource::ResourceMetadata,
+    resource_key,
+    topology::pooled::{PoolProvider, RecycleDecision},
+    topology::resident::ResidentProvider,
+};
+
+#[derive(Clone)]
+struct BenchCfg;
+
+nebula_schema::impl_empty_has_schema!(BenchCfg);
+
+impl ResourceConfig for BenchCfg {
+    fn validate(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn fingerprint(&self) -> u64 {
+        // Unit struct: all instances identical — constant 0 is correct.
+        0
+    }
+}
+
+/// Pooled resource whose default `recycle` keeps instances (no credential
+/// slots), so acquire → release cycles exercise the idle-hit path.
+#[derive(Clone)]
+struct KeepPool;
+
+#[async_trait::async_trait]
+impl Provider for KeepPool {
+    type Config = BenchCfg;
+    type Instance = u64;
+    type Topology = Pooled<Self>;
+
+    fn key() -> ResourceKey {
+        resource_key!("bench-pool-keep")
+    }
+
+    async fn create(&self, _config: &BenchCfg, _ctx: &ResourceContext) -> Result<u64, Error> {
+        Ok(0xBEEF)
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl HasCredentialSlots for KeepPool {
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+}
+
+impl PoolProvider for KeepPool {}
+
+/// Pooled resource that discards on release, so every acquire runs the
+/// create path and every release runs destroy.
+#[derive(Clone)]
+struct DiscardPool;
+
+#[async_trait::async_trait]
+impl Provider for DiscardPool {
+    type Config = BenchCfg;
+    type Instance = u64;
+    type Topology = Pooled<Self>;
+
+    fn key() -> ResourceKey {
+        resource_key!("bench-pool-discard")
+    }
+
+    async fn create(&self, _config: &BenchCfg, _ctx: &ResourceContext) -> Result<u64, Error> {
+        Ok(0xDEAD)
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl HasCredentialSlots for DiscardPool {
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+}
+
+impl PoolProvider for DiscardPool {
+    async fn recycle(
+        &self,
+        _instance: &u64,
+        _metrics: &nebula_resource::topology::pooled::InstanceMetrics,
+    ) -> Result<RecycleDecision, Error> {
+        Ok(RecycleDecision::Drop)
+    }
+}
+
+/// Resident resource: one shared instance, cloned per acquire.
+#[derive(Clone)]
+struct SharedResident;
+
+#[async_trait::async_trait]
+impl Provider for SharedResident {
+    type Config = BenchCfg;
+    type Instance = u64;
+    type Topology = Resident<Self>;
+
+    fn key() -> ResourceKey {
+        resource_key!("bench-resident")
+    }
+
+    async fn create(&self, _config: &BenchCfg, _ctx: &ResourceContext) -> Result<u64, Error> {
+        Ok(0xF00D)
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl HasCredentialSlots for SharedResident {
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+}
+
+#[async_trait::async_trait]
+impl ResidentProvider for SharedResident {
+    fn is_alive_sync(&self, _instance: &u64) -> bool {
+        true
+    }
+}
+
+fn bench_ctx() -> ResourceContext {
+    use nebula_core::scope::Scope;
+    use tokio_util::sync::CancellationToken;
+    ResourceContext::minimal(Scope::default(), CancellationToken::new())
+}
+
+fn bench_acquire(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("bench runtime");
+    let mut group = c.benchmark_group("resource/acquire");
+
+    // Manager construction spawns the ReleaseQueue workers — build inside
+    // the runtime so the background tasks have an executor.
+    let manager = rt.block_on(async {
+        let manager = Manager::new();
+        manager
+            .register(RegistrationSpec {
+                resource: KeepPool,
+                config: BenchCfg,
+                scope: ScopeLevel::Global,
+                slot_identity: SlotIdentity::Unbound,
+                topology: Pooled::<KeepPool>::new(PoolConfig::default(), 0),
+                recovery_gate: None,
+            })
+            .expect("register keep pool");
+        manager
+            .register(RegistrationSpec {
+                resource: DiscardPool,
+                config: BenchCfg,
+                scope: ScopeLevel::Global,
+                slot_identity: SlotIdentity::Unbound,
+                topology: Pooled::<DiscardPool>::new(PoolConfig::default(), 0),
+                recovery_gate: None,
+            })
+            .expect("register discard pool");
+        manager
+            .register(RegistrationSpec {
+                resource: SharedResident,
+                config: BenchCfg,
+                scope: ScopeLevel::Global,
+                slot_identity: SlotIdentity::Unbound,
+                topology: Resident::<SharedResident>::new(ResidentConfig::default()),
+                recovery_gate: None,
+            })
+            .expect("register resident");
+        manager
+    });
+    let ctx = bench_ctx();
+    let options = AcquireOptions::default();
+
+    // Warm one pooled instance so the loop below is a pure idle-hit cycle.
+    rt.block_on(async {
+        let guard = manager
+            .acquire_pooled::<KeepPool>(&ctx, &options)
+            .await
+            .expect("warm the pool");
+        guard.release().await.expect("warm release");
+    });
+
+    group.bench_function("pooled_hit", |b| {
+        b.to_async(&rt).iter(|| async {
+            let guard = manager
+                .acquire_pooled::<KeepPool>(&ctx, &options)
+                .await
+                .expect("idle-hit acquire");
+            black_box(*guard);
+            guard.release().await.expect("recycling release");
+        });
+    });
+
+    group.bench_function("pooled_create_destroy", |b| {
+        b.to_async(&rt).iter(|| async {
+            let guard = manager
+                .acquire_pooled::<DiscardPool>(&ctx, &options)
+                .await
+                .expect("create-path acquire");
+            black_box(*guard);
+            guard.release().await.expect("discarding release");
+        });
+    });
+
+    group.bench_function("resident_hit", |b| {
+        b.to_async(&rt).iter(|| async {
+            let guard = manager
+                .acquire_resident::<SharedResident>(&ctx, &options)
+                .await
+                .expect("resident acquire");
+            black_box(*guard);
+            drop(guard);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_acquire);
+criterion_main!(benches);

--- a/crates/resource/src/credential_fanout/index.rs
+++ b/crates/resource/src/credential_fanout/index.rs
@@ -37,6 +37,7 @@
 use dashmap::DashMap;
 use nebula_core::{ResourceKey, ScopeLevel};
 use nebula_credential::CredentialId;
+use smallvec::SmallVec;
 
 use crate::SlotIdentity;
 
@@ -117,6 +118,12 @@ struct BindRef {
     refs: usize,
 }
 
+/// Per-credential row list. Most credentials resolve into one or two
+/// resource rows, so two rows live inline in the map entry (no heap
+/// allocation, better locality on the rotation fan-out read); larger
+/// families spill to the heap transparently.
+type BindRows = SmallVec<[BindRef; 2]>;
+
 /// Reverse index from a rotated `CredentialId` to the resource registry
 /// rows that resolved it.
 ///
@@ -130,12 +137,17 @@ struct BindRef {
 #[derive(Debug, Default)]
 pub struct ResourceFanoutIndex {
     /// `CredentialId` -> refcounted rows whose resolved slot bound that
-    /// credential.
+    /// credential. See [`BindRows`] for the inline-buffer rationale.
     ///
-    /// `nebula-resource` has no direct `smallvec` dependency, so the
-    /// per-credential row list is a plain `Vec`. Promoting this to a small
-    /// inline buffer is a deferred, dependency-gated optimisation.
-    by_credential: DashMap<CredentialId, Vec<BindRef>>,
+    /// Deliberately **one-way**: the unbind paths scan-and-`retain` across
+    /// credentials (O(total binds), average O(rows-per-credential) per
+    /// bucket) instead of keeping a resource→credential reverse map. Unbind
+    /// runs only on registration removal (cold), while the reverse map would
+    /// buy that cold path speed at the price of a two-map consistency
+    /// protocol on every bind/rollback (the TOCTOU discipline below relies
+    /// on a single shard lock). Rotation fan-out — the hot read — is already
+    /// a single-key lookup.
+    by_credential: DashMap<CredentialId, BindRows>,
 }
 
 impl ResourceFanoutIndex {

--- a/crates/resource/src/credential_fanout/orchestrator.rs
+++ b/crates/resource/src/credential_fanout/orchestrator.rs
@@ -48,6 +48,14 @@ impl ResourceFanoutIndex {
     ///
     /// An empty `affected(cid)` returns
     /// [`RotationOutcome::default()`](RotationOutcome) (a no-op fan-out).
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Dropping it mid-fan-out abandons
+    /// whichever per-row dispatches had not yet completed; each row is left
+    /// in a well-defined state (an un-dispatched refresh simply never ran).
+    /// The only effect of cancellation is that the aggregate
+    /// [`RotationOutcome`] for this call is never produced.
     #[tracing::instrument(
         level = "debug",
         name = "nebula.credential.rotation.fanout_refresh",
@@ -74,6 +82,15 @@ impl ResourceFanoutIndex {
     /// [`dispatch_refresh`](Self::dispatch_refresh) — only the per-row port
     /// differs (`revoke_slot_for_identity` taints → drains → runs the revoke
     /// hook).
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. A revoke row that had already
+    /// synchronously tainted its resource stays tainted — new acquires
+    /// remain rejected — even if its drain/hook tail never ran (see
+    /// [`Manager::drain_and_revoke`](crate::Manager::drain_and_revoke)).
+    /// Cancellation only means the aggregate [`RotationOutcome`] is never
+    /// produced.
     #[tracing::instrument(
         level = "debug",
         name = "nebula.credential.rotation.fanout_revoke",

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -400,6 +400,16 @@ impl<R: Provider> ResourceGuard<R> {
     /// bounded `Exclusive` cap the failed reset has already latched the
     /// runtime poisoned and returned the permit before the error reaches
     /// here (S4 / #384), exactly as on the queued path.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. The release state is taken out of `self`
+    /// synchronously before the first await, and the teardown plus
+    /// drain-accounting run on a detached background task; if this future is
+    /// dropped while awaited, that task still runs to completion — the
+    /// resource is still torn down or recycled and the drain trackers still
+    /// settle. Dropping only means the caller never observes the resulting
+    /// `Result`.
     pub async fn release(mut self) -> Result<(), crate::Error> {
         // Take the post-callback settle inputs OUT of `self` so the drop of
         // the husk at end of scope is inert — no double settle, no double

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -6,8 +6,9 @@
 //! The engine is the owner of the resource lifecycle: acquire, health-check,
 //! hot-reload via `ReloadOutcome`, and scope-bounded release. Action code
 //! receives a `ResourceGuard` that derefs to `R::Instance` and releases on
-//! drop. Three built-in topologies cover the integration space: `Pooled`,
-//! `Resident`.
+//! drop. Three built-in topologies cover the integration space: `Pooled`
+//! (N interchangeable instances), `Resident` (one shared instance, cloned
+//! per acquire), and `Bounded` (a concurrency cap with no warm idle pool).
 //!
 //! ## Quick start
 //!
@@ -45,6 +46,24 @@
 //! | `ResourceContext` | Execution context with cancellation and capabilities |
 //! | `ResourceEvent` | Lifecycle events for observability |
 //! | `ResourceOpsMetrics` | Registry-backed operation counters |
+//!
+//! ## Cancel safety
+//!
+//! Public async methods document their cancellation contract in a
+//! `# Cancel safety` section (the tokio convention). The load-bearing
+//! guarantees: dropping an acquire future never leaks an instance (a slot in
+//! flight is destroyed asynchronously via the `ReleaseQueue`), and dropping a
+//! revoke future never un-revokes a credential (the taint runs synchronously
+//! before the first await).
+//!
+//! ## Feature flags
+//!
+//! - `rotation` — enables the credential-rotation fan-out module
+//!   (`credential_fanout`): the `CredentialId` → resource-rows reverse
+//!   index, the rotation orchestrator, and
+//!   `ResourceActivatorRegistry::register_and_bind`. Off by default so the
+//!   base build pays no eventbus-subscriber or extra-task overhead; the
+//!   engine enables it together with its own `rotation` feature.
 //!
 //! ## Canon note — §11.4
 //!
@@ -165,7 +184,7 @@ pub use state::{ResourceErrorSummary, ResourcePhase, ResourceStatus};
 // Topology configurations — used at registration time.
 pub use topology::{
     AdmissionPhase, AdmissionStatus, CheckedOut, Checkout, InstanceStore, Load,
-    MaintenanceSchedule, NoTopology, ReturnOutcome, Ticket, Topology, Unavailable,
+    MaintenanceSchedule, NoTopology, PoolStrategy, ReturnOutcome, Ticket, Topology, Unavailable,
     bounded::{BoundedMode, BoundedProvider},
     pooled::{
         BrokenCheck, InstanceMetrics, PoolProvider, RecycleDecision, config::Config as PoolConfig,

--- a/crates/resource/src/manager/acquire.rs
+++ b/crates/resource/src/manager/acquire.rs
@@ -139,6 +139,15 @@ impl Manager {
     ///
     /// Same as the typed `acquire_*_for_identity` family: not found,
     /// ambiguous, shutdown, taint, topology, and acquire-time failures.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Dropping the future at any await point
+    /// releases the topology permit, settles the drain accounting, and
+    /// auto-fails a held recovery-gate probe ticket (its backoff applies).
+    /// An instance in flight between checkout/create and the returned guard
+    /// is destroyed asynchronously via the release queue, never leaked. The
+    /// only effect of cancellation is that no guard is returned.
     pub async fn acquire_any(
         manager: Arc<Self>,
         key: &ResourceKey,
@@ -224,6 +233,15 @@ impl Manager {
     ///   when the resolved slot identity is known; this identity-agnostic
     ///   path stays fail-closed for the no-identity caller.
     /// - Propagates pool-specific acquire errors.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Dropping the future at any await point
+    /// releases the topology permit, settles the drain accounting, and
+    /// auto-fails a held recovery-gate probe ticket (its backoff applies).
+    /// An instance in flight between checkout/create and the returned guard
+    /// is destroyed asynchronously via the release queue, never leaked. The
+    /// only effect of cancellation is that no guard is returned.
     pub async fn acquire_pooled<R>(
         &self,
         ctx: &ResourceContext,
@@ -261,6 +279,13 @@ impl Manager {
     /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if the resource is not using
     ///   pool topology.
     /// - Propagates pool-specific acquire errors.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe — same contract as
+    /// [`acquire_pooled`](Self::acquire_pooled): permit, drain accounting,
+    /// and gate ticket all settle on drop; an in-flight instance is destroyed
+    /// asynchronously via the release queue.
     pub async fn acquire_pooled_for_identity<R>(
         &self,
         ctx: &ResourceContext,
@@ -447,6 +472,13 @@ impl Manager {
     /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if the resource is not using
     ///   resident topology.
     /// - Propagates resident-specific acquire errors.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe — same contract as
+    /// [`acquire_pooled`](Self::acquire_pooled): permit, drain accounting,
+    /// and gate ticket all settle on drop; an in-flight instance is destroyed
+    /// asynchronously via the release queue.
     pub async fn acquire_resident<R>(
         &self,
         ctx: &ResourceContext,
@@ -485,6 +517,13 @@ impl Manager {
     /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if the resource is not using
     ///   resident topology.
     /// - Propagates resident-specific acquire errors.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe — same contract as
+    /// [`acquire_pooled`](Self::acquire_pooled): permit, drain accounting,
+    /// and gate ticket all settle on drop; an in-flight instance is destroyed
+    /// asynchronously via the release queue.
     pub async fn acquire_resident_for_identity<R>(
         &self,
         ctx: &ResourceContext,
@@ -546,6 +585,14 @@ impl Manager {
     ///   a multi-tenant pool is warmed per resolved row through the
     ///   slot-identity-pinned acquire path
     ///   ([`acquire_pooled_for_identity`](Self::acquire_pooled_for_identity)).
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Slots already deposited stay in the pool;
+    /// a slot in flight between creation and its fenced deposit is destroyed
+    /// asynchronously via the release queue (this also covers the internal
+    /// author-hook ceiling timeout). Cancellation only means the caller
+    /// never learns how many slots were admitted.
     pub async fn warmup_pool<R>(&self, ctx: &ResourceContext) -> Result<usize, Error>
     where
         R: PoolProvider

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -95,9 +95,11 @@ impl Manager {
         }
 
         // The framework-owned idle store the acquire loop fences. Its capacity
-        // is the topology's (`Pooled`: `max_size`; non-pooling topologies:
-        // `None`, store stays empty). Read before moving `topology` in.
+        // and queue order are the topology's (`Pooled`: `max_size` + the
+        // configured LIFO/FIFO strategy; non-pooling topologies: `None`,
+        // store stays empty). Read before moving `topology` in.
         let store_capacity = <R::Topology as Topology<R>>::store_capacity(&topology);
+        let store_strategy = <R::Topology as Topology<R>>::queue_strategy(&topology);
 
         // Tier-3 foolproofing (ADR-0093): a credentialed *Pooled* resource is
         // safe by default — `PoolProvider::recycle` DISCARDS on release, so the
@@ -121,7 +123,8 @@ impl Manager {
             topology,
             // Framework-owned idle store the acquire loop runs checkout / return
             // / evict against — the real idle queue, not a throwaway sentinel.
-            store: crate::topology::store::InstanceStore::new(store_capacity),
+            store: crate::topology::store::InstanceStore::new(store_capacity)
+                .with_strategy(store_strategy),
             release_queue: Arc::clone(&self.release_queue),
             generation: AtomicU64::new(0),
             status: arc_swap::ArcSwap::from_pointee(crate::state::ResourceStatus::new()),

--- a/crates/resource/src/manager/rotation.rs
+++ b/crates/resource/src/manager/rotation.rs
@@ -135,6 +135,13 @@ impl Manager {
     /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
     ///   down.
     /// - Whatever the resource's `on_credential_refresh` hook maps into [`Error`].
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. It mutates no framework state before
+    /// dispatching the hook; if the future is dropped, the only effect is
+    /// that `on_credential_refresh` may not have run for this call and no
+    /// `SlotRefreshed` / `SlotRefreshFailed` event is emitted.
     #[tracing::instrument(
         level = "debug",
         name = "nebula.resource.slot_refresh",
@@ -173,6 +180,10 @@ impl Manager {
     /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
     ///   down.
     /// - Whatever the resource's `on_credential_refresh` hook maps into [`Error`].
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe — same contract as [`refresh_slot`](Self::refresh_slot).
     #[tracing::instrument(
         level = "debug",
         name = "nebula.resource.slot_refresh",
@@ -446,12 +457,17 @@ impl Manager {
     /// timed-out drain can never skip the hook, and only a hung hook is
     /// bounded — never the taint.
     ///
-    /// **Cancellation-safety.** The taint is *not* in this future — it
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. The taint is *not* in this future — it
     /// ran in the synchronous
     /// [`taint_slot_for_identity`](Self::taint_slot_for_identity)
     /// phase. So if this future *is* dropped anyway (an outer abort, task
     /// cancel), the row stays tainted and consistent: new acquires are
-    /// still rejected, the credential is never silently un-revoked.
+    /// still rejected, the credential is never silently un-revoked. The
+    /// only effect of a drop is that
+    /// [`Provider::on_credential_revoke`](crate::resource::Provider::on_credential_revoke)
+    /// may never run for this attempt.
     #[tracing::instrument(
         level = "debug",
         name = "nebula.resource.slot_drain_revoke",
@@ -611,6 +627,13 @@ impl Manager {
     /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
     ///   down.
     /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. The taint and revoke-epoch bump run
+    /// synchronously before the first await, so dropping the future never
+    /// un-revokes the row — same contract as
+    /// [`drain_and_revoke`](Self::drain_and_revoke).
     pub async fn revoke_slot(
         &self,
         key: &ResourceKey,

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -179,6 +179,17 @@ impl Manager {
     ///     .expect("graceful shutdown should succeed");
     /// # }
     /// ```
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel safe with respect to correctness: the shutdown flag and the
+    /// cancellation token are set synchronously before the first await, so
+    /// dropping this future still leaves new acquires permanently rejected
+    /// and the release-queue workers still drain and exit on their own. It
+    /// is **not** idempotent-on-cancel: a drop mid-shutdown skips the
+    /// registry clear and the final [`ShutdownReport`], and a retry
+    /// immediately returns `AlreadyShuttingDown` — treat shutdown as
+    /// one-shot and do not race it against a timeout you intend to retry.
     pub async fn graceful_shutdown(
         &self,
         config: ShutdownConfig,

--- a/crates/resource/src/recovery/gate.rs
+++ b/crates/resource/src/recovery/gate.rs
@@ -155,9 +155,14 @@ impl RecoveryTicket {
     }
 
     /// Marks the recovery as transiently failed with exponential backoff.
+    ///
+    /// The imposed delay is the jittered nominal backoff — uniform in
+    /// `[backoff/2, backoff]` (internal `apply_equal_jitter`), so a fleet of
+    /// gates failing at the same instant does not re-line up on the same
+    /// retry tick.
     pub fn fail_transient(mut self, message: impl Into<String>) {
         self.consumed = true;
-        let backoff = compute_backoff(self.gate.base_backoff, self.attempt);
+        let backoff = apply_equal_jitter(compute_backoff(self.gate.base_backoff, self.attempt));
         let next = Arc::new(GateState::Failed {
             message: message.into(),
             retry_at: Instant::now() + backoff,
@@ -190,7 +195,7 @@ impl RecoveryTicket {
 impl Drop for RecoveryTicket {
     fn drop(&mut self) {
         if !self.consumed {
-            let backoff = compute_backoff(self.gate.base_backoff, self.attempt);
+            let backoff = apply_equal_jitter(compute_backoff(self.gate.base_backoff, self.attempt));
             let next = Arc::new(GateState::Failed {
                 message: "recovery ticket dropped without resolution".into(),
                 retry_at: Instant::now() + backoff,
@@ -253,6 +258,13 @@ impl RecoveryWaiter {
     /// Switching any notifier to `notify_one`, or loading the state before
     /// constructing the `Notified` future, would reintroduce a lost-wakeup
     /// window; the `#[cfg(test)]` correctness-pin below guards that ordering.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. It performs no mutation — it only
+    /// observes gate state and waits on a notification. If the future is
+    /// dropped, no wakeup or state transition is lost; a subsequent call
+    /// re-observes the gate correctly.
     pub async fn wait(&self) -> GateState {
         loop {
             // Register notification BEFORE checking state to avoid missing
@@ -350,11 +362,16 @@ impl RecoveryGate {
         self.inner.base_backoff
     }
 
-    /// Returns the backoff that would be imposed if the attempt with the
-    /// given 1-based index were to fail transiently. Mirrors the internal
-    /// `compute_backoff` formula (`base * 2^(attempt - 1)`, capped at 5
-    /// minutes) so callers can publish a truthful expected delay in
+    /// Returns the **nominal** backoff that would be imposed if the attempt
+    /// with the given 1-based index were to fail transiently. Mirrors the
+    /// internal `compute_backoff` formula (`base * 2^(attempt - 1)`, capped
+    /// at 5 minutes) so callers can publish a truthful expected delay in
     /// [`ResourceEvent::RetryAttempt`] without reimplementing the math.
+    ///
+    /// The delay actually imposed on failure is this value with equal
+    /// jitter applied (uniform in `[nominal/2, nominal]` — see the internal
+    /// `apply_equal_jitter`), so the published figure is the upper bound
+    /// of the real retry window.
     pub fn backoff_for_attempt(&self, attempt: u32) -> Duration {
         compute_backoff(self.inner.base_backoff, attempt)
     }
@@ -534,6 +551,37 @@ fn compute_backoff(base: Duration, attempt: u32) -> Duration {
     Duration::from_millis(backoff_millis.min(max_millis))
 }
 
+/// Spreads a nominal backoff uniformly over `[nominal/2, nominal]`
+/// ("equal jitter").
+///
+/// Without jitter, a fleet of gates that failed at the same instant (one
+/// dead backend behind many resources, a cold-start stampede) all expire
+/// their `retry_at` on the same tick and re-probe in lockstep — the exact
+/// herd the gate exists to prevent, just phase-shifted. Keeping at least
+/// half the nominal delay preserves the exponential-escalation contract
+/// (`retry_at` never lands before `nominal/2`, never after `nominal`, so
+/// the [`MAX_BACKOFF`] cap still holds).
+///
+/// Entropy is [`std::hash::RandomState`] — per-instance random seeding from
+/// std, deliberately no `rand` dependency for one draw per *failed*
+/// recovery attempt (cold path). A zero nominal backoff stays zero, so
+/// zero-backoff tests remain deterministic.
+fn apply_equal_jitter(nominal: Duration) -> Duration {
+    use std::hash::{BuildHasher, RandomState};
+
+    let half_nanos = (nominal / 2).as_nanos() as u64;
+    if half_nanos == 0 {
+        return nominal;
+    }
+    // Uniform-enough draw in [0, half]: SipHash output of a fresh
+    // randomly-seeded RandomState. Modulo bias over a 64-bit draw is
+    // negligible for a retry spread.
+    let draw_nanos = RandomState::new().hash_one(0u64) % (half_nanos + 1);
+    // `draw <= half <= nominal`, so this never saturates; `saturating_sub`
+    // states the no-underflow intent without a panic path.
+    nominal.saturating_sub(Duration::from_nanos(draw_nanos))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,6 +679,51 @@ mod tests {
         let base = Duration::from_mins(1);
         // 60 * 2^4 = 960s > 300s cap
         assert_eq!(compute_backoff(base, 5), MAX_BACKOFF);
+    }
+
+    #[test]
+    fn equal_jitter_stays_within_half_to_nominal() {
+        let nominal = Duration::from_secs(10);
+        for _ in 0..1_000 {
+            let jittered = apply_equal_jitter(nominal);
+            assert!(
+                jittered >= nominal / 2 && jittered <= nominal,
+                "equal jitter must spread over [nominal/2, nominal], got {jittered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn equal_jitter_zero_backoff_stays_zero() {
+        // Zero-backoff test configs rely on retry_at being immediately
+        // expired — jitter must not resurrect a delay from nothing.
+        assert_eq!(apply_equal_jitter(Duration::ZERO), Duration::ZERO);
+        // Sub-2ns backoff has a zero half; passes through unjittered.
+        assert_eq!(
+            apply_equal_jitter(Duration::from_nanos(1)),
+            Duration::from_nanos(1)
+        );
+    }
+
+    #[test]
+    fn failed_retry_at_lands_within_the_jitter_window() {
+        let gate = RecoveryGate::new(RecoveryGateConfig {
+            max_attempts: 5,
+            base_backoff: Duration::from_secs(8),
+        });
+        let before = Instant::now();
+        let ticket = gate.try_begin().expect("gate starts idle");
+        ticket.fail_transient("probe refused");
+        match gate.state() {
+            GateState::Failed { retry_at, .. } => {
+                let delay = retry_at.duration_since(before);
+                assert!(
+                    delay >= Duration::from_secs(4) && delay <= Duration::from_secs(8),
+                    "attempt 1 delay must land in [nominal/2, nominal] = [4s, 8s], got {delay:?}"
+                );
+            },
+            other => panic!("expected Failed, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/resource/src/release_queue.rs
+++ b/crates/resource/src/release_queue.rs
@@ -347,6 +347,14 @@ impl ReleaseQueue {
     /// Workers must have been signaled to stop first — either by dropping
     /// the `ReleaseQueue` (closing channels) or by cancelling the token
     /// (via [`close`](Self::close) or external cancellation).
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If dropped while awaiting a worker's
+    /// `JoinHandle`, that worker (and any not yet reached) is not aborted —
+    /// it keeps draining and exits on its own once the shared cancellation
+    /// token fires. The caller only loses the "all workers finished"
+    /// observation, not correctness.
     pub async fn shutdown(handle: ReleaseQueueHandle) {
         for worker in handle.workers {
             let _ = worker.await;

--- a/crates/resource/src/runtime/acquire_loop.rs
+++ b/crates/resource/src/runtime/acquire_loop.rs
@@ -113,15 +113,16 @@ where
             .map_err(|u| u.into_error(R::key()))?
             .into_permit();
 
-        // 2-4. Fenced checkout → destroy stale → accept-or-create. The whole
+        // 2-5. Fenced checkout → destroy stale → accept-or-create. The whole
         //      idle-then-create decision is the framework's; the topology only
-        //      validates (`accept`) or makes (`create_slot`).
-        let (slot, checkout_epoch) = self.checkout_or_create(ctx, &config).await?;
-
-        // 5. Cancel-safety: from here until the guard is built, a drop must
-        //    `destroy(into_instance(slot))` via the ReleaseQueue.
-        let mut cancel_guard =
-            SlotCreateGuard::new(slot, Arc::clone(self), Arc::clone(&self.release_queue));
+        //      validates (`accept`) or makes (`create_slot`). The slot comes
+        //      back already armed in its cancel guard — `checkout_or_create`
+        //      wraps it the moment it leaves the store / creation call, so a
+        //      drop at ANY await from the pop onward (stale destroys, the
+        //      `accept` hook, `prepare` below) schedules an async
+        //      `destroy(into_instance(slot))` via the ReleaseQueue instead of
+        //      leaking the instance through a plain `Drop`.
+        let (mut cancel_guard, checkout_epoch) = self.checkout_or_create(ctx, &config).await?;
 
         // 6. Per-acquire session init. `prepare` borrows the slot mutably from
         //    the cancel guard (a distinct object from `self`), so the topology
@@ -153,18 +154,43 @@ where
     ///
     /// This is the inner half of the acquire loop; factored out so a future
     /// `checkout_keyed` (affinity) variant slots in beside it without reshaping
-    /// the loop. Returns the chosen slot and its checkout epoch (the create
-    /// path stamps the current epoch).
+    /// the loop. Returns the chosen slot — already armed in its
+    /// [`SlotCreateGuard`] — and its checkout epoch (the create path stamps
+    /// the current epoch).
+    ///
+    /// # Cancel safety
+    ///
+    /// A popped or freshly-created slot is wrapped in a [`SlotCreateGuard`]
+    /// **before** any subsequent await (the stale-destroy loop, the `accept`
+    /// hook, the fence destroy), so a caller cancellation — a `tokio::select!`
+    /// branch or `tokio::time::timeout` dropping the acquire future — never
+    /// discards a live instance through a plain `Drop`: the guard schedules an
+    /// async `Provider::destroy` via the [`ReleaseQueue`]. A cancellation that
+    /// lands *inside* one of the inline `destroy_within` awaits abandons only
+    /// that teardown attempt (teardown is best-effort and deadline-bounded);
+    /// the instance is already consumed by the destroy at that point, never
+    /// leaked live.
     ///
     /// Complexity: O(stale + 1) idle pops per call (average and worst case);
     /// bounded by the store's idle capacity.
     async fn checkout_or_create(
-        &self,
+        self: &Arc<Self>,
         ctx: &ResourceContext,
         config: &R::Config,
-    ) -> Result<(SlotOf<R>, u64), Error> {
+    ) -> Result<(SlotCreateGuard<R>, u64), Error> {
         loop {
             let checkout = self.store.checkout().await;
+            // Cancel-safety: arm the fresh slot's guard NOW, before the stale
+            // destroys and the `accept` hook below get a chance to park this
+            // future — a drop while suspended there must schedule an async
+            // destroy, not leak the popped instance.
+            let fresh = checkout.fresh.map(|co| {
+                let (slot, epoch) = co.into_parts();
+                (
+                    SlotCreateGuard::new(slot, Arc::clone(self), Arc::clone(&self.release_queue)),
+                    epoch,
+                )
+            });
             // FRAMEWORK destroys since-revoked stale slots — the author can
             // never skip this fence.
             for stale in checkout.stale {
@@ -175,7 +201,7 @@ where
                 )
                 .await;
             }
-            let Some(co) = checkout.fresh else {
+            let Some((mut cancel_guard, epoch)) = fresh else {
                 // Idle-miss — create a fresh slot. Snapshot the revoke epoch
                 // BEFORE create so a revoke that lands *during* `create_slot` is
                 // detectable (HikariCP #1836): stamping after the await would
@@ -208,14 +234,24 @@ where
                         R::key()
                     )));
                 }
-                return Ok((slot, create_epoch));
+                // No await between `create_slot` returning and this wrap, so
+                // the created instance is guarded before the caller's next
+                // suspension point.
+                return Ok((
+                    SlotCreateGuard::new(slot, Arc::clone(self), Arc::clone(&self.release_queue)),
+                    create_epoch,
+                ));
             };
-            let (mut slot, epoch) = co.into_parts();
-            if self.topology.accept(&mut slot, &self.resource, ctx).await {
-                return Ok((slot, epoch));
+            if self
+                .topology
+                .accept(cancel_guard.slot_mut(), &self.resource, ctx)
+                .await
+            {
+                return Ok((cancel_guard, epoch));
             }
             // Rejected (stale fingerprint / max-lifetime / broken) — destroy and
             // loop to the next idle slot, then create.
+            let slot = cancel_guard.defuse();
             let _ = destroy_within(
                 &self.resource,
                 self.topology.into_instance(slot),
@@ -307,10 +343,19 @@ where
     /// (fenced) at registration. Returns the number admitted.
     ///
     /// Each warmed slot is stamped with the live revoke epoch under the idle
-    /// lock via [`crate::topology::store::InstanceStore::deposit_fresh`], so a revoke that already
-    /// landed evicts it immediately rather than admitting a since-revoked
-    /// instance.
-    pub(crate) async fn warmup(&self, ctx: &ResourceContext) -> usize {
+    /// lock via `InstanceStore::deposit_fresh_locked`, so a revoke that
+    /// already landed evicts it immediately rather than admitting a
+    /// since-revoked instance.
+    ///
+    /// # Cancel safety
+    ///
+    /// A created-but-not-yet-deposited slot is armed in a [`SlotCreateGuard`]
+    /// before the idle lock is awaited, so a drop of this future — including
+    /// the author-hook ceiling timeout `Manager::warmup_pool` wraps it in —
+    /// schedules an async `Provider::destroy` via the [`ReleaseQueue`]
+    /// instead of leaking the instance. The guard is defused only once the
+    /// lock is held and the fenced deposit runs synchronously to completion.
+    pub(crate) async fn warmup(self: &Arc<Self>, ctx: &ResourceContext) -> usize {
         let config = self.config();
         let target = self.topology.warmup_target(&config);
         if target == 0 {
@@ -324,16 +369,34 @@ where
                 .create_slot(&self.resource, &config, ctx)
                 .await
             {
-                Ok(slot) => match self.store.deposit_fresh(slot, created_epoch).await {
-                    ReturnOutcome::Recycled => created += 1,
-                    ReturnOutcome::Evict(slot) => {
-                        let _ = destroy_within(
-                            &self.resource,
-                            self.topology.into_instance(slot),
-                            TeardownReason::Evicted,
-                        )
-                        .await;
-                    },
+                Ok(slot) => {
+                    // Cancel-safety: arm the guard before the idle-lock await
+                    // below — a cancellation landing there must destroy the
+                    // just-created instance, not drop it silently.
+                    let cancel_guard = SlotCreateGuard::new(
+                        slot,
+                        Arc::clone(self),
+                        Arc::clone(&self.release_queue),
+                    );
+                    let mut idle = self.store.lock_idle().await;
+                    let slot = cancel_guard.defuse();
+                    let outcome = self
+                        .store
+                        .deposit_fresh_locked(&mut idle, slot, created_epoch);
+                    // Release the idle lock before any teardown await — the
+                    // evict destroy must not block checkout/return.
+                    drop(idle);
+                    match outcome {
+                        ReturnOutcome::Recycled => created += 1,
+                        ReturnOutcome::Evict(slot) => {
+                            let _ = destroy_within(
+                                &self.resource,
+                                self.topology.into_instance(slot),
+                                TeardownReason::Evicted,
+                            )
+                            .await;
+                        },
+                    }
                 },
                 Err(e) => {
                     tracing::warn!(
@@ -716,6 +779,9 @@ mod tests {
     struct Mock {
         created: Arc<AtomicU64>,
         destroyed: Arc<AtomicU64>,
+        /// When `true`, `check` parks forever — the deterministic suspension
+        /// point for the accept-await cancellation tests.
+        hang_check: Arc<AtomicBool>,
     }
 
     impl Mock {
@@ -723,6 +789,7 @@ mod tests {
             Self {
                 created: Arc::new(AtomicU64::new(0)),
                 destroyed: Arc::new(AtomicU64::new(0)),
+                hang_check: Arc::new(AtomicBool::new(false)),
             }
         }
     }
@@ -740,6 +807,16 @@ mod tests {
         async fn create(&self, _config: &PoolCfg, _ctx: &ResourceContext) -> Result<u64, Error> {
             let id = self.created.fetch_add(1, Ordering::SeqCst);
             Ok(id)
+        }
+
+        async fn check(&self, _runtime: &u64) -> Result<(), Error> {
+            if self.hang_check.load(Ordering::SeqCst) {
+                std::future::pending::<()>().await;
+                // guard-justified: `std::future::pending()` never resolves,
+                // so this line is statically unreachable.
+                unreachable!("pending future never resolves")
+            }
+            Ok(())
         }
 
         async fn destroy(&self, _runtime: u64, _cx: TeardownCx) -> Result<(), Error> {
@@ -785,6 +862,162 @@ mod tests {
             in_flight: Arc::new((AtomicU64::new(0), Notify::new())),
             maintenance_sweeps: AtomicU64::new(0),
         })
+    }
+
+    /// Cancel-safety regression (audit 2026-07-01 bug #1): an acquire future
+    /// cancelled while suspended in `Topology::accept` (here: a hanging
+    /// `test_on_checkout` health check) must destroy the popped idle slot via
+    /// the release queue — before the fix the slot was a plain local across
+    /// the `accept().await` and a cancellation dropped the live instance
+    /// without ever calling `Provider::destroy` (permanent leak: the slot was
+    /// already off the idle queue).
+    #[tokio::test]
+    async fn cancelled_acquire_during_accept_destroys_the_popped_slot() {
+        let resource = Mock::new();
+        let destroyed = Arc::clone(&resource.destroyed);
+        let hang_check = Arc::clone(&resource.hang_check);
+        let (rq, rq_handle) = ReleaseQueue::new(1);
+        let rq = Arc::new(rq);
+        let mr = {
+            let topology = Pooled::<Mock>::new(
+                PoolConfig {
+                    test_on_checkout: true,
+                    ..PoolConfig::default()
+                },
+                0,
+            );
+            Arc::new(ManagedResource {
+                resource,
+                config: ArcSwap::from_pointee(PoolCfg),
+                topology,
+                store: InstanceStore::new(None),
+                release_queue: Arc::clone(&rq),
+                generation: AtomicU64::new(0),
+                status: ArcSwap::from_pointee(ResourceStatus::new()),
+                recovery_gate: None,
+                tainted: AtomicBool::new(false),
+                in_flight: Arc::new((AtomicU64::new(0), Notify::new())),
+                maintenance_sweeps: AtomicU64::new(0),
+            })
+        };
+
+        // Seed one healthy idle slot, then arm the hang so the NEXT acquire
+        // parks inside `accept`'s health check with the slot popped.
+        let slot = mr
+            .topology
+            .create_slot(&mr.resource, &PoolCfg, &test_ctx())
+            .await
+            .expect("create the seed slot");
+        let epoch = mr.store.stamp_epoch();
+        assert!(
+            !mr.store.deposit_fresh(slot, epoch).await.is_evict(),
+            "the seed slot must land in the idle queue"
+        );
+        hang_check.store(true, Ordering::SeqCst);
+
+        // The cancellation: a timeout drops the acquire future while it is
+        // suspended in `accept` → `resource.check`.
+        let cancelled = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            mr.run_acquire_loop(&test_ctx(), &AcquireOptions::default(), None),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "the acquire must still be parked in the hanging health check \
+             when the timeout fires"
+        );
+        assert!(
+            mr.store.is_empty().await,
+            "the popped slot must not have been silently re-queued"
+        );
+
+        // Drain the release queue and assert the destroy actually ran.
+        rq.close();
+        drop(rq);
+        drop(mr);
+        ReleaseQueue::shutdown(rq_handle).await;
+        assert_eq!(
+            destroyed.load(Ordering::SeqCst),
+            1,
+            "a cancellation during `accept` must destroy the popped slot via \
+             the ReleaseQueue, never leak it through a plain Drop"
+        );
+    }
+
+    /// Cancel-safety regression (audit 2026-07-01 bug #2): a warmup future
+    /// dropped between `create_slot` succeeding and the fenced deposit
+    /// completing (here: parked on the held idle lock; in production the
+    /// author-hook ceiling timeout in `Manager::warmup_pool`) must destroy
+    /// the created instance via the release queue — before the fix the slot
+    /// travelled unguarded into `deposit_fresh`'s future and a cancellation
+    /// dropped it without `Provider::destroy`.
+    #[tokio::test]
+    async fn cancelled_warmup_between_create_and_deposit_destroys_the_slot() {
+        let resource = Mock::new();
+        let created = Arc::clone(&resource.created);
+        let destroyed = Arc::clone(&resource.destroyed);
+        let (rq, rq_handle) = ReleaseQueue::new(1);
+        let rq = Arc::new(rq);
+        let mr = {
+            let topology = Pooled::<Mock>::new(
+                PoolConfig {
+                    min_size: 1, // warmup_target = 1
+                    ..PoolConfig::default()
+                },
+                0,
+            );
+            Arc::new(ManagedResource {
+                resource,
+                config: ArcSwap::from_pointee(PoolCfg),
+                topology,
+                store: InstanceStore::new(None),
+                release_queue: Arc::clone(&rq),
+                generation: AtomicU64::new(0),
+                status: ArcSwap::from_pointee(ResourceStatus::new()),
+                recovery_gate: None,
+                tainted: AtomicBool::new(false),
+                in_flight: Arc::new((AtomicU64::new(0), Notify::new())),
+                maintenance_sweeps: AtomicU64::new(0),
+            })
+        };
+
+        // Hold the idle lock so warmup creates its slot, then parks on the
+        // lock acquisition — the exact created-but-undeposited window.
+        let idle_lock = mr.store.lock_idle().await;
+        let ctx = test_ctx();
+        {
+            let mut warmup = Box::pin(mr.warmup(&ctx));
+            let parked =
+                tokio::time::timeout(std::time::Duration::from_millis(100), &mut warmup).await;
+            assert!(
+                parked.is_err(),
+                "warmup must be parked awaiting the idle lock with a created slot in hand"
+            );
+            drop(warmup); // the cancellation
+        }
+        drop(idle_lock);
+
+        assert_eq!(
+            created.load(Ordering::SeqCst),
+            1,
+            "exactly one instance was created before the cancellation"
+        );
+        assert!(
+            mr.store.is_empty().await,
+            "the cancelled warmup must not have deposited the slot"
+        );
+
+        rq.close();
+        drop(rq);
+        drop(mr);
+        ReleaseQueue::shutdown(rq_handle).await;
+        assert_eq!(
+            destroyed.load(Ordering::SeqCst),
+            1,
+            "a warmup cancelled between create and deposit must destroy the \
+             created instance via the ReleaseQueue, never leak it"
+        );
     }
 
     /// Cancel-safety: a [`SlotCreateGuard`] dropped before `defuse` schedules an

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -479,6 +479,10 @@ where
         Some(self.config.max_size as usize)
     }
 
+    fn queue_strategy(&self) -> crate::topology::store::PoolStrategy {
+        self.config.strategy
+    }
+
     fn warmup_target(&self, _config: &R::Config) -> usize {
         self.config.min_size as usize
     }
@@ -855,6 +859,32 @@ mod tests {
                 .on_release(&mut slot, &resource)
                 .await
                 .expect("release")
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_strategy_forwards_the_configured_strategy() {
+        use crate::topology::store::PoolStrategy;
+        // The registration path builds the framework store from this hook —
+        // a Pooled topology must forward its configured strategy, not the
+        // trait's FIFO fallback (the pre-fix behavior: `Config::strategy`
+        // was declared but never read, so every pool silently ran FIFO).
+        let lifo_pool = mock_pool(Config::default(), 0);
+        assert_eq!(
+            Topology::<MockPool>::queue_strategy(&lifo_pool),
+            PoolStrategy::Lifo,
+            "default pool config promises LIFO and the store must honor it"
+        );
+        let fifo_pool = mock_pool(
+            Config {
+                strategy: PoolStrategy::Fifo,
+                ..Default::default()
+            },
+            0,
+        );
+        assert_eq!(
+            Topology::<MockPool>::queue_strategy(&fifo_pool),
+            PoolStrategy::Fifo
         );
     }
 

--- a/crates/resource/src/topology/contract.rs
+++ b/crates/resource/src/topology/contract.rs
@@ -35,7 +35,7 @@ use crate::{
     context::ResourceContext,
     error::{Error, ErrorKind},
     resource::Provider,
-    topology::store::InstanceStore,
+    topology::store::{InstanceStore, PoolStrategy},
     topology_tag::TopologyTag,
 };
 
@@ -526,6 +526,20 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// `ManagedResource::store`. Default `None`.
     fn store_capacity(&self) -> Option<usize> {
         None
+    }
+
+    /// The idle-queue ordering the framework applies to this topology's store
+    /// (see [`PoolStrategy`]): checkout always pops the front; the strategy
+    /// chooses the push side on return. Read once at registration alongside
+    /// [`store_capacity`](Topology::store_capacity).
+    ///
+    /// Only meaningful for topologies whose store can hold more than one idle
+    /// slot (Pooled overrides this with its configured strategy); single-slot
+    /// and permit-only topologies are unaffected by either choice. Default
+    /// [`PoolStrategy::Fifo`] — even wear, the least surprising order for a
+    /// custom topology that never opted in.
+    fn queue_strategy(&self) -> PoolStrategy {
+        PoolStrategy::Fifo
     }
 
     // ── warmup / maintenance (framework-driven over the store) ──────────────

--- a/crates/resource/src/topology/mod.rs
+++ b/crates/resource/src/topology/mod.rs
@@ -30,7 +30,7 @@ pub use contract::{
 };
 pub use pooled::{BrokenCheck, InstanceMetrics, PoolProvider, RecycleDecision};
 pub use resident::ResidentProvider;
-pub use store::{CheckedOut, Checkout, InstanceStore, ReturnOutcome};
+pub use store::{CheckedOut, Checkout, InstanceStore, PoolStrategy, ReturnOutcome};
 
 /// Framework topology structs that implement the open [`Topology`] contract.
 ///

--- a/crates/resource/src/topology/pooled.rs
+++ b/crates/resource/src/topology/pooled.rs
@@ -146,16 +146,12 @@ pub trait PoolProvider: Provider + crate::resource::HasCredentialSlots {
 pub mod config {
     use std::time::Duration;
 
-    /// Pool checkout ordering strategy.
-    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-    #[non_exhaustive]
-    pub enum PoolStrategy {
-        /// Last-in, first-out — reuses the most recently returned instance.
-        #[default]
-        Lifo,
-        /// First-in, first-out — spreads load evenly across instances.
-        Fifo,
-    }
+    /// Idle-queue ordering strategy — canonical definition lives on the
+    /// framework store whose queue it governs
+    /// ([`InstanceStore`](crate::topology::store::InstanceStore));
+    /// re-exported here because pool authors configure it through
+    /// [`Config::strategy`].
+    pub use crate::topology::store::PoolStrategy;
 
     /// Strategy for pre-warming the pool at startup.
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -188,7 +184,10 @@ pub mod config {
         pub max_lifetime: Option<Duration>,
         /// Timeout for creating a new instance.
         pub create_timeout: Duration,
-        /// Checkout ordering strategy.
+        /// Idle-queue ordering strategy: LIFO reuses the hottest instance
+        /// (lets the tail age out so `idle_timeout` can shrink the pool);
+        /// FIFO rotates through every instance for even wear. Read once at
+        /// registration to build the framework store.
         pub strategy: PoolStrategy,
         /// Warmup strategy at pool startup.
         pub warmup: WarmupStrategy,

--- a/crates/resource/src/topology/store.rs
+++ b/crates/resource/src/topology/store.rs
@@ -19,6 +19,33 @@ use std::{
 use tokio::sync::{Mutex, MutexGuard};
 use tracing::debug;
 
+// ─── PoolStrategy ─────────────────────────────────────────────────────────────
+
+/// Idle-queue ordering strategy: which end of the queue a returned slot
+/// re-enters.
+///
+/// Checkout always pops the **front** ([`InstanceStore::checkout`]); the
+/// strategy chooses the **push side** on return
+/// ([`return_slot`](InstanceStore::return_slot) /
+/// [`deposit_fresh`](InstanceStore::deposit_fresh)):
+///
+/// - [`Lifo`](Self::Lifo) pushes to the front — the most recently returned
+///   slot is reused first, keeping a hot working set warm while the queue's
+///   tail ages out, so an `idle_timeout` reaper can actually shrink the pool
+///   under falling load.
+/// - [`Fifo`](Self::Fifo) pushes to the back — leases rotate through every
+///   idle slot for even wear, keeping the whole pool warm at the cost of
+///   never letting any slot idle long enough to be reaped.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PoolStrategy {
+    /// Last-in, first-out — reuses the most recently returned instance.
+    #[default]
+    Lifo,
+    /// First-in, first-out — spreads load evenly across instances.
+    Fifo,
+}
+
 // ─── InstanceStore ────────────────────────────────────────────────────────────
 
 /// A timestamped slot entry: the slot value plus the revoke-epoch snapshot
@@ -109,6 +136,9 @@ pub struct InstanceStore<S> {
     /// Maximum number of slots the store will hold idle.
     /// `None` = unbounded (Resident / permit-only topologies).
     capacity: Option<usize>,
+    /// Which end of the idle queue a returned slot re-enters — see
+    /// [`PoolStrategy`]. Checkout always pops the front.
+    strategy: PoolStrategy,
 }
 
 impl<S> Clone for InstanceStore<S> {
@@ -117,6 +147,7 @@ impl<S> Clone for InstanceStore<S> {
             idle: Arc::clone(&self.idle),
             revoke_epoch: Arc::clone(&self.revoke_epoch),
             capacity: self.capacity,
+            strategy: self.strategy,
         }
     }
 }
@@ -125,6 +156,7 @@ impl<S> std::fmt::Debug for InstanceStore<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InstanceStore")
             .field("capacity", &self.capacity)
+            .field("strategy", &self.strategy)
             .field("revoke_epoch", &self.revoke_epoch.load(Ordering::Acquire))
             .finish()
     }
@@ -135,11 +167,39 @@ impl<S: Send + 'static> InstanceStore<S> {
     ///
     /// Pass `None` for unbounded (e.g., Resident or permit-only topologies);
     /// pass `Some(n)` for Pooled-like topologies that cap the idle queue.
+    /// The idle queue defaults to FIFO ordering — see
+    /// [`with_strategy`](Self::with_strategy).
     pub fn new(capacity: Option<usize>) -> Self {
         Self {
             idle: Arc::new(Mutex::new(VecDeque::new())),
             revoke_epoch: Arc::new(AtomicU64::new(0)),
             capacity,
+            strategy: PoolStrategy::Fifo,
+        }
+    }
+
+    /// Sets the idle-queue ordering strategy (see [`PoolStrategy`]).
+    ///
+    /// Ordering only matters when the store can hold more than one idle slot
+    /// (Pooled); single-slot and permit-only topologies are unaffected by
+    /// either choice.
+    #[must_use]
+    pub fn with_strategy(mut self, strategy: PoolStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// The configured idle-queue ordering strategy.
+    pub fn strategy(&self) -> PoolStrategy {
+        self.strategy
+    }
+
+    /// Enqueues on the strategy's push side: back for FIFO (even wear),
+    /// front for LIFO (hot-set reuse). Checkout always pops the front.
+    fn enqueue(&self, idle: &mut VecDeque<StoreEntry<S>>, entry: StoreEntry<S>) {
+        match self.strategy {
+            PoolStrategy::Fifo => idle.push_back(entry),
+            PoolStrategy::Lifo => idle.push_front(entry),
         }
     }
 
@@ -182,6 +242,16 @@ impl<S: Send + 'static> InstanceStore<S> {
     /// lock — the same lock the credential-revoke idle-walk
     /// ([`evict_stale`](Self::evict_stale)) holds — so a slot revoked while
     /// idle is observed as stale here even if the revoke raced the checkout.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If the future is dropped before the
+    /// idle-queue lock is acquired, no slot is popped and the store is
+    /// unchanged. Once the lock is held the method completes without any
+    /// further await, so a drop cannot observe or leave behind a partial
+    /// state. (The returned [`Checkout`] transfers ownership of live slots —
+    /// the *caller* must not drop it across a cancellation point without
+    /// destroying them.)
     ///
     /// [`Provider::destroy`]: crate::resource::Provider::destroy
     pub async fn checkout(&self) -> Checkout<S> {
@@ -234,6 +304,15 @@ impl<S: Send + 'static> InstanceStore<S> {
     /// lock, so a concurrent `bump_revoke_epoch` followed by an idle-walk
     /// cannot enqueue a stale slot: the walk holds the same lock and sees the
     /// already-bumped counter.
+    ///
+    /// # Cancel safety
+    ///
+    /// The lock-then-mutate shape is cancel safe (a drop before the lock is
+    /// acquired mutates nothing; after, the method finishes without another
+    /// await) — but the future *owns* `slot` while it waits for the lock, so
+    /// a caller that can be cancelled must hold the slot in a destroy-on-drop
+    /// guard (the framework acquire loop's `SlotCreateGuard` pattern) rather
+    /// than rely on this method to place it.
     pub async fn return_slot(&self, slot: S, checkout_epoch: u64) -> ReturnOutcome<S> {
         let mut idle = self.idle.lock().await;
         // Revoke-epoch fence: re-read under the idle lock (same lock the
@@ -254,10 +333,13 @@ impl<S: Send + 'static> InstanceStore<S> {
         {
             return ReturnOutcome::Evict(slot);
         }
-        idle.push_back(StoreEntry {
-            slot,
-            checkout_epoch,
-        });
+        self.enqueue(
+            &mut idle,
+            StoreEntry {
+                slot,
+                checkout_epoch,
+            },
+        );
         ReturnOutcome::Recycled
     }
 
@@ -293,8 +375,12 @@ impl<S: Send + 'static> InstanceStore<S> {
     /// reaper sweep — so a stale slot can never be served regardless of which
     /// path observes it first.
     pub async fn evict_stale(&self) -> Vec<S> {
-        let live_epoch = self.current_revoke_epoch();
         let mut idle = self.idle.lock().await;
+        // Epoch read under the idle lock — the same discipline as `checkout` /
+        // `return_slot` — so a revoke racing this sweep is either fully
+        // observed (its slots evicted now) or fully deferred to the next
+        // fence crossing, never half-applied against a pre-lock snapshot.
+        let live_epoch = self.current_revoke_epoch();
         let mut evicted = Vec::new();
         let mut keep = VecDeque::with_capacity(idle.len());
         for entry in idle.drain(..) {
@@ -383,8 +469,34 @@ impl<S: Send + 'static> InstanceStore<S> {
     /// The epoch read and the push happen under the idle lock — the same lock
     /// the revoke idle-walk holds — so the compare-then-push is atomic against
     /// a concurrent `bump_revoke_epoch` + reaper sweep.
+    ///
+    /// # Cancel safety
+    ///
+    /// Same contract as [`return_slot`](Self::return_slot): the store is
+    /// never left half-mutated, but the future owns `slot` while awaiting the
+    /// lock. Cancellation-guarded callers should use the crate-internal
+    /// `lock_idle` + `deposit_fresh_locked` split so their destroy-on-drop
+    /// guard stays armed across the lock acquisition — the warmup loop does
+    /// exactly this.
     pub async fn deposit_fresh(&self, slot: S, created_epoch: u64) -> ReturnOutcome<S> {
         let mut idle = self.idle.lock().await;
+        self.deposit_fresh_locked(&mut idle, slot, created_epoch)
+    }
+
+    /// The synchronous core of [`deposit_fresh`](Self::deposit_fresh),
+    /// against an already-held idle lock.
+    ///
+    /// Split out for cancellation-guarded callers (the warmup loop): they
+    /// acquire the lock via [`lock_idle`](Self::lock_idle) while the slot is
+    /// still armed in its cancel guard, then defuse and hand the slot over
+    /// only once no await remains — so a caller cancellation can never drop
+    /// a created-but-undeposited instance through a plain `Drop`.
+    pub(crate) fn deposit_fresh_locked(
+        &self,
+        idle: &mut VecDeque<StoreEntry<S>>,
+        slot: S,
+        created_epoch: u64,
+    ) -> ReturnOutcome<S> {
         let live_epoch = self.revoke_epoch.load(Ordering::Acquire);
         if created_epoch != live_epoch {
             debug!(
@@ -398,10 +510,13 @@ impl<S: Send + 'static> InstanceStore<S> {
         {
             return ReturnOutcome::Evict(slot);
         }
-        idle.push_back(StoreEntry {
-            slot,
-            checkout_epoch: created_epoch,
-        });
+        self.enqueue(
+            idle,
+            StoreEntry {
+                slot,
+                checkout_epoch: created_epoch,
+            },
+        );
         ReturnOutcome::Recycled
     }
 }
@@ -660,6 +775,52 @@ mod tests {
             "third slot exceeds cap of 2 → evicted"
         );
         assert_eq!(store.len().await, 2);
+    }
+
+    // Default FIFO: checkout order matches return order (even wear).
+    #[tokio::test]
+    async fn fifo_default_checks_out_in_return_order() {
+        let store: InstanceStore<u32> = InstanceStore::new(None);
+        assert_eq!(store.strategy(), PoolStrategy::Fifo, "new() defaults FIFO");
+        let epoch = store.stamp_epoch();
+        store.return_slot(1, epoch).await;
+        store.return_slot(2, epoch).await;
+        let first = store.checkout().await.fresh.map(|c| c.slot);
+        assert_eq!(first, Some(1), "FIFO hands out the oldest return first");
+    }
+
+    // LIFO: the most recently returned slot is reused first (hot-set reuse,
+    // the tail ages out for the idle_timeout reaper).
+    #[tokio::test]
+    async fn lifo_checks_out_most_recent_return_first() {
+        let store: InstanceStore<u32> = InstanceStore::new(None).with_strategy(PoolStrategy::Lifo);
+        let epoch = store.stamp_epoch();
+        store.return_slot(1, epoch).await;
+        store.return_slot(2, epoch).await;
+        let first = store.checkout().await.fresh.map(|c| c.slot);
+        assert_eq!(first, Some(2), "LIFO hands out the hottest slot first");
+        let second = store.checkout().await.fresh.map(|c| c.slot);
+        assert_eq!(second, Some(1), "the colder slot is next");
+    }
+
+    // LIFO first-deposit: deposit_fresh honors the same push side.
+    #[tokio::test]
+    async fn lifo_deposit_fresh_lands_at_the_front() {
+        let store: InstanceStore<u32> = InstanceStore::new(None).with_strategy(PoolStrategy::Lifo);
+        let epoch = store.stamp_epoch();
+        store.deposit_fresh(1, epoch).await;
+        store.deposit_fresh(2, epoch).await;
+        let first = store.checkout().await.fresh.map(|c| c.slot);
+        assert_eq!(first, Some(2), "LIFO deposits land at the checkout end");
+    }
+
+    // A cloned handle shares queue AND strategy.
+    #[tokio::test]
+    async fn clone_preserves_strategy() {
+        let store: InstanceStore<u32> = InstanceStore::new(None).with_strategy(PoolStrategy::Lifo);
+        let cloned = store.clone();
+        assert_eq!(cloned.strategy(), store.strategy());
+        assert_eq!(cloned.strategy(), PoolStrategy::Lifo);
     }
 
     // drain_all empties the queue.


### PR DESCRIPTION
## Summary

Post-audit improvement pass over `nebula-resource`. The 5-model audit's verified fix set already landed (#915, #917, #918); this PR implements the **verified remainder** of that backlog, plus two genuine cancel-safety leaks found by a dedicated line-level audit of the whole public async surface — and makes the crate's async contracts tokio-grade (documented, benchmarked, verified).

## Cancel-safety fixes (real leaks, both regression-tested)

1. **Cancelled acquire leaked the popped idle slot** — in `checkout_or_create` the slot was a plain local across the `Topology::accept().await` (and the fresh slot across the stale-destroy loop). A `tokio::time::timeout`/`select!` cancellation dropped the live instance via plain `Drop` — never `Provider::destroy` — after it was already off the idle queue: one permanently leaked connection per occurrence. `SlotCreateGuard` is now armed the moment a slot leaves the store/create call, so cancellation schedules an async destroy via the `ReleaseQueue`.
   Regression: `cancelled_acquire_during_accept_destroys_the_popped_slot`.
2. **Cancelled warmup leaked the created instance** — unguarded gap between `create_slot().await` and `deposit_fresh().await`, reachable in production via the 30s `guard_author_hook` ceiling in `Manager::warmup_pool` (whose SAFETY comment already *claimed* guard protection that didn't exist). `deposit_fresh` is split into lock + sync `deposit_fresh_locked` so the guard stays armed across every await.
   Regression: `cancelled_warmup_between_create_and_deposit_destroys_the_slot`.
3. `evict_stale` now reads the revoke epoch **under** the idle lock — same fence discipline as `checkout`/`return_slot` (was a benign pre-lock TOCTOU).

## BREAKING: pools now genuinely default to LIFO

`Config.strategy: PoolStrategy` (default `Lifo`, documented "checkout ordering strategy") was **declared but never read** — every pool silently ran FIFO. Now: `PoolStrategy` lives on `topology::store` (the queue it governs; pooled config re-exports it), `InstanceStore` gained `strategy` + `with_strategy()` (checkout always pops the front; the strategy picks the push side — bb8 mechanism), a defaulted `Topology::queue_strategy()` hook threads it, and registration builds the store with it.

**Behavior change:** default pools switch FIFO → LIFO (per their long-documented contract). LIFO keeps the hot set warm so `idle_timeout` can actually shrink a pool under falling load; set `PoolStrategy::Fifo` explicitly for even-wear.

## Verified-backlog improvements

- **RecoveryGate equal jitter** — `retry_at` spreads uniformly over `[nominal/2, nominal]` at `fail_transient` + ticket-`Drop` (std `RandomState`, no `rand` dep; zero-backoff test configs unaffected; `backoff_for_attempt` stays the truthful nominal upper bound). Kills the phase-locked re-probe herd on simultaneous gate expiries.
- **Fanout index rows `Vec` → `SmallVec<[BindRef; 2]>`** — the recorded dependency-gated optimization (`smallvec` was a declared-but-unused dep with a stale comment claiming otherwise). Module doc records the *rejected* reverse-index design: unbind is cold, the hot read is one keyed lookup, and a second map would break the single-shard-lock TOCTOU discipline.

## Tokio-grade docs + perf grounding

- `# Cancel safety` sections (tokio convention) on the full public async surface — every claim verified against actual control flow: the `acquire_*` family, `ResourceGuard::release`, store methods, `RecoveryWaiter::wait`, `ReleaseQueue::shutdown`, refresh/revoke/`drain_and_revoke`, fan-out dispatchers, and `graceful_shutdown` (documented correctness-safe but **not idempotent-on-cancel**).
- Crate root gains `## Cancel safety` + `## Feature flags` sections; the intro's "three built-in topologies" no longer lists two.
- New `benches/acquire.rs` (criterion `async_tokio`) pins the full framework acquire loop — `pooled_hit` ≈ 2.76 µs, `pooled_create_destroy` ≈ 2.84 µs, `resident_hit` — a CodSpeed baseline so hit-path regressions (accidental clone/box) surface in CI.
- Refuted en route: `assert_matches!` is **not** stable on 1.96 (compile-probed; the perf research note was wrong) — the 41 `assert!(matches!(..))` sites deliberately stay.

## Test plan

- [x] 439 crate tests (`--features rotation`), incl. 2 new cancellation regressions + LIFO/FIFO store-order + jitter-window pins
- [x] 977 consumer tests (engine / sdk / plugin / action)
- [x] 14 doc-tests
- [x] clippy `--all-targets --all-features` (pedantic+nursery) — 0 warnings
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features`
- [x] fmt clean; both benches compile and run

Caveat, stated honestly: the two cancellation regression tests were written alongside the fix (they park deterministically at the exact await points the audit identified) rather than formally proven red first. A cancellation landing *inside* an inline `destroy_within` await still abandons that bounded, best-effort teardown attempt — the instance is already consumed at that point, never leaked live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pool ordering for idle resources, letting pooled items reuse either FIFO or LIFO behavior.
  * Improved acquire, release, warmup, shutdown, and rotation flows with clearer cancel-safety behavior when operations are interrupted.
* **Bug Fixes**
  * Resource recovery backoff now adds jitter to reduce retry spikes and spread out repeated failures.
  * Acquire and warmup paths now better ensure resources are cleaned up correctly if cancellation happens mid-operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->