### PR TITLE
chore: Rust 1.96.1 + print/allow-attributes lint gates, purge stale suppressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,14 @@ rc_mutex = "warn"
 arc_with_non_send_sync = "warn"
 # `dbg!` must not ship in non-test code (tests exempt via clippy.toml).
 dbg_macro = "warn"
+# Output goes through `tracing`, not stdout/stderr. The only sanctioned prints
+# are pre/post-tracing edges (telemetry bootstrap/shutdown fallbacks), each
+# marked `#[expect]` at the site (tests exempt via clippy.toml).
+print_stdout = "warn"
+print_stderr = "warn"
+# Prefer `#[expect(...)]` over `#[allow(...)]`: an expectation warns when the
+# suppressed lint stops firing, so stale suppressions can't accumulate.
+allow_attributes = "warn"
 # Pattern-matching recall (Rust Reference + Clippy)
 match_like_matches_macro = "warn"
 redundant_pattern_matching = "warn"

--- a/apps/worker/src/main.rs
+++ b/apps/worker/src/main.rs
@@ -17,6 +17,11 @@
 //! [`CorePlugin`]: nebula_plugin_core::CorePlugin
 //! [`WorkflowEngine`]: nebula_engine::WorkflowEngine
 
+#![expect(
+    clippy::print_stderr,
+    reason = "binary edge: startup/exit errors must reach stderr outside the tracing lifetime"
+)]
+
 mod compose_main;
 
 use compose_main::run;

--- a/crates/action/src/context.rs
+++ b/crates/action/src/context.rs
@@ -739,10 +739,6 @@ pub trait ActionContextExt: HasResources + HasCredentials {
     /// Returns [`ActionError::Fatal`] if the id is not a valid
     /// [`ResourceKey`], the resource is not
     /// registered, or the accessor returns the wrong type.
-    #[allow(
-        clippy::type_complexity,
-        reason = "object-safe Pin<Box<dyn Future>> is required so derive-emitted call sites can dispatch through &dyn ActionContext"
-    )]
     fn acquire_resource_by_id<'a, R>(
         &'a self,
         id: &'a str,
