### PR TITLE
refactor(credential)!: curate public surface — privatize 7 accidentally-pub internal modules (−1,152 items)

### DIFF
--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -87,9 +87,9 @@ pub mod contract;
 pub mod credentials;
 /// Credential lifecycle as data — `CredentialPolicy` / `RefreshStrategy` /
 /// `RevokeStrategy` (ADR-0088 D2: capabilities are data, not sub-traits).
-pub mod lifecycle;
+pub(crate) mod lifecycle;
 /// Credential operation metrics — counter names and label helpers.
-pub mod metrics;
+pub(crate) mod metrics;
 /// External credential provider abstraction — delegation to external secret managers.
 pub mod provider;
 /// Authentication scheme types — AuthScheme trait, AuthPattern, 12 built-in schemes.
@@ -108,7 +108,7 @@ mod accessor;
 /// Audit trait and value types — [`AuditSink`], [`AuditEvent`],
 /// [`AuditOperation`], [`AuditResult`]. The audit decorator (`AuditLayer`)
 /// stays in `nebula_storage::credential` and imports these from here.
-pub mod audit;
+pub(crate) mod audit;
 /// Credential operation context — CredentialContext, CredentialContextBuilder.
 mod context;
 /// Typed credential reference — `CredentialRef<C>` slot-binding handle (typed ref fields).
@@ -129,11 +129,11 @@ mod record;
 
 /// Dyn-erasure bridge for the two RPITIT storage ports — lets the
 /// `CredentialService` facade be non-generic (ADR-0088 D4).
-pub mod erased;
+pub(crate) mod erased;
 /// Error types for credential operations.
 pub mod error;
 /// Credential lifecycle events for cross-crate signaling.
-pub mod event;
+pub(crate) mod event;
 /// Pending state store trait for interactive credential flows.
 pub mod pending_store;
 /// Credential lifecycle orchestration the execution engine drives —
@@ -143,9 +143,9 @@ pub mod runtime;
 /// `CredentialService` facade — the sole public entry to the credential
 /// management bounded context (ADR-0092, relocated from
 /// `nebula-credential-runtime`).
-pub mod service;
+pub(crate) mod service;
 /// Credential snapshot.
-pub mod snapshot;
+pub(crate) mod snapshot;
 /// Credential store trait with layered composition.
 pub mod store;
 

--- a/crates/credential/src/runtime/resolve_error.rs
+++ b/crates/credential/src/runtime/resolve_error.rs
@@ -126,7 +126,7 @@ pub enum ResolveError {
         /// Why re-authentication is required.
         reason: ReauthReason,
     },
-    /// The service is configured with an external [`StateSource`](crate::service)
+    /// The service is configured with an external [`StateSource`](crate::StateSource)
     /// whose resolution bridge (ADR-0051) is not yet wired, so the resolver
     /// refuses to read local bytes. Fail-closed: never a silent local-store
     /// fallback. The facade maps this to