@@ -786,7 +782,7 @@ pub trait ActionContextExt: HasResources + HasCredentials {
     /// Returns [`ActionError::Fatal`] if the id is not a valid
     /// [`CredentialKey`], the credential is not registered, or the auth
     /// scheme does not match `C::Scheme`.
-    #[allow(
+    #[expect(
         clippy::type_complexity,
         reason = "object-safe Pin<Box<dyn Future>> is required so derive-emitted call sites can dispatch through &dyn ActionContext"
     )]

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -187,7 +187,7 @@ pub struct EmailEnvelope {
 
 // guard-justified: the `From` impl exists exclusively to feed the
 // deprecated `EmailEnvelope` type and cannot itself avoid touching it.
-#[allow(deprecated, reason = "shim feeds the deprecated public type")]
+#[expect(deprecated, reason = "shim feeds the deprecated public type")]
 impl From<EmailMessage> for EmailEnvelope {
     fn from(m: EmailMessage) -> Self {
         Self {
@@ -258,7 +258,7 @@ impl InMemoryAuthBackend {
     // guard-justified: this accessor IS the back-compat shim and must
     // return the deprecated `EmailEnvelope` type by contract.
     #[must_use]
-    #[allow(deprecated, reason = "deliberate back-compat shim over EmailEnvelope")]
+    #[expect(deprecated, reason = "deliberate back-compat shim over EmailEnvelope")]
     pub fn emails(&self) -> Vec<EmailEnvelope> {
         self.default_echo
             .as_ref()
@@ -1232,7 +1232,7 @@ impl AuthBackend for InMemoryAuthBackend {
 // guard-justified: the tests below intentionally exercise the
 // deprecated `EmailEnvelope` shim and `emails()` accessor.
 #[cfg(test)]
-#[allow(
+#[expect(
     deprecated,
     reason = "tests still assert on the deprecated `EmailEnvelope` back-compat shim"
 )]

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -545,8 +545,6 @@ fn map_oauth_store_err(err: StoreError, credential_id: &str) -> ApiError {
 }
 
 #[cfg(test)]
-// `SecretString::expose_secret` is HRTB; `|s| s.to_owned()` is the correct pattern.
-#[allow(clippy::redundant_closure_for_method_calls)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/api/src/middleware/tenancy.rs
+++ b/crates/api/src/middleware/tenancy.rs
@@ -32,11 +32,6 @@ use crate::{error::ApiError, state::AppState};
 /// bucket). The `?` maps [`nebula_tenancy::TenancyError`] through the
 /// coarse [`From`] impl (`MissingWorkspace` → 404, `Unauthorized` → 403)
 /// so no tenant-graph detail leaks (spec §6.1).
-//
-// guard-justified: additive seam — wired into the workflow/execution
-// handlers in the following expand-contract commits; dead until the
-// first handler is migrated off the placeholder-scoped `AppState` path.
-#[allow(dead_code)]
 pub(crate) fn request_scope(tenant: &TenantContext) -> Result<Scope, ApiError> {
     Ok(nebula_tenancy::request_scope(tenant)?)
 }

--- a/crates/api/src/ports/credential_builder.rs
+++ b/crates/api/src/ports/credential_builder.rs
@@ -73,7 +73,7 @@ impl<B: CredentialStore + 'static> CredentialServiceBuilder<B> {
     // guard-justified: the ten mandatory collaborators are the secure-construction
     // contract; bundling them into a params struct just moves the arity to that
     // struct's single literal at the call site.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         raw_store: B,
         key_provider: Arc<dyn KeyProvider>,

--- a/crates/api/src/telemetry_init.rs
+++ b/crates/api/src/telemetry_init.rs
@@ -160,6 +160,10 @@ impl TelemetryGuard {
     /// Called automatically on drop, but exposed so binaries that want a deterministic
     /// shutdown point (e.g. after the axum server returns) can drain telemetry before the
     /// process exits.
+    #[expect(
+        clippy::print_stderr,
+        reason = "shutdown-at-exit edge; the subscriber may already be torn down"
+    )]
     pub fn shutdown(&mut self) {
         // Drop metrics first so the discovery task observes the stop flag before the tracer
         // pipeline goes away (the two are independent, but ordering keeps shutdown logs
@@ -202,6 +206,10 @@ impl Drop for TelemetryGuard {
 /// leaking the background batch processor task.
 ///
 /// `RUST_LOG` is honoured by `EnvFilter`; falls back to `info` when unset or malformed.
+#[expect(
+    clippy::print_stderr,
+    reason = "double-init and unused-provider edges must reach operators even when no subscriber accepts events"
+)]
 pub fn init_api_telemetry() -> Result<TelemetryGuard, TelemetryInitError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
 

--- a/crates/api/src/transport/oauth/discovery.rs
+++ b/crates/api/src/transport/oauth/discovery.rs
@@ -465,10 +465,6 @@ pub async fn resolve_provider_endpoints(
 /// module + the `nebula_test_util` cfg-gated `test_support` module
 /// can reach it.
 #[cfg(any(test, nebula_test_util))]
-#[allow(
-    dead_code,
-    reason = "surfaced only through the test_support cfg-gated re-export; in regular `cargo test` the inner cache is not yet exercised"
-)]
 pub(crate) fn clear_discovery_cache_for_tests() {
     cache().clear();
 }

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -1044,7 +1044,7 @@ mod tests {
     ///
     /// Stores the `ActivationHandle` so `dispatch_with_id` / `dispatch_without_id`
     /// can derive the correct `(trigger_uuid, nonce)` webhook key.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct TestFixture {
         transport: WebhookTransport,
         version_store: Arc<InMemoryWorkflowVersionStore>,

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -38,7 +38,7 @@ pub fn ws_path(suffix: &str) -> String {
 }
 
 /// Helper to build an org-scoped API path.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn org_path(suffix: &str) -> String {
     format!("/api/v1/orgs/{TEST_ORG}{suffix}")
 }

--- a/crates/api/tests/credential_facade_lifecycle_e2e.rs
+++ b/crates/api/tests/credential_facade_lifecycle_e2e.rs
@@ -91,7 +91,7 @@ identity_state!(TestScheme, "test_lifecycle_state", 1);
 // at runtime through `FieldValues` in `resolve`, never via direct field access —
 // `dead_code` cannot see those paths on a private test struct.
 #[derive(Schema, Deserialize, Default)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct TestProps {
     /// Initial secret token.
     #[field(secret, label = "Token")]
@@ -213,7 +213,7 @@ impl ExternalProvider for StubExternalProvider {
 
     // guard-justified: the `ExternalProvider` trait fixes the `-> &str` return,
     // so the lint's suggested `-> &'static str` cannot apply to this impl.
-    #[allow(clippy::unnecessary_literal_bound)]
+    #[expect(clippy::unnecessary_literal_bound)]
     fn provider_name(&self) -> &str {
         "stub-vault"
     }

--- a/crates/credential/examples/credential_metadata.rs
+++ b/crates/credential/examples/credential_metadata.rs
@@ -6,6 +6,11 @@
 //! across action/credential/resource. Credential-specific details
 //! (`pattern`) stay on [`CredentialMetadata`] itself.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_credential::CredentialMetadata;
 use nebula_metadata::Metadata;
 use nebula_schema::{Field, Schema, field_key};

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -31,7 +31,6 @@ pub use crate::scheme::oauth2::AuthStyle;
 // from this submodule; the inner items themselves are NOT deprecated,
 // only the legacy `AuthStyle` constant on `oauth2_config` is, and the
 // deprecation surfaces at the caller's import site, not here.
-#[allow(deprecated)]
 pub use oauth2_config::{
     AuthCodeBuilder, ClientCredentialsBuilder, DeviceCodeBuilder, GrantType, OAuth2Config,
     PkceMethod,
@@ -897,7 +896,7 @@ mod tests {
     // (returning `oauth2_http_transport_disabled()`); the trait
     // membership is still required so the engine's revoke / test
     // dispatchers can bind on it once the transport is wired.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn assert_oauth2_capabilities()
     where
         OAuth2Credential: Credential + Interactive + Refreshable + Revocable + Testable,

--- a/crates/credential/src/runtime/lease/scheduler.rs
+++ b/crates/credential/src/runtime/lease/scheduler.rs
@@ -654,7 +654,7 @@ impl Scheduler {
 
     fn update_active_gauge(&self) {
         if let Some(m) = &self.inputs.metrics {
-            #[allow(clippy::cast_precision_loss)] // counts beyond f64 mantissa are not realistic
+            #[expect(clippy::cast_precision_loss)] // counts beyond f64 mantissa are not realistic
             let value = self.registry.len() as f64;
             m.gauge(CredentialMetrics::DYNAMIC_LEASE_ACTIVE, value, &[]);
         }

--- a/crates/credential/src/runtime/refresh/sentinel.rs
+++ b/crates/credential/src/runtime/refresh/sentinel.rs
@@ -100,7 +100,7 @@ impl SentinelTrigger {
 
     // guard-justified: consumed by reclaim-sweep wiring that lands in Stage 3.3; removing
     // silences the compiler but breaks the planned composition root
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn repo(&self) -> &Arc<dyn RefreshClaimRepo> {
         &self.repo
     }

--- a/crates/credential/src/runtime/resolver.rs
+++ b/crates/credential/src/runtime/resolver.rs
@@ -304,7 +304,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     /// parses as a typed [`CredentialId`]. Non-parseable legacy ids fall
     /// back to the L1-only coalescing path. `CoalescedByOtherReplica` is
     /// success — caller re-reads state.
-    #[allow(deprecated)] // Calls deprecated `is_circuit_open` until П3 typed-id migration completes.
+    #[expect(deprecated)] // Calls deprecated `is_circuit_open` until П3 typed-id migration completes.
     pub async fn resolve_with_refresh<C>(
         &self,
         credential_id: &str,
@@ -401,7 +401,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     }
 
     /// Two-tier coordinated refresh path (parseable [`CredentialId`]).
-    #[allow(deprecated)] // Calls deprecated `record_success` / `record_failure` for L1 circuit breaker until П3.
+    #[expect(deprecated)] // Calls deprecated `record_success` / `record_failure` for L1 circuit breaker until П3.
     async fn refresh_via_coordinator<C>(
         &self,
         credential_id: &str,
@@ -555,7 +555,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     /// Mirrors the pre-Stage-2 single-process coalescer behavior: first
     /// caller wins, others wait on a `oneshot::Receiver`, completion
     /// drains all waiters. No L2 claim is acquired.
-    #[allow(deprecated)] // Whole function is the legacy-id fallback; uses deprecated L1 surface until П3.
+    #[expect(deprecated)] // Whole function is the legacy-id fallback; uses deprecated L1 surface until П3.
     async fn refresh_via_l1_only<C>(
         &self,
         credential_id: &str,
@@ -965,7 +965,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
             // `RefreshOutcome` is `#[non_exhaustive]`; this arm is required for
             // forward-compatibility with future variants. Clippy flags it
             // unreachable against current variants — that is the intent.
-            #[allow(unreachable_patterns)]
+            #[expect(unreachable_patterns)]
             _ => {
                 let scheme = C::project(&state);
                 Ok(self.materialize_handle::<C>(credential_id, scheme))

--- a/crates/credential/src/runtime/resolver.rs
+++ b/crates/credential/src/runtime/resolver.rs
@@ -745,7 +745,13 @@ impl<S: CredentialStore> CredentialResolver<S> {
             Ok(Some(RefreshOutcome::Refreshed))
         }
 
-        #[cfg_attr(not(feature = "rotation"), allow(unused_variables))]
+        #[cfg_attr(
+            not(feature = "rotation"),
+            expect(
+                unused_variables,
+                reason = "transport feeds only the rotation-gated oauth2 refresh path"
+            )
+        )]
         let transport = Arc::clone(&self.transport);
         let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), async {
             #[cfg(feature = "rotation")]

--- a/crates/credential/src/service/facade.rs
+++ b/crates/credential/src/service/facade.rs
@@ -193,7 +193,7 @@ impl CredentialService {
     // guard-justified: from_secure_parts mirrors the eight mandatory collaborators
     // the builder composes; bundling them into a struct would just move the
     // arity to that struct's literal at the single call site.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn from_secure_parts(
         store: Arc<dyn DynCredentialStore>,
         scan_store: ErasedCredentialStore,

--- a/crates/credential/tests/dead_pub_audit.rs
+++ b/crates/credential/tests/dead_pub_audit.rs
@@ -2,7 +2,7 @@
 //! either a public symbol was added without intent or one was removed
 //! and we need to update this list.
 
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use nebula_credential::{
     AuthScheme, CredentialContext, CredentialError, CredentialId, CredentialMetadata,
     CredentialRecord, CredentialRegistry, CredentialSnapshot, CredentialState, CredentialStore,

--- a/crates/engine/src/daemon/event_source.rs
+++ b/crates/engine/src/daemon/event_source.rs
@@ -167,11 +167,11 @@ pub struct EventSourceAdapter<E: EventSource> {
     metadata: ActionMetadata,
     // guard-justified: retained as a downstream-observability buffer-size
     // hint; not read on the current adapter path.
-    #[allow(dead_code, reason = "buffer_size hint for downstream observability")]
+    #[expect(dead_code, reason = "buffer_size hint for downstream observability")]
     config: EventSourceConfig,
     // guard-justified: a single boxed-fn field — a type alias would not
     // improve readability over the inline signature.
-    #[allow(
+    #[expect(
         clippy::type_complexity,
         reason = "single field — extracting to a type alias adds no readability"
     )]

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2598,7 +2598,7 @@ impl NodeTask {
 /// be skipped.
 ///
 /// Returns `true` if the error was handled (at least one OnError edge activated).
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn process_outgoing_edges(
     source_id: NodeKey,
     result: Option<&ActionResult<serde_json::Value>>,

--- a/crates/engine/src/engine/frontier.rs
+++ b/crates/engine/src/engine/frontier.rs
@@ -26,7 +26,7 @@ impl WorkflowEngine {
     ///
     /// Returns `Some((node_key, error))` if a node failed without an error handler,
     /// `None` if all reachable nodes completed (or were skipped).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(super) async fn run_frontier(
         &self,
         scope: &Scope,
@@ -810,7 +810,7 @@ impl WorkflowEngine {
             // unit-like timer markers. The size asymmetry is intrinsic
             // to a wake-reason discriminant and acceptable on a path
             // that allocates one value per loop iteration.
-            #[allow(clippy::large_enum_variant)]
+            #[expect(clippy::large_enum_variant)]
             enum WakeReason {
                 Joined(JoinedResult),
                 RetryTimer,
@@ -1975,7 +1975,7 @@ impl WorkflowEngine {
     ///
     /// Returns `true` if the node was spawned, `false` if it failed during setup
     /// (e.g., param resolution error).
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn spawn_node(
         &self,
         node_key: NodeKey,

--- a/crates/engine/src/engine/outcome.rs
+++ b/crates/engine/src/engine/outcome.rs
@@ -282,7 +282,7 @@ pub(super) fn apply_failure_recovery(
 /// strategy with no OnError handler took the failure. Returns `None`
 /// when routing completed cleanly (OnError handled, ContinueOnError
 /// resolved, or IgnoreErrors routed-as-success).
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(super) fn route_failure_edges(
     outcome: FailureOutcome,
     node_key: NodeKey,

--- a/crates/engine/src/engine/persistence.rs
+++ b/crates/engine/src/engine/persistence.rs
@@ -18,7 +18,7 @@ impl WorkflowEngine {
     /// Returns `true` when the node was short-circuited (caller should `continue`
     /// to the next ready queue entry). Returns `false` when the node should be
     /// dispatched normally.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(super) async fn check_and_apply_idempotency(
         &self,
         scope: &Scope,
@@ -216,7 +216,7 @@ impl WorkflowEngine {
     /// error to `run_frontier`'s caller. The real durability gap —
     /// `save_node_output` after panic — is already logged by
     /// `checkpoint_node` itself.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "mirrors checkpoint_node's arity; the fencing token is required by the \
                   dual-dispatch storage seam"
@@ -269,7 +269,7 @@ impl WorkflowEngine {
     // borrow checker then prevents any caller from substituting an alternate
     // scope. Combined with the fencing token this pushes past the 7-arg
     // threshold that is designed for public APIs.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(super) async fn checkpoint_node(
         &self,
         scope: &Scope,
@@ -325,7 +325,7 @@ impl WorkflowEngine {
     /// `resume_tokens` is non-empty only on signal-park commits (W-S3c);
     /// the batch builder defaults to empty so non-park checkpoints are
     /// unaffected.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn checkpoint_node_port(
         &self,
         scope: &Scope,

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -31,7 +31,7 @@ pub mod queue;
 pub mod registry;
 pub mod runner;
 // guard-justified: module_inception is intentional — runtime/runtime.rs carries ActionRuntime; kept stable for external callers
-#[allow(
+#[expect(
     clippy::module_inception,
     reason = "runtime/runtime.rs carries ActionRuntime; kept stable for external callers"
 )]

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -353,7 +353,7 @@ impl ActionRuntime {
     /// fresh `ActionHandle` via [`ActionFactory::instantiate`], and dispatches it
     /// through [`Self::run_factory`]. Returns
     /// [`RuntimeError::ActionNotFound`] if no factory is registered for the key.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn dispatch_action(
         &self,
         action_key_str: &str,
@@ -398,7 +398,7 @@ impl ActionRuntime {
     /// for instantiate failures so dashboards reflect the per-dispatch cost
     /// regardless of whether the failure happened in instantiation or
     /// during the action itself.
-    #[allow(
+    #[expect(
         clippy::too_many_arguments,
         reason = "private dispatch entry — splitting into a struct hides the metric/observe contract from the call site"
     )]
@@ -413,7 +413,7 @@ impl ActionRuntime {
         checkpoint: Option<Arc<dyn StatefulCheckpointSink>>,
     ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
         let error_counter = &self.action_failures_total;
-        #[allow(
+        #[expect(
             clippy::unwrap_or_default,
             reason = "ExecutionId::new() != Default::default()"
         )]

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -122,7 +122,7 @@ impl ResourceConfig for WitnessResourceConfig {
 }
 
 #[derive(Debug)]
-#[allow(dead_code, reason = "fields exist for diagnostics on lease inspection")]
+#[expect(dead_code, reason = "fields exist for diagnostics on lease inspection")]
 struct WitnessResourceInner {
     instance_id: u64,
     label: String,

--- a/crates/engine/tests/resource_rotation_redaction.rs
+++ b/crates/engine/tests/resource_rotation_redaction.rs
@@ -213,7 +213,7 @@ struct SecretBearingResource {
     /// The dispatch borrows the runtime, not this cell, so it is not
     /// read directly — its presence makes the secret reachable through
     /// the resolved slot the engine rotates.
-    #[allow(
+    #[expect(
         dead_code,
         reason = "models the author-declared resolved SlotCell; rotation dispatch borrows the runtime, not this cell"
     )]

--- a/crates/engine/tests/resource_rotation_wiring_redaction.rs
+++ b/crates/engine/tests/resource_rotation_wiring_redaction.rs
@@ -139,7 +139,7 @@ struct SecretRuntime {
 
 #[derive(Clone)]
 struct SecretRes {
-    #[allow(
+    #[expect(
         dead_code,
         reason = "models the author-declared resolved SlotCell; the hook borrows the runtime, not this cell — its presence makes the secret reachable through the resolved slot the fan-out rotates"
     )]

--- a/crates/env/src/testing.rs
+++ b/crates/env/src/testing.rs
@@ -43,7 +43,7 @@ impl EnvGuard {
         self.remember(key);
         // guard-justified: edition-2024 set_var is unsafe; the held lock
         // serializes all env mutation so no other thread races this write.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         // SAFETY: `self._lock` is held for the lifetime of this guard, so no
         // concurrent reader or writer of the environment can observe a torn
         // state during this single-threaded mutation.
@@ -57,7 +57,7 @@ impl EnvGuard {
         self.remember(key);
         // guard-justified: edition-2024 remove_var is unsafe; serialized by
         // the held process-global lock, same invariant as `set`.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         // SAFETY: the held lock serializes this mutation; see `set`.
         unsafe {
             std::env::remove_var(key);
@@ -76,7 +76,7 @@ impl Drop for EnvGuard {
         for (key, prior) in &self.saved {
             // guard-justified: restoring env on drop is unsafe under edition
             // 2024 but serialized by the still-held lock.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             // SAFETY: the lock is held until this Drop completes, so the
             // restore is serialized against all other env access.
             unsafe {

--- a/crates/eventbus/examples/subscriber_patterns.rs
+++ b/crates/eventbus/examples/subscriber_patterns.rs
@@ -6,6 +6,11 @@
 //! 3. Lag monitoring with lagged_count()
 //! 4. Multi-bus registry pattern
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::sync::Arc;
 
 use nebula_eventbus::{BackPressurePolicy, EventBus, EventBusRegistry, EventFilter};

--- a/crates/expression/src/builtins.rs
+++ b/crates/expression/src/builtins.rs
@@ -234,7 +234,7 @@ pub(crate) fn check_min_arg_count(
 }
 
 /// Helper to extract a lambda expression from args
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn extract_lambda(arg: &Expr) -> ExpressionResult<(&str, &Expr)> {
     match arg {
         Expr::Lambda { param, body } => Ok((param, body)),

--- a/crates/log/Cargo.toml
+++ b/crates/log/Cargo.toml
@@ -104,6 +104,16 @@ name = "sentry_setup"
 path = "examples/sentry_setup.rs"
 required-features = ["sentry"]
 
+[[example]]
+name = "async_timing"
+path = "examples/async_timing.rs"
+required-features = ["async"]
+
+[[example]]
+name = "context_propagation"
+path = "examples/context_propagation.rs"
+required-features = ["async"]
+
 [[bench]]
 name = "log_hot_path"
 harness = false

--- a/crates/log/examples/custom_observability.rs
+++ b/crates/log/examples/custom_observability.rs
@@ -6,6 +6,11 @@
 //! - Integration with external monitoring systems
 //! - Advanced observability patterns
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -127,7 +132,7 @@ impl ObservabilityEvent for UserActionEvent {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum HealthStatus {
     Healthy,
     Degraded,
@@ -197,7 +202,7 @@ impl ObservabilityEvent for BusinessMetricEvent {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ErrorSeverity {
     Low,
     Medium,

--- a/crates/log/examples/file_logging.rs
+++ b/crates/log/examples/file_logging.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    not(feature = "file"),
+    expect(
+        clippy::print_stdout,
+        reason = "fallback branch prints the missing-feature hint"
+    )
+)]
+
 #[cfg(feature = "file")]
 use nebula_log::{Config, Format, Rolling, WriterConfig};
 

--- a/crates/log/examples/multi_crate_observability.rs
+++ b/crates/log/examples/multi_crate_observability.rs
@@ -9,6 +9,11 @@
 //! - Event correlation and tracing
 //! - Centralized observability configuration
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},

--- a/crates/log/examples/observability_hooks.rs
+++ b/crates/log/examples/observability_hooks.rs
@@ -6,6 +6,11 @@
 //! 3. Use built-in hooks (logging)
 //! 4. Track operation lifecycle
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     sync::{
         Arc,

--- a/crates/log/examples/resource_based_observability.rs
+++ b/crates/log/examples/resource_based_observability.rs
@@ -8,6 +8,11 @@
 //! - Event filtering
 //! - Resource-aware hooks
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::sync::Arc;
 
 use nebula_log::observability::{

--- a/crates/log/examples/sentry_test.rs
+++ b/crates/log/examples/sentry_test.rs
@@ -1,5 +1,10 @@
 //! Sentry integration test example
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::env;
 
 use anyhow::Result;
@@ -7,7 +12,7 @@ use nebula_log::prelude::*;
 use tokio::time::{Duration, sleep};
 
 #[tokio::main]
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 async fn main() -> Result<()> {
     // Set Sentry DSN for testing
     unsafe {

--- a/crates/log/examples/span_like_resources.rs
+++ b/crates/log/examples/span_like_resources.rs
@@ -3,6 +3,11 @@
 //! Demonstrates how resources automatically merge from parent contexts,
 //! similar to how `tracing` spans inherit attributes.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_log::observability::{
     ExecutionContext, LogLevel, LoggerResource, NodeContext, ObservabilityEvent,
     ResourceAwareAdapter, ResourceAwareHook, emit_event, get_current_logger_resource,

--- a/crates/log/src/builder/mod.rs
+++ b/crates/log/src/builder/mod.rs
@@ -41,7 +41,6 @@ pub struct LoggerBuilder {
 pub struct LoggerGuard {
     /// RAII guard - field must exist even if never accessed directly
     /// to keep file guards and other resources alive
-    #[allow(dead_code)]
     inner: Option<Box<Inner>>,
 }
 
@@ -295,6 +294,13 @@ impl LoggerGuard {
 }
 
 impl Drop for LoggerGuard {
+    #[cfg_attr(
+        feature = "telemetry",
+        expect(
+            clippy::print_stderr,
+            reason = "shutdown-at-exit edge; the subscriber may already be torn down"
+        )
+    )]
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take() {
             // Drop root span first so pending spans are closed

--- a/crates/log/src/builder/telemetry.rs
+++ b/crates/log/src/builder/telemetry.rs
@@ -12,7 +12,16 @@
 ///
 /// # Feature flags
 /// - `sentry`: Enables Sentry integration
-pub(super) fn init_telemetry(#[allow(unused_variables)] inner: &mut super::Inner) {
+pub(super) fn init_telemetry(
+    #[cfg_attr(
+        not(feature = "sentry"),
+        expect(
+            unused_variables,
+            reason = "only the sentry integration reads the inner state"
+        )
+    )]
+    inner: &mut super::Inner,
+) {
     // Initialize Sentry if enabled
     #[cfg(feature = "sentry")]
     {

--- a/crates/log/src/config/writer.rs
+++ b/crates/log/src/config/writer.rs
@@ -129,7 +129,7 @@ impl Default for DisplayConfig {
     }
 }
 
-#[allow(dead_code)]
+#[cfg(feature = "file")]
 fn default_non_blocking() -> bool {
     true
 }
@@ -138,6 +138,7 @@ fn default_non_blocking() -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "file")]
     #[test]
     fn default_non_blocking_is_true() {
         assert!(default_non_blocking());

--- a/crates/log/src/layer/context.rs
+++ b/crates/log/src/layer/context.rs
@@ -53,11 +53,11 @@ mod storage {
     }
 
     #[inline]
-    pub fn current() -> Arc<Context> {
+    pub(crate) fn current() -> Arc<Context> {
         CTX.with(|c| c.borrow().clone())
     }
 
-    pub fn with_ctx_sync<R>(ctx: Arc<Context>, f: impl FnOnce() -> R) -> R {
+    pub(crate) fn with_ctx_sync<R>(ctx: Arc<Context>, f: impl FnOnce() -> R) -> R {
         CTX.with(|cell| {
             let prev = cell.borrow().clone();
             *cell.borrow_mut() = ctx;

--- a/crates/log/src/observability/context.rs
+++ b/crates/log/src/observability/context.rs
@@ -209,16 +209,16 @@ mod storage {
     }
 
     #[inline]
-    pub fn current_execution() -> Option<Arc<ExecutionContext>> {
+    pub(crate) fn current_execution() -> Option<Arc<ExecutionContext>> {
         EXECUTION_CTX.with(|ctx| ctx.borrow().clone())
     }
 
     #[inline]
-    pub fn current_node() -> Option<Arc<NodeContext>> {
+    pub(crate) fn current_node() -> Option<Arc<NodeContext>> {
         NODE_CTX.with(|ctx| ctx.borrow().clone())
     }
 
-    pub fn with_execution_sync<R>(ctx: Arc<ExecutionContext>, f: impl FnOnce() -> R) -> R {
+    pub(crate) fn with_execution_sync<R>(ctx: Arc<ExecutionContext>, f: impl FnOnce() -> R) -> R {
         EXECUTION_CTX.with(|cell| {
             let prev = cell.borrow_mut().replace(ctx);
             let result = f();
@@ -227,7 +227,7 @@ mod storage {
         })
     }
 
-    pub fn with_node_sync<R>(ctx: Arc<NodeContext>, f: impl FnOnce() -> R) -> R {
+    pub(crate) fn with_node_sync<R>(ctx: Arc<NodeContext>, f: impl FnOnce() -> R) -> R {
         NODE_CTX.with(|cell| {
             let prev = cell.borrow_mut().replace(ctx);
             let result = f();

--- a/crates/log/src/telemetry/otel.rs
+++ b/crates/log/src/telemetry/otel.rs
@@ -187,6 +187,10 @@ pub(crate) fn install_globals(provider: &SdkTracerProvider) {
 /// Uses `eprintln!` rather than `tracing::error!` because this runs only after
 /// `try_init` failed, so the tracing dispatcher is not installed — a
 /// `tracing::error!` call would silently go to the global no-op dispatcher.
+#[expect(
+    clippy::print_stderr,
+    reason = "runs only after try_init failed, so no tracing dispatcher is installed (see doc comment)"
+)]
 pub(crate) fn shutdown_unused_provider(provider: SdkTracerProvider) {
     if let Err(e) = provider.shutdown() {
         eprintln!("nebula-log: unused OTel provider shutdown error: {e}");

--- a/crates/log/src/telemetry/sentry.rs
+++ b/crates/log/src/telemetry/sentry.rs
@@ -40,6 +40,10 @@ pub(crate) fn init() -> Option<ClientInitGuard> {
 /// `LoggerBuilder::build` *before* `try_init` installs the tracing subscriber,
 /// so a `tracing::warn!` alone would land on the global no-op dispatcher and
 /// be dropped.
+#[expect(
+    clippy::print_stderr,
+    reason = "invalid-DSN edge runs before the tracing dispatcher can be trusted; mirrored to stderr for operators"
+)]
 fn init_from_dsn(
     dsn: &str,
     environment: String,

--- a/crates/metrics/examples/cardinality_guard.rs
+++ b/crates/metrics/examples/cardinality_guard.rs
@@ -13,6 +13,11 @@
 //! cargo run -p nebula-metrics --example cardinality_guard
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::time::Duration;
 
 use nebula_metrics::{LabelAllowlist, MetricsRegistry, naming::NEBULA_ACTION_EXECUTIONS_TOTAL};

--- a/crates/metrics/examples/prometheus_export.rs
+++ b/crates/metrics/examples/prometheus_export.rs
@@ -9,6 +9,11 @@
 //! cargo run -p nebula-metrics --example prometheus_export
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_metrics::{
     MetricsRegistry,
     naming::{

--- a/crates/metrics/src/otlp.rs
+++ b/crates/metrics/src/otlp.rs
@@ -165,6 +165,10 @@ impl OtlpMetricsGuard {
     ///
     /// Called automatically on `Drop`; exposed so callers that want a deterministic shutdown
     /// (e.g. after `axum::serve` returns) can drain exports before process exit.
+    #[expect(
+        clippy::print_stderr,
+        reason = "shutdown-at-exit edge; tracing dispatch may already be torn down"
+    )]
     pub fn shutdown(&mut self) {
         self.stop.store(true, Ordering::SeqCst);
         if let Some(provider) = self.provider.take()

--- a/crates/resilience/src/circuit_breaker.rs
+++ b/crates/resilience/src/circuit_breaker.rs
@@ -304,7 +304,7 @@ fn byte_sum(slice: &[u8]) -> u32 {
 /// SSE2 SIMD path: `psadbw` sums 16 bytes per iteration into two u64 lanes.
 /// SSE2 is guaranteed on all x86-64 CPUs — no runtime feature check needed.
 #[cfg(target_arch = "x86_64")]
-#[allow(
+#[expect(
     unsafe_code,
     clippy::cast_ptr_alignment,
     clippy::cast_possible_truncation,
@@ -1104,7 +1104,7 @@ impl std::fmt::Debug for CircuitBreaker {
 /// Uses fixed-point scaling (`count * SCALE >= threshold_scaled * total`) to avoid
 /// `cvtsi2sd` false-dependency stalls on Intel CPUs. Precision: 6 decimal places.
 // Reason: casts are safe — u32 * 1_000_000 fits in u64, threshold in [0.0, 1.0].
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_precision_loss

--- a/crates/resilience/src/hedge.rs
+++ b/crates/resilience/src/hedge.rs
@@ -242,7 +242,7 @@ impl HedgeExecutor {
                 // Fire the next hedge after the configured delay.
                 () = &mut delay, if hedges_sent < self.config.max_hedges => {
                     // Reason: max_hedges is a small config value, never exceeds u32.
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     let hedge_num = (hedges_sent + 1) as u32;
                     self.sink.record(ResilienceEvent::HedgeFired { hedge_number: hedge_num });
                     set.spawn(operation());
@@ -439,12 +439,9 @@ impl LatencyTracker {
         }
     }
 
-    // Reason: u128 nanosecond values from Duration::as_nanos() are truncated to u64
-    // (max ~584 years), and f64 precision loss is acceptable for percentile calculations.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_precision_loss
+        reason = "u128 nanoseconds from Duration::as_nanos() truncate to u64 (max ~584 years)"
     )]
     pub fn record(&mut self, latency: Duration) {
         let nanos = latency.as_nanos() as u64;
@@ -468,7 +465,7 @@ impl LatencyTracker {
     }
 
     // Reason: f64 precision loss and sign loss are acceptable for percentile index calculation.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         clippy::cast_precision_loss

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -1199,7 +1199,6 @@ fn classify_error_cb_outcome(
 }
 
 /// Execute the Retry step of the pipeline.
-#[allow(clippy::excessive_nesting)]
 async fn run_retry_step<T, E, F>(
     config: &RetryConfig<E>,
     ctx: PipelineRunContext<E>,

--- a/crates/resilience/src/rate_limiter.rs
+++ b/crates/resilience/src/rate_limiter.rs
@@ -564,7 +564,7 @@ impl LeakyBucket {
     }
 
     // Reason: f64/usize conversions are acceptable for approximate leak accounting.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_precision_loss,
         clippy::cast_sign_loss
@@ -627,7 +627,7 @@ impl RateLimiter for LeakyBucket {
 
     // Reason: f64 leak amount cast to usize and usize capacity cast to f64 — acceptable for rate
     // reporting.
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
@@ -897,7 +897,7 @@ impl AdaptiveRateLimiter {
     /// (`refill_rate` 0.001..=10,000, derived capacity 1..=100,000), if
     /// `min_rate > max_rate`, or if `initial_rate` is outside `[min_rate, max_rate]`.
     // Reason: f64 rates cast to usize for token bucket capacity — acceptable for rate limiting.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub fn new(
         initial_rate: f64,
         min_rate: f64,
@@ -991,7 +991,7 @@ impl AdaptiveRateLimiter {
     /// Perform the rate adjustment. Caller must hold the write lock.
     // Reason: u64 counts cast to f64 for rate calculation, and f64 rate cast to usize for
     // token bucket capacity — acceptable for approximate rate limiting.
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
@@ -1091,7 +1091,7 @@ impl RateLimiter for AdaptiveRateLimiter {
     }
 
     // Reason: f64 rate cast to usize for token bucket capacity — acceptable for rate limiting.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     async fn reset(&self) {
         self.success_count.store(0, Ordering::Relaxed);
         self.error_count.store(0, Ordering::Relaxed);

--- a/crates/resilience/src/retry.rs
+++ b/crates/resilience/src/retry.rs
@@ -127,14 +127,11 @@ impl BackoffConfig {
     /// Compute the delay for the given zero-based attempt number.
     ///
     /// Useful for integrators building custom retry loops outside of [`retry_with`].
-    // Reason: u128 millis cast to f64 for exponential math, f64 result cast to u64 for Duration,
-    // and u32 attempt cast to i32 for powi are all acceptable within configured retry bounds.
     #[must_use]
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_possible_wrap
+        clippy::cast_possible_wrap,
+        reason = "u128 millis cast to f64 for exponential math and u32 attempt to i32 for powi stay within configured retry bounds"
     )]
     pub fn delay_for(&self, attempt: u32) -> Duration {
         match self {
@@ -191,7 +188,7 @@ fn normalize_exponential_multiplier(multiplier: f64) -> f64 {
     }
 }
 
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -146,8 +146,7 @@ pub struct ResourceGuard<R: Provider> {
     /// time" without any `Drop`-path logic. `None` when the resource declared
     /// no hold deadline (the common case — zero cost).
     // Held only for its `Drop`: the watchdog observes liveness via a `Weak`
-    // upgrade, never by reading this field, so `dead_code` is expected.
-    #[allow(dead_code)]
+    // upgrade, never by reading this field.
     hold_token: Option<Arc<()>>,
 }
 

--- a/crates/resource/src/manager/registration.rs
+++ b/crates/resource/src/manager/registration.rs
@@ -497,7 +497,7 @@ impl Manager {
     // guard-justified: irreducible engine ABI — the engine registrar dispatches
     // positionally with a JSON-driven shape; collapsing to a struct reintroduces
     // the navigation hop the single register funnel removed. See issue #718.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[tracing::instrument(
         level = "debug",
         target = "nebula_resource::register_resolved",

--- a/crates/resource/src/topology/contract.rs
+++ b/crates/resource/src/topology/contract.rs
@@ -449,7 +449,7 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     // `entry` argument is consumed — `into_*` names the entry→instance
     // conversion, not a `self`-consuming builder, so wrong_self_convention is a
     // false match here.
-    #[allow(
+    #[expect(
         clippy::wrong_self_convention,
         reason = "topology is borrowed, the entry argument is consumed; the conversion is entry→instance"
     )]

--- a/crates/resource/tests/bounded_topology.rs
+++ b/crates/resource/tests/bounded_topology.rs
@@ -38,7 +38,7 @@ impl ResourceConfig for SeatCfg {
 /// A leased "seat" carrying a unique id.
 #[derive(Clone)]
 struct Seat(
-    #[allow(
+    #[expect(
         dead_code,
         reason = "id carried by the handle; counters are the observable"
     )]

--- a/crates/resource/tests/custom_topology_manager.rs
+++ b/crates/resource/tests/custom_topology_manager.rs
@@ -53,7 +53,7 @@ impl ResourceConfig for FfmpegCfg {
 /// directly in assertions (the destroy/create counters are the observables).
 #[derive(Clone)]
 struct Transcoder(
-    #[allow(
+    #[expect(
         dead_code,
         reason = "entry identity carried by the handle, not asserted on directly"
     )]

--- a/crates/resource/tests/dx_audit.rs
+++ b/crates/resource/tests/dx_audit.rs
@@ -84,7 +84,6 @@ struct FakeHttpClient {
 }
 
 #[derive(Clone)]
-#[allow(dead_code)]
 struct HttpClientConfig {
     base_url: String,
     pool_size: u32,

--- a/crates/resource/tests/dx_evaluation.rs
+++ b/crates/resource/tests/dx_evaluation.rs
@@ -318,7 +318,6 @@ async fn use_case_2_resident_config_store() {
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 struct DbConfig {
     dsn: String,
     pool_size: u32,

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -86,7 +86,7 @@ mod counting {
         /// model the engine having resolved the credential before
         /// `create`; the rotation hooks act on the runtime, not this cell,
         /// so it is not read directly in these tests.
-        #[allow(
+        #[expect(
             dead_code,
             reason = "models the author-declared SlotCell field; rotation dispatch borrows the runtime, not this cell"
         )]

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -30,10 +30,6 @@ use serde_json::json;
 // ── Test resource ──────────────────────────────────────────────────────────
 
 #[derive(Clone, Debug, Deserialize)]
-#[allow(
-    dead_code,
-    reason = "fields exercised through ResourceConfig::validate + serde::Deserialize, not direct read"
-)]
 struct PgConfig {
     host: String,
     #[serde(default = "default_port")]

--- a/crates/resource/tests/register_from_value_rejects_secret.rs
+++ b/crates/resource/tests/register_from_value_rejects_secret.rs
@@ -39,10 +39,6 @@ use serde_json::json;
 // `password` — is outside the typed `R::Config` surface and must be refused.
 
 #[derive(Clone, Debug, Deserialize)]
-#[allow(
-    dead_code,
-    reason = "fields exercised via the HasSchema closed-set guard + serde::Deserialize, not direct read"
-)]
 struct DbConfig {
     host: String,
     #[serde(default = "default_port")]

--- a/crates/resource/tests/resource_config_derive.rs
+++ b/crates/resource/tests/resource_config_derive.rs
@@ -109,7 +109,7 @@ struct SkipFieldCfg {
     /// Excluded from fingerprint — changing this alone must not trigger hot-reload.
     // guard-justified: the field is under test precisely for being skipped by
     // the fingerprint fold; it is set but never read, which is the point.
-    #[allow(
+    #[expect(
         dead_code,
         reason = "exercised via skip_fingerprint, intentionally never read"
     )]

--- a/crates/schema/examples/async_resolve.rs
+++ b/crates/schema/examples/async_resolve.rs
@@ -4,6 +4,11 @@
 //! Run:
 //! `cargo run -p nebula-schema --example async_resolve`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 use nebula_schema::{
     EvalFuture, ExpressionAst, ExpressionContext, Field, FieldValues, Schema, field_key,
 };

--- a/crates/schema/examples/builder_validate.rs
+++ b/crates/schema/examples/builder_validate.rs
@@ -4,6 +4,11 @@
 //! Run:
 //! `cargo run -p nebula-schema --example builder_validate`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 use nebula_schema::{Field, FieldValues, Schema, field_key};
 use serde_json::json;
 

--- a/crates/schema/examples/conditional_fields.rs
+++ b/crates/schema/examples/conditional_fields.rs
@@ -4,6 +4,11 @@
 //! Run:
 //! `cargo run -p nebula-schema --example conditional_fields`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 use nebula_schema::prelude::*;
 use serde_json::json;
 

--- a/crates/schema/examples/derive_config.rs
+++ b/crates/schema/examples/derive_config.rs
@@ -4,6 +4,11 @@
 //! Run:
 //! `cargo run -p nebula-schema --example derive_config`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 use nebula_schema::{FieldValues, HasSchema, Schema};
 use serde::Deserialize;
 use serde_json::json;

--- a/crates/schema/examples/json_schema_export.rs
+++ b/crates/schema/examples/json_schema_export.rs
@@ -3,6 +3,11 @@
 //! Run:
 //! `cargo run -p nebula-schema --example json_schema_export --features schemars`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 use nebula_schema::{Field, FieldKey, Schema};
 use serde_json::Value;
 

--- a/crates/schema/examples/outbound_http_connector.rs
+++ b/crates/schema/examples/outbound_http_connector.rs
@@ -4,6 +4,11 @@
 //!
 //! Run: `cargo run -p nebula-schema --example outbound_http_connector`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 include!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/examples_include/outbound_http_connector_shared.rs"

--- a/crates/schema/examples/telegram_send_message.rs
+++ b/crates/schema/examples/telegram_send_message.rs
@@ -6,6 +6,11 @@
 //!
 //! Run: `cargo run -p nebula-schema --example telegram_send_message`
 
+#![expect(
+    clippy::print_stderr,
+    reason = "example: errors are reported to stderr"
+)]
+
 include!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/examples_include/telegram_send_message_shared.rs"

--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -145,7 +145,13 @@ impl Expression {
     }
 
     /// Build a parse error tagged for this expression.
-    #[allow(dead_code)]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "currently exercised only by unit tests; the expression parser wires this in"
+        )
+    )]
     pub(crate) fn parse_error(
         &self,
         msg: impl Into<std::borrow::Cow<'static, str>>,

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -338,7 +338,7 @@ macro_rules! define_field {
             /// For use by builders and derive-macro code that has already validated
             /// the key. Callers must ensure uniqueness themselves.
             #[must_use]
-            #[allow(dead_code)] // used by derive-macro code (not yet generated)
+            #[expect(dead_code)] // used by derive-macro code (not yet generated)
             pub(crate) fn read_alias_unchecked(mut self, key: FieldKey) -> Self {
                 self.read_aliases.push_unchecked(key);
                 self
@@ -349,7 +349,7 @@ macro_rules! define_field {
             /// For use by builders and derive-macro code that has already validated
             /// the key.
             #[must_use]
-            #[allow(dead_code)] // used by derive-macro code (not yet generated)
+            #[expect(dead_code)] // used by derive-macro code (not yet generated)
             pub(crate) fn emit_as_unchecked(mut self, key: FieldKey) -> Self {
                 self.emit_as = Some(key);
                 self
@@ -1150,7 +1150,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_string(key: impl AsRef<str>) -> Result<StringField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(StringField::with_key(key))
@@ -1167,7 +1167,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_secret(key: impl AsRef<str>) -> Result<SecretField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(SecretField::with_key(key))
@@ -1184,7 +1184,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_number(key: impl AsRef<str>) -> Result<NumberField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(NumberField::with_key(key))
@@ -1201,7 +1201,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_integer(key: impl AsRef<str>) -> Result<NumberField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(NumberField::with_key(key).integer())
@@ -1235,7 +1235,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_boolean(key: impl AsRef<str>) -> Result<BooleanField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(BooleanField::with_key(key))
@@ -1252,7 +1252,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_select(key: impl AsRef<str>) -> Result<SelectField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(SelectField::with_key(key))
@@ -1269,7 +1269,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_object(key: impl AsRef<str>) -> Result<ObjectField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(ObjectField::with_key(key))
@@ -1286,7 +1286,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_list(key: impl AsRef<str>) -> Result<ListField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(ListField::with_key(key))
@@ -1304,7 +1304,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_mode(key: impl AsRef<str>) -> Result<ModeField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(ModeField::with_key(key))
@@ -1321,7 +1321,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_code(key: impl AsRef<str>) -> Result<CodeField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(CodeField::with_key(key))
@@ -1338,7 +1338,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_file(key: impl AsRef<str>) -> Result<FileField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(FileField::with_key(key))
@@ -1355,7 +1355,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_computed(key: impl AsRef<str>) -> Result<ComputedField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(ComputedField::with_key(key))
@@ -1372,7 +1372,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_dynamic(key: impl AsRef<str>) -> Result<DynamicField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(DynamicField::with_key(key))
@@ -1389,7 +1389,7 @@ impl Field {
     /// # Errors
     ///
     /// Returns `invalid_key` when `key` cannot be parsed into a [`FieldKey`].
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_notice(key: impl AsRef<str>) -> Result<NoticeField, ValidationError> {
         let key = Self::parse_key_or_error(key.as_ref())?;
         Ok(NoticeField::with_key(key))

--- a/crates/schema/src/prelude.rs
+++ b/crates/schema/src/prelude.rs
@@ -35,10 +35,9 @@ mod coverage_smoke {
     //! Fails to compile if an item listed in the prelude doc comment stops
     //! being re-exported. Add any newly-documented item here.
 
-    #[allow(unused_imports)]
     use super::*;
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn touch_all_reexports() {
         fn _j<T: HasSchema>(_: &T) {}
         fn _k<T: HasSelectOptions>(_: &T) {}

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -195,7 +195,7 @@ fn parse_top_level_key(key: &str) -> Result<crate::key::FieldKey, ValidationErro
         .map_err(|e| ValidationError::invalid_key(FieldPath::root(), key, e.message))
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -207,7 +207,7 @@ pub(crate) fn resolve_select_loader_key(
     resolve_select_loader_path(fields, &path)
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -222,7 +222,7 @@ pub(crate) fn resolve_select_loader_path(
     loader_key_or_error(select.loader.as_deref(), path)
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -234,7 +234,7 @@ pub(crate) fn resolve_dynamic_loader_key(
     resolve_dynamic_loader_path(fields, &path)
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -249,7 +249,7 @@ pub(crate) fn resolve_dynamic_loader_path(
     loader_key_or_error(dynamic.loader.as_deref(), path)
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -265,7 +265,7 @@ fn loader_type_mismatch(path: &FieldPath, expected: &str, actual: &str) -> Valid
 }
 
 /// Look up a named child field under `parent_path`, returning the child and its full path.
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]
@@ -281,7 +281,7 @@ fn find_named_child<'a>(
     }
 }
 
-#[allow(
+#[expect(
     clippy::result_large_err,
     reason = "ValidationError is intentionally large; callers are on the validation path"
 )]

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -162,7 +162,7 @@ fn derive_handles_vec_and_nested_user_type() {
 }
 
 #[derive(Schema)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct WithSkip {
     keep: String,
     #[field(skip)]
@@ -178,7 +178,7 @@ fn derive_respects_skip() {
 
 #[derive(Schema)]
 #[schema(reserved("legacy_token", "v1_secret"))]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct WithReservedKeys {
     name: String,
     enabled: bool,
@@ -197,7 +197,7 @@ fn derive_reserved_keys_do_not_materialize_or_block_other_fields() {
 
 #[derive(Schema)]
 #[schema(reserved("dropped"))]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct ReservedMatchesSkippedField {
     keep: String,
     // A skipped field has no wire key, so reserving its name is not a collision —
@@ -219,7 +219,7 @@ fn derive_reserved_key_matching_a_skipped_field_is_allowed() {
 
 #[derive(Schema, serde::Deserialize)]
 #[schema(reserved("removed"))]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct AliasDoesNotCollide {
     // An alias that does NOT match a reserved key is allowed — only a collision
     // is rejected, aliases are not blanket-forbidden on reserved-key structs.
@@ -292,7 +292,7 @@ fn derive_enum_select_field_becomes_select() {
 }
 
 #[derive(Schema)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct Uses {
     #[field(label = "Plain string")]
     value: String,
@@ -505,10 +505,6 @@ fn derive_same_field_read_and_emit_as_reuse_builds() {
 
 #[derive(Schema, serde::Deserialize)]
 #[expect(dead_code, reason = "exercised via HasSchema::schema")]
-#[allow(
-    unreachable_patterns,
-    reason = "serde emits a duplicate match arm for the repeated alias"
-)]
 struct DuplicateAlias {
     #[serde(alias = "alt", alias = "alt")]
     name: String,
@@ -540,7 +536,7 @@ fn derive_duplicate_serde_alias_is_deduped_not_rejected() {
 /// An enum with no `rename_all` annotation: serde keeps variant names verbatim
 /// but EnumSelect converts them to heck snake_case.
 #[derive(EnumSelect, serde::Serialize, Clone, Copy)]
-#[allow(dead_code)] // AnotherOne is exercised only via select_options(), not direct construction
+#[expect(dead_code)] // AnotherOne is exercised only via select_options(), not direct construction
 enum NoPolicyEnum {
     SimpleVariant,
     AnotherOne,

--- a/crates/schema/tests/derive_union.rs
+++ b/crates/schema/tests/derive_union.rs
@@ -222,7 +222,7 @@ enum WithSkip {
         n: i64,
     },
     #[serde(skip)]
-    #[allow(
+    #[expect(
         dead_code,
         reason = "exercises that #[serde(skip)] drops the union arm"
     )]

--- a/crates/schema/tests/flow/derive_roundtrip.rs
+++ b/crates/schema/tests/flow/derive_roundtrip.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 #[derive(Schema, Deserialize)]
 #[schema(custom = "phase3_engine_stub")]
 struct Demo {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     name: String,
 }
 

--- a/crates/sdk/macros-support/src/attrs.rs
+++ b/crates/sdk/macros-support/src/attrs.rs
@@ -107,7 +107,7 @@ impl AttrArgs {
     }
 
     /// Get an ident value by key (e.g. `auth_style = PostBody`).
-    #[allow(dead_code)] // Reason: reserved for OAuth2/LDAP credential derive macros
+    // Reserved for OAuth2/LDAP credential derive macros.
     pub fn get_ident(&self, key: &str) -> Option<&Ident> {
         self.get_value(key).and_then(|v| match v {
             AttrValue::Ident(i) => Some(i),
@@ -116,13 +116,13 @@ impl AttrArgs {
     }
 
     /// Get an ident value as a string (e.g. `auth_style = PostBody` -> `"PostBody"`).
-    #[allow(dead_code)] // Reason: reserved for OAuth2/LDAP credential derive macros
+    // Reserved for OAuth2/LDAP credential derive macros.
     pub fn get_ident_str(&self, key: &str) -> Option<String> {
         self.get_ident(key).map(ToString::to_string)
     }
 
     /// Get a boolean value by key (e.g. `pkce = true`).
-    #[allow(dead_code)] // Reason: reserved for OAuth2/LDAP credential derive macros
+    // Reserved for OAuth2/LDAP credential derive macros.
     pub fn get_bool(&self, key: &str) -> Option<bool> {
         self.get_value(key).and_then(|v| match v {
             AttrValue::Lit(Lit::Bool(b)) => Some(b.value()),

--- a/crates/storage-port/src/dto/execution.rs
+++ b/crates/storage-port/src/dto/execution.rs
@@ -37,7 +37,7 @@ impl<'a> NewExecution<'a> {
 // guard-justified: `state` is `serde_json::Value`, which is not `Eq`
 // (it can hold a float). `Eq` is therefore not derivable; the clippy
 // hint is a false positive for any DTO carrying an opaque JSON payload.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExecutionRecord {
     /// Execution id (opaque string form).

--- a/crates/storage-port/src/dto/identity.rs
+++ b/crates/storage-port/src/dto/identity.rs
@@ -44,7 +44,7 @@ pub struct UserRow {
 // guard-justified: `settings` is `serde_json::Value` (not `Eq` — can
 // hold a float); the clippy `Eq`-derivable hint is a false positive for
 // JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OrgRow {
     /// `org_` ULID (opaque string form).
@@ -73,7 +73,7 @@ pub struct OrgRow {
 // guard-justified: `settings` is `serde_json::Value` (not `Eq` — can
 // hold a float); the clippy `Eq`-derivable hint is a false positive for
 // JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkspaceRow {
     /// `ws_` ULID (opaque string form).
@@ -204,7 +204,7 @@ pub struct MembershipRow {
 // guard-justified: `config` is `serde_json::Value` (not `Eq` — can
 // hold a float); the clippy `Eq`-derivable hint is a false positive for
 // JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ResourceRow {
     /// `res_` ULID (opaque string form).
@@ -233,7 +233,7 @@ pub struct ResourceRow {
 // guard-justified: `config` is `serde_json::Value` (not `Eq` — can
 // hold a float); the clippy `Eq`-derivable hint is a false positive for
 // JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TriggerRow {
     /// `trg_` ULID (opaque string form).
@@ -294,7 +294,7 @@ pub struct QuotaRow {
 // guard-justified: `details` is `Option<serde_json::Value>` (not `Eq`
 // — can hold a float); the clippy `Eq`-derivable hint is a false
 // positive for JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AuditLogRow {
     /// ULID primary key (opaque string form).
@@ -327,7 +327,7 @@ pub struct AuditLogRow {
 // guard-justified: `metadata` is `Option<serde_json::Value>` (not `Eq`
 // — can hold a float); the clippy `Eq`-derivable hint is a false
 // positive for JSON-bearing rows.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BlobRow {
     /// ULID primary key (opaque string form).

--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -111,7 +111,7 @@ impl JobDispatchMsg {
     /// construction; a `debug_assert` catches violations in test.
     // guard-justified: constructor over all DTO fields; a builder adds no safety
     // for an internal #[non_exhaustive] record whose fields are all independent.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: [u8; 16],
         execution_id: impl Into<String>,

--- a/crates/storage-port/src/dto/journal.rs
+++ b/crates/storage-port/src/dto/journal.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 // guard-justified: `payload` is `serde_json::Value`, which is not `Eq`
 // (it can hold a float). `Eq` is therefore not derivable; the clippy
 // hint is a false positive for any DTO carrying an opaque JSON payload.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct JournalEntry {
     /// Backend-assigned sequence number (`None` until persisted).

--- a/crates/storage-port/src/dto/node_result.rs
+++ b/crates/storage-port/src/dto/node_result.rs
@@ -15,7 +15,7 @@ pub const MAX_SUPPORTED_RESULT_SCHEMA_VERSION: u32 = 1;
 // guard-justified: `json` is `serde_json::Value`, which is not `Eq`
 // (it can hold a float). `Eq` is therefore not derivable; the clippy
 // hint is a false positive for any DTO carrying an opaque JSON payload.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NodeResultRecord {
     /// Producer-stamped result-kind discriminant.

--- a/crates/storage-port/src/dto/resume_token.rs
+++ b/crates/storage-port/src/dto/resume_token.rs
@@ -113,7 +113,7 @@ impl ResumeTokenRow {
     /// The only public constructor — needed cross-crate because
     /// `#[non_exhaustive]` makes struct-literal syntax unavailable outside
     /// the defining crate.
-    #[allow(clippy::too_many_arguments)] // flat DTO; a builder would obscure the schema
+    #[expect(clippy::too_many_arguments)] // flat DTO; a builder would obscure the schema
     pub fn new(
         token_hash: TokenHash,
         scope: Scope,

--- a/crates/storage-port/src/dto/workflow.rs
+++ b/crates/storage-port/src/dto/workflow.rs
@@ -25,7 +25,7 @@ pub struct WorkflowRecord {
 // `Eq` (it can hold a float). `Eq` is therefore not derivable; the
 // clippy hint is a false positive for any DTO carrying an opaque JSON
 // payload.
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkflowVersionRecord {
     /// Owning workflow id (opaque string form).

--- a/crates/storage-port/tests/object_safe.rs
+++ b/crates/storage-port/tests/object_safe.rs
@@ -1,6 +1,6 @@
 use nebula_storage_port::store::*;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn _assert_object_safe(
     _a: &dyn ExecutionStore,
     _b: &dyn ExecutionJournalReader,
@@ -19,7 +19,7 @@ fn _assert_object_safe(
 
 // Compile-time object-safety probe over the identity zoo: it is never
 // called, so the argument count is not an ergonomics concern.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn _assert_identity_object_safe(
     _a: &dyn UserStore,
     _b: &dyn OrgStore,

--- a/crates/storage/src/credential/refresh_claim/in_memory.rs
+++ b/crates/storage/src/credential/refresh_claim/in_memory.rs
@@ -20,7 +20,7 @@ struct ClaimRow {
     claim_id: Uuid,
     generation: u64,
     holder: ReplicaId,
-    #[allow(dead_code, reason = "kept for future event/metric emission")]
+    #[expect(dead_code, reason = "kept for future event/metric emission")]
     acquired_at: DateTime<Utc>,
     expires_at: DateTime<Utc>,
     sentinel: SentinelState,
@@ -31,12 +31,12 @@ struct ClaimRow {
 struct SentinelEventRow {
     credential_id: CredentialId,
     detected_at: DateTime<Utc>,
-    #[allow(
+    #[expect(
         dead_code,
         reason = "kept for symmetry with the SQL backends; surfaces in diagnostics"
     )]
     crashed_holder: ReplicaId,
-    #[allow(
+    #[expect(
         dead_code,
         reason = "kept for symmetry with the SQL backends; surfaces in diagnostics"
     )]

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -14,6 +14,11 @@
 //! store via `unimplemented!()`, so the suite compiles and that backend's
 //! cases are red. That red is the TDD target for the remaining P2 tasks.
 
+#![expect(
+    clippy::print_stderr,
+    reason = "conformance harness reports skip/diagnostic lines to stderr"
+)]
+
 #[path = "conformance/mod.rs"]
 mod harness;
 

--- a/crates/storage/tests/identity_conformance.rs
+++ b/crates/storage/tests/identity_conformance.rs
@@ -23,6 +23,11 @@
 //! `unimplemented!()` behind that skip guard, so the suite compiles and
 //! only the live backend's cases run.
 
+#![expect(
+    clippy::print_stderr,
+    reason = "conformance harness reports skip/diagnostic lines to stderr"
+)]
+
 use std::future::Future;
 use std::sync::Arc;
 

--- a/crates/tenancy/tests/scope_decorator_coverage.rs
+++ b/crates/tenancy/tests/scope_decorator_coverage.rs
@@ -58,7 +58,7 @@ where
 /// Marker every `Scoped*` decorator satisfies for its port trait: it can
 /// be built from a raw `Arc<dyn P>` plus the tenant `Scope` it binds.
 trait ScopeDecorator<P: ?Sized> {
-    #[allow(dead_code)] // guard-justified: linked only for the type-bound proof above.
+    #[expect(dead_code)] // guard-justified: linked only for the type-bound proof above.
     fn bind(inner: Arc<P>, scope: Scope) -> Self;
 }
 

--- a/crates/validator/examples/combinators.rs
+++ b/crates/validator/examples/combinators.rs
@@ -1,5 +1,10 @@
 //! Combinators example for nebula-validator
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_validator::prelude::{Validate, and, max_length, min_length};
 
 fn main() {

--- a/crates/validator/examples/json_validation.rs
+++ b/crates/validator/examples/json_validation.rs
@@ -2,6 +2,11 @@
 //!
 //! Run: `cargo run -p nebula-validator --features serde --example json_validation`
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_validator::{
     combinators::{json_field, json_field_optional, not, when, with_message},
     foundation::{Validate, ValidateExt},

--- a/crates/validator/examples/validator_basic_usage.rs
+++ b/crates/validator/examples/validator_basic_usage.rs
@@ -1,5 +1,10 @@
 //! Basic usage example for nebula-validator
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_validator::prelude::{
     AnyValidator, Validatable, Validate, ValidateExt, ValidationError, ValidationMode, all_of,
     alphanumeric, email, exact_length, hostname, in_range, ip_addr, json_field,

--- a/crates/validator/src/macros.rs
+++ b/crates/validator/src/macros.rs
@@ -515,7 +515,7 @@ macro_rules! validator {
     ) => {
         $($meta)*
         #[derive(Debug, Clone, $($ed,)*)]
-        #[allow(missing_docs)]
+        #[allow(missing_docs, clippy::allow_attributes, reason = "expands in downstream crates where the lint may not fire, so #[expect] cannot be used")]
         $vis struct $name $($gu)* {
             $($all_fields)+
         }
@@ -562,7 +562,7 @@ macro_rules! validator {
         $vis:vis $name:ident [$($gd:tt)*] [$($gu:tt)*]
         [$($args:tt)*] $body:block
     ) => {
-        #[allow(clippy::new_without_default)]
+        #[allow(clippy::new_without_default, clippy::allow_attributes, reason = "expands in downstream crates where the lint may not fire, so #[expect] cannot be used")]
         impl $($gd)* $name $($gu)* {
             /// Creates a new instance.
             #[must_use] #[inline]
@@ -597,7 +597,7 @@ macro_rules! validator {
     ) => {
         impl $($gd)* $crate::foundation::Validate<$input> for $name $($gu)* {
             #[inline]
-            #[allow(unused_variables)]
+            #[allow(unused_variables, clippy::allow_attributes, reason = "expands in downstream crates where the lint may not fire, so #[expect] cannot be used")]
             fn validate(&$self_ref, $inp: &$input)
                 -> ::std::result::Result<(), $crate::foundation::ValidationError>
             {

--- a/crates/validator/src/prelude.rs
+++ b/crates/validator/src/prelude.rs
@@ -21,7 +21,6 @@
 //! # Ok::<(), ValidationError>(())
 //! ```
 
-#[allow(clippy::wildcard_imports, ambiguous_glob_reexports)]
 pub use crate::validators::*;
 pub use crate::{
     combinators::{

--- a/crates/validator/src/proof.rs
+++ b/crates/validator/src/proof.rs
@@ -99,7 +99,7 @@ impl<T> Validated<T> {
     /// Misuse breaks the trust boundary that `Validated<T>` exists to enforce.
     /// Prefer re-validating when in doubt.
     #[inline]
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn map<U>(self, f: impl FnOnce(T) -> U) -> Validated<U> {
         Validated {
             value: f(self.value),

--- a/examples/examples/credential_plugin_scheme_family.rs
+++ b/examples/examples/credential_plugin_scheme_family.rs
@@ -10,6 +10,11 @@
 //!
 //! Run: `cargo run -p nebula-examples --example credential_plugin_scheme_family`
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_core::auth::{
     AuthPattern, AuthScheme, EgressShape, ExternalScheme, RefreshStrategyKind, SchemeFamily,
 };

--- a/examples/examples/expression_error_messages.rs
+++ b/examples/examples/expression_error_messages.rs
@@ -3,6 +3,11 @@
 //! This example shows how the template engine provides detailed error messages
 //! with source code context and visual highlighting.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_expression::{EvaluationContext, ExpressionEngine, Template};
 use serde_json::Value;
 

--- a/examples/examples/expression_maybe_vs_template.rs
+++ b/examples/examples/expression_maybe_vs_template.rs
@@ -2,6 +2,11 @@
 //!
 //! This example demonstrates when to use each type and how they work together.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_expression::{
     EvaluationContext, ExpressionEngine, MaybeExpression, MaybeTemplate, Template,
 };

--- a/examples/examples/expression_template_advanced.rs
+++ b/examples/examples/expression_template_advanced.rs
@@ -5,6 +5,11 @@
 //! - Position tracking for error reporting
 //! - MaybeTemplate for conditional rendering
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_expression::{
     EvaluationContext, ExpressionEngine, MaybeTemplate, Template, TemplatePart,
 };

--- a/examples/examples/expression_template_rendering.rs
+++ b/examples/examples/expression_template_rendering.rs
@@ -3,6 +3,11 @@
 //! This example shows how to use Template for parse-once, render-many pattern
 //! with multiple {{ }} expressions in various formats (HTML, JSON, plain text)
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_expression::{EvaluationContext, ExpressionEngine, Template};
 use serde_json::Value;
 

--- a/examples/examples/resource_pooled_http_prelude.rs
+++ b/examples/examples/resource_pooled_http_prelude.rs
@@ -7,6 +7,11 @@
 //! cargo run -p nebula-examples --example resource_pooled_http_prelude
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use nebula_core::{ExecutionId, scope::Scope};
 use nebula_resource::prelude::*;
 use nebula_resource::topology::pooled::{BrokenCheck, PoolProvider};

--- a/examples/examples/resource_postgres_pool.rs
+++ b/examples/examples/resource_postgres_pool.rs
@@ -29,6 +29,11 @@
 //!   branch
 //! - Final pool stats (idle, capacity, in-use)
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     sync::{
         Arc,
@@ -58,7 +63,7 @@ use tokio_util::sync::CancellationToken;
 /// store; here we only model the shape so `QueryUsers` can show the slot
 /// pattern without requiring full credential plumbing.
 #[derive(Clone)]
-#[allow(
+#[expect(
     dead_code,
     reason = "password field is held to model SecretString-shaped slot — never logged"
 )]
@@ -318,10 +323,6 @@ impl Drop for ScopedSchemaHandle {
 /// the macro emits this struct + `FromWorkflowNode` impl that resolves the
 /// slots at dispatch. Here we wire the slots by hand so the example focuses
 /// on the lifecycle.
-#[allow(
-    dead_code,
-    reason = "auth field models the credential slot — full resolution lives in the engine"
-)]
 struct QueryUsers {
     /// Resource slot — declared `#[resource(key = "db")]` in ADR-0043 form.
     db: Arc<MockPgConnection>,

--- a/examples/examples/resource_resident_http.rs
+++ b/examples/examples/resource_resident_http.rs
@@ -27,6 +27,11 @@
 //! 4. The example explicitly forces three refreshes to demonstrate the pattern — production code
 //!    refreshes only when the cached token has actually expired.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     sync::{
         Arc, OnceLock,
@@ -53,7 +58,7 @@ use tokio_util::sync::CancellationToken;
 /// from `nebula-credential`. The mock keeps the shape but skips the storage
 /// + projection layers so the example focuses on the refresh flow.
 #[derive(Clone)]
-#[allow(
+#[expect(
     dead_code,
     reason = "client_secret models the SecretString slot — never read in mock, never logged in production"
 )]

--- a/examples/examples/resource_telegram_multi_workflow.rs
+++ b/examples/examples/resource_telegram_multi_workflow.rs
@@ -25,6 +25,11 @@
 //! cargo run -p nebula-examples --example resource_telegram_multi_workflow
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{
     sync::{
         Arc,

--- a/examples/examples/workflow_batch_etl.rs
+++ b/examples/examples/workflow_batch_etl.rs
@@ -40,6 +40,11 @@
 //! cargo run -p nebula-examples --example workflow_batch_etl
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_conditional_routing.rs
+++ b/examples/examples/workflow_conditional_routing.rs
@@ -43,6 +43,11 @@
 //! cargo run -p nebula-examples --example workflow_conditional_routing
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_data_pipeline.rs
+++ b/examples/examples/workflow_data_pipeline.rs
@@ -41,6 +41,11 @@
 //! cargo run -p nebula-examples --example workflow_data_pipeline
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_datetime_schedule.rs
+++ b/examples/examples/workflow_datetime_schedule.rs
@@ -50,6 +50,11 @@
 //! cargo run -p nebula-examples --example workflow_datetime_schedule
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_delay_resume.rs
+++ b/examples/examples/workflow_delay_resume.rs
@@ -44,6 +44,11 @@
 //!
 //! It completes in a fraction of a second (the real timer span) plus engine overhead.
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc, time::Duration, time::Instant};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_json_reshape.rs
+++ b/examples/examples/workflow_json_reshape.rs
@@ -39,6 +39,11 @@
 //! cargo run -p nebula-examples --example workflow_json_reshape
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/examples/examples/workflow_switch_router.rs
+++ b/examples/examples/workflow_switch_router.rs
@@ -45,6 +45,11 @@
 //! cargo run -p nebula-examples --example workflow_switch_router
 //! ```
 
+#![expect(
+    clippy::print_stdout,
+    reason = "example: printed output is the demonstration"
+)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,6 +14,6 @@
 #   recommended format per the rustup book.
 
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

**Toolchain** — pin bumped to Rust 1.96.1 (fixes a MIR-optimization miscompile, missing retries/timeouts in cargo's HTTP client, and three libssh2 CVEs). Zero lint churn: clippy is unchanged from 1.96.0.

**New workspace lint gates** (`[workspace.lints.clippy]`):
- `print_stdout` / `print_stderr` = warn — output goes through `tracing`; the only sanctioned prints are pre/post-tracing edges (telemetry bootstrap/shutdown fallbacks, bin exit reporting), each carrying `#[expect(..., reason = ...)]` at the site. Tests were already exempt via `clippy.toml`; examples declare `#![expect]` at file top (printed output is their deliverable).
- `allow_attributes` = warn — standardizes on `#[expect]`, which warns when the suppressed lint stops firing, so stale suppressions can't accumulate.

**Migration fallout, all resolved:**
- ~190 `#[allow]` → `#[expect]` across the workspace (mostly `cargo clippy --fix`).
- The new lint immediately exposed **29 stale/inert suppressions** — e.g. `dead_code` on `request_scope` ("dead until first handler is migrated") with 30+ live call sites, inert `dead_code` on pub library fns, an obsolete `unreachable_patterns` for a serde duplicate-alias arm serde no longer emits. Deleted.
- Feature-/cfg-conditional sites got precise `cfg_attr` gates (`not(feature = "sentry")`, `not(test)`, `not(feature = "file")`, `feature = "telemetry"`).
- `nebula-resilience` re-enables pedantic at crate level over the workspace cast allows, so the two functions with real u128→u64/f64 casts keep narrow `#[expect]`s with reasons.
- `nebula-validator` macros emit `#[allow(..., clippy::allow_attributes, reason = ...)]` (self-suppressing) because expansions land in downstream crates where an expectation could not be fulfilled.
- `default_non_blocking()` in `nebula-log` is now properly `#[cfg(feature = "file")]` (matching its only consumer) instead of suppressing `dead_code`.

**`nebula-log --no-default-features` fixed** (was broken pre-existing): `async_timing` / `context_propagation` examples now declare `required-features = ["async"]`, and the `not(async)` thread-local storage fallbacks align visibility (`pub(crate)`) with their task-local twins, clearing six `unreachable_pub` warnings.

## Verification

- `cargo clippy --all-targets --all-features`: **0 warnings** across the workspace
- `nebula-log` matrix (no-default / default / all-features): 0 warnings, 0 errors
- `cargo fmt --check`: clean
- `cargo nextest run -p nebula-log -p nebula-validator`: 729/729 passed; `nebula-log --no-default-features`: 86/86 passed

## Deliberately deferred

`allow_attributes_without_reason` (~366 sites need hand-written reasons — separate campaign), and the pre-existing `#![warn(pedantic)]` duplication in `resilience/src/lib.rs` that shadows workspace cast allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)