--- a/crates/credential/src/runtime/resolver.rs
+++ b/crates/credential/src/runtime/resolver.rs
@@ -67,7 +67,7 @@ pub struct CredentialResolver<S: CredentialStore> {
     /// disconnected handles on every resolve/refresh cycle.
     handle_cache: Arc<HandleCache>,
     /// When `true`, the service is configured with an external
-    /// [`StateSource`](crate::service) whose resolution bridge is not yet wired,
+    /// [`StateSource`](crate::StateSource) whose resolution bridge is not yet wired,
     /// so **every** resolution path refuses to read local bytes (fail-closed at
     /// the resolver tail — see [`gate_external_source`](Self::gate_external_source)).
     /// This closes the source gate on the direct-resolver paths
@@ -115,7 +115,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     /// Fail-closed the resolver against an external, not-yet-wired state source.
     ///
     /// Set by the composition root when the service is built with
-    /// [`StateSource::External`](crate::service). Once gated, **every** resolution
+    /// [`StateSource::External`](crate::StateSource). Once gated, **every** resolution
     /// entry point ([`resolve`](Self::resolve) / [`resolve_scoped`](Self::resolve_scoped)
     /// / [`resolve_with_refresh`](Self::resolve_with_refresh), and therefore
     /// [`scheme_factory`](Self::scheme_factory)) returns

--- a/crates/credential/src/service/mod.rs
+++ b/crates/credential/src/service/mod.rs
@@ -10,7 +10,7 @@
 /// `CredentialService` (split from `facade` for size; behaviour-preserving
 /// `impl` block).
 mod acquire;
-pub mod binding;
+pub(crate) mod binding;
 /// Capability operations (`test` / `refresh` / `revoke`) of
 /// `CredentialService` (split from `facade` for size; behaviour-preserving
 /// `impl` block).
@@ -21,16 +21,16 @@ mod crud;
 /// Type-discovery methods of `CredentialService` (split from `facade` for
 /// size; behaviour-preserving `impl` block).
 mod discovery;
-pub mod error;
-pub mod facade;
-pub mod head;
-pub mod observer;
-pub mod ops;
-pub mod scope;
+pub(crate) mod error;
+pub(crate) mod facade;
+pub(crate) mod head;
+pub(crate) mod observer;
+pub(crate) mod ops;
+pub(crate) mod scope;
 /// Slot / binding resolution methods of `CredentialService` (split from
 /// `facade` for size; behaviour-preserving `impl` block).
 mod slot;
-pub mod state_source;
+pub(crate) mod state_source;
 
 pub use binding::{TenantFingerprint, ValidatedCredentialBinding, ValidatedCredentialBindingError};
 pub use error::CredentialServiceError;

--- a/crates/credential/src/store.rs
+++ b/crates/credential/src/store.rs
@@ -101,7 +101,7 @@ pub(crate) const LAST_VALIDATED_AT_METADATA_KEY: &str = "last_validated_at";
 /// `owner_id` that a prior tenant-scope check proved owns it.
 ///
 /// The constructor is crate-private and the only in-crate caller is
-/// [`ValidatedCredentialBinding::owner_scoped_key`](crate::service::binding::ValidatedCredentialBinding),
+/// [`ValidatedCredentialBinding::owner_scoped_key`](crate::ValidatedCredentialBinding),
 /// whose own constructor is reachable only through
 /// `CredentialService::validate_credential_binding` (the owner gate). A caller
 /// therefore cannot *express* an unscoped (cross-tenant) load on the slot


### PR DESCRIPTION
Toward a **Tokio-grade curated public surface** (audit finding F33). External crates consume only ~124 distinct `nebula_credential::` symbols against a **9,083-item** public API (~75× over-exposed).

## What
Privatized the seven internal modules that **no external crate, test, example, or doctest reaches through a module path** — `metrics`, `lifecycle`, `audit`, `event`, `snapshot`, `erased`, `service` — from `pub mod` to `pub(crate) mod`, keeping every externally-consumed item re-exported at the crate root.

Deliberately **kept public**: the DESIGN's intentional escape-hatch modules (`contract`, `secrets`, `credentials`) and the externally-used namespaces (`runtime`, `provider`, `scheme`, `store`, `error`).

## Result
**Public API surface: 9,083 → 7,931 items (−1,152, ~13%)** for a 19-line diff.

## Verified safe
- Mapped each module's usage across external crates **and** credential's own integration tests / examples / doctests (they compile as external crates) — privatized only the 0/0/0 set.
- `cargo fix` applied the `unreachable_pub` cascade (8 `service` submodules → `pub(crate)`); 3 public doc-links repointed from the now-private `crate::service` to their `crate::` root re-exports.
- Whole workspace builds; 421 credential tests + clippy `-D warnings` + rustdoc `-D warnings` (`--document-private-items`) + fmt all green. No external consumer broke.

## Semver note
Technically breaking (removed `nebula_credential::<mod>::…` paths), pre-1.0, **no external consumer uses those paths** — every one of the ~124 consumed symbols still resolves at `nebula_credential::<Name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)