### PR TITLE
ci: Tier 1 toolchain gates — feature-matrix clippy, dep hygiene, API-surface and workflow-security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   check:
     name: Check + Clippy
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,8 +86,16 @@ jobs:
           cache-on-failure: true
       - name: Clippy (workspace, all features, all targets)
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
-      # Per-crate `--no-default-features` checks moved to the `feature-hygiene`
-      # job below, which covers every member and every feature systematically.
+      # Feature-matrix clippy (ENGINEERING_2026 C4): an all-features pass cannot
+      # see code or attributes behind `cfg(not(feature = ...))` — a
+      # `cfg_attr(not(feature = "x"), allow(...))` survived exactly this blind
+      # spot in #951. `feature-hygiene` below runs `cargo hack check` per
+      # feature (type errors), these two runs add the *lint* dimension for the
+      # workspace-level default / no-default configurations on the warm cache.
+      - name: Clippy (workspace, default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Clippy (workspace, no default features)
+        run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
 
   # ── Feature hygiene (the standalone-crate / modularity promise) ────────────
   # Modularity gate: each optional feature must build in isolation. cargo-hack
@@ -255,13 +263,75 @@ jobs:
       - name: Run cargo deny
         run: cargo deny check
 
+  # ── Test-dep leak gate (reth pattern, ENGINEERING_2026 §2.3) ──────────────
+  # Test-only crates must never reach the release binaries' normal dependency
+  # graph — they inflate the binary and widen the supply-chain surface.
+  # `-e normal` excludes dev-dependencies, so a hit means a test-only crate is
+  # wired as a real dependency somewhere in the tree.
+  test-dep-leak:
+    name: No test deps in release binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: "1.96"
+      - name: Assert test-only crates absent from binary dep trees
+        run: |
+          set -euo pipefail
+          for bin in nebula-server nebula-worker-bin; do
+            if cargo tree -p "$bin" -e normal --all-features \
+               | grep -E '\b(proptest|arbitrary|rstest|mockall|wiremock|criterion|insta|loom|quickcheck|fake)\b'; then
+              echo "::error::test-only crate found in $bin normal dependency tree"
+              exit 1
+            fi
+          done
+
+  # ── Public API surface gate (ENGINEERING_2026 Tier 1 §4; iroh/wasmtime) ───
+  # `cargo-check-external-types` asserts the API-boundary crates (`sdk`, `api`)
+  # only expose third-party types from their explicit allowlists
+  # (`[package.metadata.cargo_check_external_types]` in each Cargo.toml).
+  # The nightly toolchain is pinned to the rustdoc JSON format the tool's
+  # version understands (0.5.x ↔ format 57 ↔ nightly-2026-03-20); bump the
+  # two together.
+  external-types:
+    name: Public API surface (sdk, api)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install pinned nightly (rustdoc JSON format 57)
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: nightly-2026-03-20
+      - name: Install cargo-check-external-types
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: cargo-check-external-types@0.5.0
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
+        with:
+          shared-key: ci-external-types
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+      - name: Check sdk public surface
+        working-directory: crates/sdk
+        run: cargo +nightly-2026-03-20 check-external-types --all-features
+      - name: Check api public surface
+        working-directory: crates/api
+        run: cargo +nightly-2026-03-20 check-external-types --all-features
+
   # ── Required aggregator ───────────────────────────────────────────────────
   # Single required check for branch protection. Treats `skipped` (draft-gated
   # tier 2 jobs) as success, but `failure`/`cancelled` fails the whole suite.
   required:
     name: CI
     if: always()
-    needs: [fmt, check, feature-hygiene, doctests, msrv, doc, deny]
+    needs: [fmt, check, feature-hygiene, doctests, msrv, doc, deny, test-dep-leak, external-types]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -274,11 +344,14 @@ jobs:
           MSRV: ${{ needs.msrv.result }}
           DOC: ${{ needs.doc.result }}
           DENY: ${{ needs.deny.result }}
+          TEST_DEP_LEAK: ${{ needs.test-dep-leak.result }}
+          EXTERNAL_TYPES: ${{ needs.external-types.result }}
         run: |
           set -euo pipefail
           fail=0
           for pair in "fmt=$FMT" "check=$CHECK" "feature-hygiene=$FEATURE_HYGIENE" \
-                     "doctests=$DOCTESTS" "msrv=$MSRV" "doc=$DOC" "deny=$DENY"; do
+                     "doctests=$DOCTESTS" "msrv=$MSRV" "doc=$DOC" "deny=$DENY" \
+                     "test-dep-leak=$TEST_DEP_LEAK" "external-types=$EXTERNAL_TYPES"; do
             name="${pair%%=*}"
             result="${pair#*=}"
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,10 +13,6 @@ on:
         description: "Always keep at least N most recent runs per workflow"
         default: "10"
 
-permissions:
-  actions: write
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -24,6 +20,9 @@ concurrency:
 jobs:
   # ── 1. Branch deletion → orphan runs from that branch ─────────────────────
   cleanup-deleted-branch:
+    permissions:
+      actions: write
+      contents: read
     name: Cleanup runs from deleted branch
     if: github.event_name == 'delete' && github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
@@ -48,6 +47,9 @@ jobs:
 
   # ── 2. Weekly retention sweep — delete runs older than retain_days ───────
   cleanup-old:
+    permissions:
+      actions: write
+      contents: read
     name: Cleanup old runs (retention sweep)
     if: github.event_name != 'delete'
     runs-on: ubuntu-latest

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,7 +35,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -190,6 +189,9 @@ jobs:
           echo "Planned shards: $SHARDS"
 
   codspeed:
+    permissions:
+      contents: read
+      id-token: write
     name: Run benchmarks (${{ matrix.shard }})
     needs: [changes]
     # Gate is shard-level only: draft PRs still get partial CodSpeed feedback

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -36,3 +36,21 @@ jobs:
 
       - name: Check TOML formatting
         run: taplo fmt --check .
+
+  # ── Workflow security audit (ENGINEERING_2026 C12; uv/reth precedent) ─────
+  # Gate on high severity: excessive permissions, template injection into
+  # `run:` blocks, etc. Medium findings (persist-credentials on checkouts)
+  # are tracked as follow-up and intentionally not blocking yet.
+  zizmor:
+    name: zizmor (workflow security)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install zizmor
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: zizmor
+      - name: Audit workflows (high severity blocks)
+        run: zizmor --no-progress --min-severity high .github/workflows/

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +29,9 @@ env:
 
 jobs:
   audit:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -31,7 +31,6 @@ jobs:
   audit:
     permissions:
       contents: read
-      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -77,6 +76,8 @@ jobs:
           exit 1
 
   notify:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: audit

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -61,13 +61,18 @@ jobs:
       - name: Select packages to test
         id: select
         shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
 
           FULL='["nebula-action","nebula-api","nebula-core","nebula-credential","nebula-engine","nebula-error","nebula-eventbus","nebula-execution","nebula-expression","nebula-log","nebula-metrics","nebula-plugin","nebula-resilience","nebula-resource","nebula-schema","nebula-sdk","nebula-storage","nebula-telemetry","nebula-validator","nebula-workflow"]'
           SMOKE='["nebula-core","nebula-engine"]'
 
-          EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "push" || "$EVENT" == "workflow_dispatch" ]]; then
             echo "packages=$FULL" >> "$GITHUB_OUTPUT"
             exit 0
@@ -76,11 +81,11 @@ jobs:
           BASE_SHA=""
           HEAD_SHA=""
           if [[ "$EVENT" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
           elif [[ "$EVENT" == "merge_group" ]]; then
-            BASE_SHA="${{ github.event.merge_group.base_sha }}"
-            HEAD_SHA="${{ github.event.merge_group.head_sha }}"
+            BASE_SHA="$MG_BASE_SHA"
+            HEAD_SHA="$MG_HEAD_SHA"
           fi
 
           # Fail-safe: if event payload does not provide diff SHAs, run full set
@@ -161,14 +166,16 @@ jobs:
       # Note: `nebula-api`'s `credential-oauth` feature was deleted 2026-04-24 —
       # OAuth ceremony now ships unconditionally per ADR-0031 §6.
       - name: Run tests for ${{ matrix.package }}
+        env:
+          PKG: ${{ matrix.package }}
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.package }}" == "nebula-engine" ]]; then
+          if [[ "$PKG" == "nebula-engine" ]]; then
             cargo nextest run -p nebula-engine --features "rotation" --profile ci --no-tests=pass
-          elif [[ "${{ matrix.package }}" == "nebula-storage" ]]; then
+          elif [[ "$PKG" == "nebula-storage" ]]; then
             cargo nextest run -p nebula-storage --features "credential-in-memory" --profile ci --no-tests=pass
           else
-            cargo nextest run -p "${{ matrix.package }}" --profile ci --no-tests=pass
+            cargo nextest run -p "$PKG" --profile ci --no-tests=pass
           fi
 
       - name: Test summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,12 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arcstr"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,49 +457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-config"
-version = "1.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 1.4.2",
- "sha1 0.10.6",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,408 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-runtime"
-version = "1.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "bytes-utils",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.135.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97e3e7e7d86fd26fcdc18bc382da5ca9e8b2ff8d54030d187fd0dac8a236d96"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-checksums",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "hmac 0.13.0",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 1.0.1",
- "lru",
- "percent-encoding",
- "regex-lite",
- "sha2 0.11.0",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.101.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.106.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "crypto-bigint",
- "form_urlencoded",
- "hex",
- "hmac 0.13.0",
- "http 0.2.12",
- "http 1.4.2",
- "p256",
- "percent-encoding",
- "sha2 0.11.0",
- "subtle",
- "time",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.64.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "crc-fast",
- "hex",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "md-5",
- "pin-project-lite",
- "sha1 0.11.0",
- "sha2 0.11.0",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
-dependencies = [
- "aws-smithy-types",
- "bytes",
- "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-client"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2",
- "http 1.4.2",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api-macros",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.4.2",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "aws-smithy-schema"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "http 1.4.2",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.2",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-schema",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +489,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -971,7 +520,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1013,16 +562,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
 
 [[package]]
 name = "base64ct"
@@ -1152,16 +691,6 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-
-[[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
 
 [[package]]
 name = "bytestring"
@@ -1421,11 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
- "futures-core",
  "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -1564,16 +1089,6 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
-name = "crc-fast"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
-dependencies = [
- "digest 0.10.7",
- "spin 0.10.0",
-]
 
 [[package]]
 name = "crc32fast"
@@ -2119,7 +1634,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2576,17 +2091,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2604,7 +2108,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2619,22 +2123,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
 
 [[package]]
 name = "hybrid-array"
@@ -2657,7 +2145,7 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2677,7 +2165,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2707,7 +2194,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "hyper",
  "ipnet",
  "libc",
@@ -3073,7 +2560,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3183,9 +2670,6 @@ name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "lru-slab"
@@ -3460,8 +2944,6 @@ dependencies = [
  "chrono",
  "compact_str",
  "dashmap",
- "futures",
- "humantime-serde",
  "insta",
  "lru",
  "mockall",
@@ -3496,7 +2978,6 @@ dependencies = [
  "tracing-subscriber",
  "trybuild",
  "url",
- "uuid",
  "zeroize",
 ]
 
@@ -3534,9 +3015,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "dashmap",
  "futures",
- "humantime-serde",
  "insta",
- "lru",
  "nebula-action",
  "nebula-core",
  "nebula-credential",
@@ -3559,7 +3038,6 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rand 0.10.1",
- "regex",
  "rstest",
  "scopeguard",
  "secrecy",
@@ -3574,7 +3052,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
- "url",
  "uuid",
  "zeroize",
 ]
@@ -3701,7 +3178,6 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "codspeed-criterion-compat",
- "flate2",
  "insta",
  "nebula-env",
  "nebula-error",
@@ -3723,7 +3199,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
@@ -3835,7 +3310,6 @@ dependencies = [
  "nebula-workflow",
  "serde",
  "serde_json",
- "thiserror",
  "tokio",
  "tracing",
 ]
@@ -4007,8 +3481,6 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "async-trait",
- "aws-config",
- "aws-sdk-s3",
  "base64",
  "chrono",
  "hex",
@@ -4022,7 +3494,6 @@ dependencies = [
  "nebula-tenancy",
  "parking_lot",
  "pretty_assertions",
- "redis",
  "rmp-serde",
  "rstest",
  "serde",
@@ -4071,7 +3542,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4585,12 +4055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4783,12 +4247,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -5198,31 +4656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
-dependencies = [
- "arcstr",
- "async-lock",
- "bytes",
- "cfg-if",
- "combine",
- "futures-util",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1_smol",
- "socket2 0.6.4",
- "tokio",
- "tokio-util",
- "url",
- "xxhash-rust",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5304,7 +4737,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5339,7 +4772,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -5974,12 +5407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6137,12 +5564,6 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -6685,7 +6106,7 @@ dependencies = [
  "base64",
  "bytes",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -6758,7 +6179,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.2",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -7161,12 +6582,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -7752,18 +7167,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,14 +298,12 @@ unnecessary_wraps = "allow"                  # API-consistency `Result` on built
 # taste or a micro-optimisation that would mean an API break. Revisit when a
 # refactor naturally touches the site.
 wildcard_imports = "allow"                    # kept noisy but shelved: prelude / re-export patterns
-or_fun_call = "allow"                         # `unwrap_or(T::default())` is clearer than unwrap_or_else
 trivially_copy_pass_by_ref = "allow"
 needless_pass_by_ref_mut = "allow"
 needless_collect = "allow"
 map_unwrap_or = "allow"
 excessive_nesting = "allow"                   # threshold lives in clippy.toml
 useless_let_if_seq = "allow"
-assigning_clones = "allow"                    # micro-perf on `a = b.clone()`
 unused_peekable = "allow"
 type_repetition_in_bounds = "allow"
 trivial_regex = "allow"
@@ -332,6 +330,16 @@ doc_markdown = "allow"
 float_cmp = "allow"
 # Bindings like `_fixture` from rstest / proptest are internal to the macro.
 used_underscore_binding = "allow"
+
+# ── async-footgun lints — restate/turso/vector consensus (ENGINEERING_2026 C14) ──
+# `or_fun_call` / `assigning_clones`: allocation on the hot path hidden behind
+# ergonomic-looking calls. `large_futures`: a future that big usually wants a
+# `Box::pin`. `await_holding_lock`: guard held across `.await` deadlocks under
+# contention (parking_lot guards are not Send-safe across awaits).
+or_fun_call = "warn"
+assigning_clones = "warn"
+large_futures = "warn"
+await_holding_lock = "warn"
 
 # ── correctness / soundness escalated from default ─────────────────────────
 mem_forget = "deny"

--- a/crates/action/macros/src/lib.rs
+++ b/crates/action/macros/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -30,6 +30,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 /// Base action trait defining identity and metadata.
 pub mod action;

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -202,3 +202,32 @@ all-features = true
 
 [lints]
 workspace = true
+
+# ── cargo-check-external-types (ENGINEERING_2026 Tier 1 §4; iroh/wasmtime) ──
+# nebula-api is server glue: exposing the web-framework vocabulary (axum,
+# tower, http, utoipa) and storage/telemetry config types is intentional.
+# The gate exists so NEW third-party types entering the public API are a
+# conscious decision, not an accident.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  "nebula_*",
+  "axum::*",
+  "axum_core::*",
+  "http::*",
+  "tower_service::*",
+  "tower_layer::*",
+  "utoipa::*",
+  "utoipa_axum::*",
+  "serde_core::*",
+  "serde_json::*",
+  "chrono::*",
+  "tokio::*",
+  "tokio_util::*",
+  "url::*",
+  "uuid::*",
+  "reqwest::*",
+  "secrecy::*",
+  "sqlx_core::*",
+  "sqlx_postgres::*",
+  "opentelemetry_otlp::*",
+]

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -611,7 +611,7 @@ impl AuthBackend for InMemoryAuthBackend {
         }
         self.users.alter(&parsed, |_, mut u| {
             if let Some(name) = patch.display_name.as_deref() {
-                u.display_name = name.trim().to_owned();
+                name.trim().clone_into(&mut u.display_name);
             }
             if let Some(avatar) = patch.avatar_url.as_deref() {
                 let trimmed = avatar.trim();

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -63,6 +63,7 @@
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod access;
 pub mod app;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,6 +36,8 @@
 //! - **Tenancy** — `TenantContext`, `ResolvedIds` (module `tenancy`).
 //! - **Slugs** — `Slug`, `SlugKind`, `SlugError`, `is_prefixed_ulid()` (module `slug`).
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 // ── Modules ─────────────────────────────────────────────────────────────────
 
 /// Accessor trait definitions for capability injection.

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -60,9 +60,7 @@ serde_json = { workspace = true }
 
 # Utilities
 chrono = { workspace = true }
-uuid = { workspace = true, features = ["v4", "serde"] }
 tracing = { workspace = true }
-humantime-serde = "1.1"
 semver = { workspace = true }
 
 # Synchronization
@@ -79,7 +77,6 @@ regex = { workspace = true }
 scopeguard = "1"
 
 # futures — select!/stream combinators in refresh coordinator
-futures = { workspace = true }
 
 # Registry primitives (Tech Spec §3.1 — KEY-keyed CredentialRegistry)
 # `ahash` 0.8 — ~3× faster than default SipHash at credential-key sizes

--- a/crates/credential/macros/src/lib.rs
+++ b/crates/credential/macros/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -70,6 +70,7 @@
 // the crate should be `pub(crate)` so the public surface stays intentional
 // (Tokio's `unreachable_pub` discipline). Additive to inherited workspace lints.
 #![warn(unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 // Self-import so proc-macros that expand to `::nebula_credential::...` paths
 // resolve correctly when the derive is used inside this crate itself (e.g.

--- a/crates/credential/src/runtime/refresh/token_refresh.rs
+++ b/crates/credential/src/runtime/refresh/token_refresh.rs
@@ -227,7 +227,7 @@ fn update_state_from_token_response(
     state.access_token = SecretString::new(token);
 
     if let Some(token_type) = body.get("token_type").and_then(Value::as_str) {
-        state.token_type = token_type.to_owned();
+        token_type.clone_into(&mut state.token_type);
     }
     if let Some(refresh_token) = body.get("refresh_token").and_then(Value::as_str) {
         state.refresh_token = Some(SecretString::new(refresh_token));

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -9,6 +9,8 @@
 //! Every plaintext buffer returned here is wrapped in `Zeroizing<T>`. Ciphertext
 //! envelopes (`EncryptedData`) are public bytes by design and are not scrubbed.
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 use aes_gcm::{
     Aes256Gcm,
     aead::{Aead, KeyInit, Payload},

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -31,7 +31,6 @@ nebula-expression = { path = "../expression" }
 nebula-plugin = { path = "../plugin" }
 nebula-workflow = { path = "../workflow" }
 nebula-execution = { path = "../execution" }
-nebula-schema = { path = "../schema" }
 nebula-credential = { path = "../credential" }
 nebula-eventbus = { path = "../eventbus" }
 nebula-resource = { path = "../resource" }
@@ -62,16 +61,14 @@ base64 = { workspace = true }
 secrecy = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 ulid = { workspace = true }
-humantime-serde = "1.1"
-lru = { workspace = true }
 parking_lot = { workspace = true }
 scopeguard = { workspace = true }
-regex = { workspace = true }
-url = { workspace = true }
 futures = { workspace = true }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]
+# Schema fixtures for unit tests (impl_empty_has_schema! in cfg(test) mods).
+nebula-schema = { path = "../schema" }
 # Dev-only: the credential moat tests build a real durable store backed by a
 # unique in-memory SQLite database (`SqliteCredentialStore::connect_memory`),
 # so the resolver exercises the same CAS path as production. `sqlite` is enough;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-engine — Composition Root
 //!

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -38,6 +38,7 @@
 // feature-gated `testing` module (env mutation under edition 2024).
 #![cfg_attr(not(any(test, feature = "testing")), forbid(unsafe_code))]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod error;
 mod reader;

--- a/crates/error/macros/src/lib.rs
+++ b/crates/error/macros/src/lib.rs
@@ -27,6 +27,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -34,6 +34,7 @@
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod category;
 mod code;

--- a/crates/eventbus/src/lib.rs
+++ b/crates/eventbus/src/lib.rs
@@ -129,6 +129,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod bus;
 mod filter;

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-execution
 //!

--- a/crates/expression/src/lib.rs
+++ b/crates/expression/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(unreachable_pub)]
 #![allow(clippy::excessive_nesting)]
 #![allow(clippy::needless_range_loop)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-expression
 //!

--- a/crates/log/Cargo.toml
+++ b/crates/log/Cargo.toml
@@ -17,7 +17,6 @@ tokio = { workspace = true, features = ["time", "sync", "rt", "fs", "io-util"], 
 # Core tracing
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.4", optional = true }
-tracing-log = { version = "0.2", optional = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
@@ -39,7 +38,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 # Telemetry (optional)
-flate2 = { version = "1.1.9", optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
@@ -72,8 +70,11 @@ smallvec = { workspace = true }
 default = ["ansi", "async"]
 ansi = []
 async = ["tokio"]
-file = ["tracing-appender", "flate2"]
-log-compat = ["tracing-log"]
+file = ["tracing-appender"]
+# The `log`-crate bridge is provided by tracing-subscriber's always-on
+# `tracing-log` feature (see [dependencies]); this feature is kept as a
+# no-op for config compatibility.
+log-compat = []
 telemetry = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]
 sentry = ["dep:sentry", "sentry-tracing"]
 full = ["ansi", "async", "file", "log-compat", "telemetry", "sentry"]

--- a/crates/log/src/lib.rs
+++ b/crates/log/src/lib.rs
@@ -130,6 +130,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![warn(unreachable_pub)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod core;
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -6,6 +6,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 /// Core [`BaseMetadata`] struct and [`Metadata`] trait.
 pub mod base;

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-metrics
 //!

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -23,6 +23,8 @@
 //! [`JobDispatchQueue::reclaim_stuck`]: nebula_storage_port::store::JobDispatchQueue::reclaim_stuck
 //! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 pub mod orchestrator;
 pub mod sink;
 

--- a/crates/plugin-core/Cargo.toml
+++ b/crates/plugin-core/Cargo.toml
@@ -23,7 +23,6 @@ nebula-workflow = { path = "../workflow" }
 chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/plugin-core/src/condition.rs
+++ b/crates/plugin-core/src/condition.rs
@@ -283,7 +283,9 @@ impl Serialize for Condition {
 /// error because field-level conditions require an object to index into.
 pub(crate) fn normalize_data(data: Option<Value>) -> Result<Value, ActionError> {
     match data {
-        Some(Value::Object(_)) | None => Ok(data.unwrap_or(Value::Object(Default::default()))),
+        Some(Value::Object(_)) | None => {
+            Ok(data.unwrap_or_else(|| Value::Object(Default::default())))
+        },
         Some(Value::Null) => Ok(Value::Object(Default::default())),
         Some(other) => Err(ActionError::fatal(format!(
             "`data` must be a JSON object or null, got {}",

--- a/crates/plugin-core/src/lib.rs
+++ b/crates/plugin-core/src/lib.rs
@@ -39,6 +39,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod actions;
 pub mod condition;

--- a/crates/plugin/macros/src/lib.rs
+++ b/crates/plugin/macros/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -30,6 +30,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod dependency;
 mod error;

--- a/crates/resilience/src/lib.rs
+++ b/crates/resilience/src/lib.rs
@@ -126,6 +126,13 @@
 #![allow(clippy::module_name_repetitions)]
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+// `loom` (optional dep behind the `loom` feature) is exercised only under
+// `--cfg loom` (RUSTFLAGS, loom chaos jobs); anchor the feature-on/cfg-off
+// combination so `unused_crate_dependencies` stays truthful.
+#[cfg(all(feature = "loom", not(loom)))]
+use loom as _;
 
 // ── Modules ────────────────────────────────────────────────────────────────
 

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 # `register_and_bind` method on `ResourceActivatorRegistry` (which stages
 # rotation fan-out reverse-index binds before the Manager row is published).
 # `scopeguard` is required only for the RAII rollback in `register_and_bind`.
-rotation = ["scopeguard"]
+rotation = ["scopeguard", "smallvec"]
 
 [dependencies]
 # Nebula ecosystem
@@ -46,7 +46,7 @@ arc-swap = { workspace = true }
 serde = { workspace = true }
 semver = { workspace = true }
 dashmap = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 scopeguard = { workspace = true, optional = true }

--- a/crates/resource/macros/src/lib.rs
+++ b/crates/resource/macros/src/lib.rs
@@ -91,6 +91,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -224,6 +224,7 @@
 #![warn(clippy::missing_panics_doc)]
 #![warn(clippy::missing_errors_doc)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub(crate) mod cell;
 pub mod context;

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -1,5 +1,7 @@
 //! Compile-time macros for nebula-schema.
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 use proc_macro::TokenStream;
 use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Span, TokenStream as TokenStream2};

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -162,6 +162,7 @@
 // supports `async fn` in traits directly; the schema crate ships a
 // `BoxFuture`-style `EvalFuture` alias for object-safe usage instead.
 #![deny(clippy::disallowed_macros)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 // Allow `nebula_schema::Foo` to resolve from inside the crate too (lib unit
 // tests, examples_include, internal docs). The proc-macro `field_key!` emits

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 # Utilities
-uuid = { workspace = true }
+uuid = { workspace = true, optional = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
@@ -46,7 +46,7 @@ rstest = { workspace = true }
 [features]
 default = ["derive", "testing"]
 derive = []
-testing = []
+testing = ["dep:uuid"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -54,3 +54,22 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+# ── cargo-check-external-types (ENGINEERING_2026 Tier 1 §4; iroh/wasmtime) ──
+# The SDK is the public facade: re-exporting the nebula-* crates is its job.
+# Ecosystem types below are deliberate public-API surface; anything NOT listed
+# failing the gate means a foreign type leaked into the API by accident.
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  "nebula_*",
+  # whole-crate re-exports (`pub use serde;` etc.) need the bare form
+  "serde",
+  "serde_json",
+  "thiserror",
+  "tokio",
+  "serde_core::*",
+  "serde_derive::*",
+  "serde_json::*",
+  "chrono::*",
+  "thiserror_impl::*",
+]

--- a/crates/sdk/macros-support/src/lib.rs
+++ b/crates/sdk/macros-support/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 /// Attribute parsing utilities.
 pub mod attrs;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -42,6 +42,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 // Re-export core crates
 pub use nebula_action;

--- a/crates/storage-loom-probe/src/lib.rs
+++ b/crates/storage-loom-probe/src/lib.rs
@@ -27,6 +27,7 @@
 //! --profile ci --no-tests=pass
 
 #![cfg(loom)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod lease_handoff;
 

--- a/crates/storage-port/src/lib.rs
+++ b/crates/storage-port/src/lib.rs
@@ -11,6 +11,7 @@
 //! without an upward dependency on the tenancy policy crate.
 #![warn(missing_docs)]
 #![warn(clippy::all)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod batch;
 /// Port-local row/record DTOs.

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -61,19 +61,6 @@ sqlx = { workspace = true, optional = true, features = [
   "chrono",
 ] }
 hex = { version = "0.4", optional = true }
-redis = { version = "1.2", optional = true, features = ["tokio-comp"] }
-aws-config = { version = "1.8", optional = true, default-features = false, features = [
-  "credentials-process",
-  "default-https-client",
-  "rt-tokio",
-  "sso",
-] }
-aws-sdk-s3 = { version = "1.129", optional = true, default-features = false, features = [
-  "default-https-client",
-  "http-1x",
-  "rt-tokio",
-  "sigv4a",
-] }
 rmp-serde = { version = "1", optional = true }
 
 [features]
@@ -97,8 +84,6 @@ credential-in-memory = []
 # needed separately.
 postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/tls-rustls-ring-native-roots", "dep:hex"]
 sqlite = ["dep:sqlx", "sqlx/sqlite"]
-redis = ["dep:redis"]
-s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
 msgpack-storage = ["dep:rmp-serde"]
 
 [dev-dependencies]
@@ -127,7 +112,7 @@ doctest = false
 # whose backend implementations live behind the feature guard. Kept
 # declared so the backend surface is stable even while implementation
 # is landing incrementally.
-ignored = ["aws-config", "aws-sdk-s3", "redis"]
+ignored = []
 
 [package.metadata.docs.rs]
 # Render feature-gated items on docs.rs (build with every feature).

--- a/crates/storage/src/credential/provider_cache.rs
+++ b/crates/storage/src/credential/provider_cache.rs
@@ -128,7 +128,7 @@ struct ProviderExpiry {
 impl ProviderExpiry {
     fn effective_ttl(&self, value_ttl: Option<Duration>) -> Duration {
         value_ttl
-            .or((!self.default_ttl.is_zero()).then_some(self.default_ttl))
+            .or_else(|| (!self.default_ttl.is_zero()).then_some(self.default_ttl))
             .filter(|d| !d.is_zero())
             .unwrap_or(Duration::ZERO)
     }

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -109,7 +109,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         let mut claimed = Vec::new();
         for id in ids.into_iter().take(batch_size as usize) {
             if let Some(q) = st.jobs.get_mut(&id) {
-                q.status = "Processing".to_owned();
+                "Processing".clone_into(&mut q.status);
                 q.processed_by = Some(*processor);
                 q.processed_at = Some(now);
                 q.msg.reclaim_count = q.reclaim_count;
@@ -138,7 +138,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
             && q.status == "Processing"
             && q.processed_by.as_ref() == Some(processor)
         {
-            q.status = "Dispatched".to_owned();
+            "Dispatched".clone_into(&mut q.status);
             return Ok(());
         }
         Err(StorageError::NotFound {
@@ -159,7 +159,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
             && q.status == "Processing"
             && q.processed_by.as_ref() == Some(processor)
         {
-            q.status = "Failed".to_owned();
+            "Failed".clone_into(&mut q.status);
             q.error_message = Some(error.to_owned());
             return Ok(());
         }
@@ -189,14 +189,14 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
                 continue;
             }
             if q.reclaim_count >= max_reclaim_count {
-                q.status = "Failed".to_owned();
+                "Failed".clone_into(&mut q.status);
                 q.error_message = Some(format!(
                     "reclaim exhausted: presumed dead after {} reclaims",
                     q.reclaim_count
                 ));
                 outcome.exhausted += 1;
             } else {
-                q.status = "Pending".to_owned();
+                "Pending".clone_into(&mut q.status);
                 q.reclaim_count = q.reclaim_count.saturating_add(1);
                 q.processed_by = None;
                 q.processed_at = None;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -53,6 +53,7 @@
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 /// Credential persistence (encryption, audit, refresh claims, pending state).
 pub mod credential;

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -2793,7 +2793,7 @@ pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backe
     let row = TriggerDedupRow::new("trg_rb", "evt_rb", s.clone(), "2026-01-01T00:00:00Z");
     let mut job = make_job(0x80, "plugin.rb", &["plugin.rb"]);
     // Override the execution_id to the colliding id.
-    job.execution_id = "exe_collision".to_owned();
+    "exe_collision".clone_into(&mut job.execution_id);
 
     let (wf_id, initial) = make_new_execution();
     let exec = NewExecution::new(&wf_id, &initial);
@@ -2859,7 +2859,7 @@ pub async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend
     // 2. Second compose reuses the SAME job id (0xB0), different execution id.
     let row2 = TriggerDedupRow::new("trg_j2", "evt_j2", s.clone(), "2026-01-01T00:00:00Z");
     let mut job2 = make_job(0xB0, "plugin.jid", &["plugin.jid"]);
-    job2.execution_id = "exe_jid_other".to_owned();
+    "exe_jid_other".clone_into(&mut job2.execution_id);
     let (wf2, init2) = make_new_execution();
     let exec2 = NewExecution::new(&wf2, &init2);
     let result = inbox

--- a/crates/tenancy/Cargo.toml
+++ b/crates/tenancy/Cargo.toml
@@ -23,7 +23,6 @@ nebula-storage-port = { path = "../storage-port" }
 nebula-credential = { path = "../credential" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tenancy/src/decorator/resource.rs
+++ b/crates/tenancy/src/decorator/resource.rs
@@ -58,7 +58,7 @@ impl ScopedResourceStore {
     /// predicates behave exactly as for any in-tenant row — never a
     /// cross-tenant write, never an existence-leaking error.
     fn rebind(&self, mut row: ResourceRow) -> ResourceRow {
-        row.workspace_id = self.bound.workspace_id.clone();
+        row.workspace_id.clone_from(&self.bound.workspace_id);
         row
     }
 }

--- a/crates/tenancy/src/decorator/trigger.rs
+++ b/crates/tenancy/src/decorator/trigger.rs
@@ -61,7 +61,7 @@ impl ScopedTriggerStore {
     /// predicates behave exactly as for any in-tenant row — never a
     /// cross-tenant write, never an existence-leaking error.
     fn rebind(&self, mut row: TriggerRow) -> TriggerRow {
-        row.workspace_id = self.bound.workspace_id.clone();
+        row.workspace_id.clone_from(&self.bound.workspace_id);
         row
     }
 }

--- a/crates/tenancy/src/lib.rs
+++ b/crates/tenancy/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! [`Scope`]: nebula_storage_port::Scope
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 mod credential_scope;
 mod decorator;
 mod error;

--- a/crates/validator/macros/src/lib.rs
+++ b/crates/validator/macros/src/lib.rs
@@ -68,6 +68,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 extern crate proc_macro;
 

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -53,6 +53,7 @@
 // Deep combinator nesting (And<Or<Not<...>,...>,...>) produces complex types
 // that are inherent to the type-safe combinator architecture.
 #![allow(clippy::type_complexity)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 // ── Public modules ──────────────────────────────────────────────────────────
 /// Combinator types for composing validators.

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-worker — Generic worker runtime (ADR-0095 D1)
 //!

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 //! # nebula-workflow
 //!

--- a/docs/ENGINEERING_2026.md
+++ b/docs/ENGINEERING_2026.md
@@ -26,17 +26,17 @@ project studied. Divergence from these needs a written reason.
 | C1 | `[workspace.lints]` in root Cargo.toml; every crate `[lints] workspace = true`; **every allow/deny decision listed with a comment, never silent** | all five | ✅ done |
 | C2 | Restriction lints promoted: `print_stdout`, `print_stderr`, `dbg_macro` warn/deny — all output flows through one sink (`tracing` / a `Printer`) | uv, rust-analyzer, iroh | ✅ done (2026-07-06) |
 | C3 | `#[expect(..., reason)]` over `#[allow]`; stale suppressions fail the gate | uv (AGENTS.md), Nebula | ✅ done (2026-07-06) |
-| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ❌ gap #1 — proven by the 2026-07-06 `cfg_attr(not(feature))` incident |
-| C5 | Rustdoc is a hard gate: `RUSTDOCFLAGS="-D warnings"` on the workspace | reth, omicron, iroh | ❌ gap |
-| C6 | Unused-dependency control is mechanized: `unused_crate_dependencies` warn per crate + udeps/machete/shear in CI | reth (all three layers), uv (shear) | 🟡 partial (machete only) |
+| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ✅ done (2026-07-07): workspace clippy on default + no-default in `check`, cargo-hack each-feature |
+| C5 | Rustdoc is a hard gate: `RUSTDOCFLAGS="-D warnings"` on the workspace | reth, omicron, iroh | ✅ already in place (`doc` job runs `RUSTDOCFLAGS=-D warnings`) |
+| C6 | Unused-dependency control is mechanized: `unused_crate_dependencies` warn per crate + udeps/machete/shear in CI | reth (all three layers), uv (shear) | ✅ done (2026-07-07): per-crate `unused_crate_dependencies` + udeps weekly + machete; 15 dead deps purged on adoption |
 | C7 | Generated artifacts are committed and CI re-generates + `git diff --exit-code` | rust-analyzer (`codegen --check`), uv (`check-generated-files`), omicron (openapi), reth (CLI docs) | ❌ not yet needed at scale; adopt with schema export |
 | C8 | A project-specific hermetic **test-context crate** (temp dirs, pinned env, frozen clock, redaction filters) | uv (`uv-test`, 2500 loc), omicron (`#[nexus_test]`), iroh (patchbay netsim) | 🟡 partial (`test-utils` exists, not formalized) |
-| C9 | One aggregator required-check (`alls-green` / `required-checks-passed`); branch protection points at it, not at N jobs | reth, uv | ❌ gap |
+| C9 | One aggregator required-check (`alls-green` / `required-checks-passed`); branch protection points at it, not at N jobs | reth, uv | ✅ already in place (`required` aggregator job) |
 | C10 | Conventional commits enforced mechanically (PR title check / convco) | iroh, reth, uv, Nebula | ✅ done |
-| C11 | nextest as the runner, with per-test overrides (serial groups, slow-timeouts, retries) | reth, uv, omicron | 🟡 partial (no `.config/nextest.toml` tuning) |
-| C12 | SHA-pinned GitHub Actions + workflow security audit (`zizmor`) | uv, reth | ❌ gap |
+| C11 | nextest as the runner, with per-test overrides (serial groups, slow-timeouts, retries) | reth, uv, omicron | ✅ already in place (trybuild groups, ci/agent/chaos profiles) |
+| C12 | SHA-pinned GitHub Actions + workflow security audit (`zizmor`) | uv, reth | ✅ done (2026-07-07): actions were already SHA-pinned; zizmor gate added (high severity) |
 | C13 | Path-/label-driven CI matrix: a plan job diffs changed files and toggles expensive suites; opt-in labels or commit magic (`prtest:full`) for the rest | uv (plan job), wasmtime (`determine` + `prtest:`), turso (diff→targeted Antithesis coverage) | ❌ gap |
-| C14 | Async-perf footgun lints **denied**: `await_holding_lock`, `redundant_clone`, `or_fun_call`, `assigning_clones`, `large_stack_frames` | restate + turso (deny), vector (`await_holding_lock` warn) | 🟡 partial — Nebula *allows* `or_fun_call`/`assigning_clones`; reconsider |
+| C14 | Async-perf footgun lints **denied**: `await_holding_lock`, `redundant_clone`, `or_fun_call`, `assigning_clones`, `large_stack_frames` | restate + turso (deny), vector (`await_holding_lock` warn) | ✅ done (2026-07-07): all four now warn; 13 sites fixed |
 | C15 | Every `unsafe` block carries a `SAFETY:` comment, lint-enforced (`undocumented_unsafe_blocks`) | wasmtime (~341 in one crate + policy doc), bevy (lint = warn) | ✅ clippy.toml configures it; `unsafe_code = "warn"` workspace-wide |
 | C16 | Backend conformance suite: one shared test suite run against every implementation of a port/trait | restate (`loglet_tests.rs` over memory/local/replicated), vector (component compliance) | ✅ `crates/storage/tests/conformance.rs` — same instinct, keep extending |
 
@@ -237,20 +237,34 @@ The blueprint for making durable execution deterministically testable:
 
 ## 3. Adoption plan
 
-### Tier 1 — quick wins (CI/config only, no code churn)
+### Tier 1 — quick wins (CI/config only, no code churn) — **SHIPPED 2026-07-07**
 
-1. **Feature-matrix clippy** (C4): add default + `--no-default-features`
-   clippy jobs; `cargo hack --each-feature` for feature-heavy crates
-   (`log`, `credential`, `resource`, `storage`).
-2. **Rustdoc gate** (C5): `RUSTDOCFLAGS="-D warnings"` workspace job.
-3. **Dep hygiene** (C6): `unused_crate_dependencies` in workspace lints
-   (cfg-gated to non-test) + reth's no-test-deps-in-release `cargo tree` check.
-4. **`cargo-check-external-types`** on `sdk` and `api` (the public crates).
-5. **Aggregator check** (C9) + SHA-pin actions + `zizmor` (C12).
-6. `.config/nextest.toml`: serial groups for DB tests, slow-timeout kill.
-7. **Async-footgun lints** (C14): flip `or_fun_call` and `assigning_clones`
-   from allow to warn; add `large_futures` and `await_holding_lock` warns
-   (restate/turso/vector consensus).
+1. ✅ **Feature-matrix clippy** (C4): `check` job now runs workspace clippy on
+   default and `--no-default-features` after the all-features pass;
+   `feature-hygiene` (cargo-hack `--each-feature`, 108 configs) was already
+   in place for type errors.
+2. ✅ **Rustdoc gate** (C5): was already in place (`doc` job,
+   `RUSTDOCFLAGS=-D warnings`, `--document-private-items`).
+3. ✅ **Dep hygiene** (C6): `#![cfg_attr(not(test), warn(unused_crate_dependencies))]`
+   in all 36 lib.rs. Adoption immediately exposed **15 dead dependencies**
+   (incl. the whole never-implemented `redis`/`s3` storage features, which
+   machete had been told to ignore) — all purged. Feature-conditional deps
+   (`loom`, `smallvec`, `uuid`) became properly optional or cfg-anchored.
+   Plus reth's no-test-deps-in-release `cargo tree` gate (`test-dep-leak` job).
+4. ✅ **`cargo-check-external-types`** on `sdk` and `api` with per-crate
+   allowlists (`external-types` job, nightly-2026-03-20 ↔ tool 0.5.0).
+5. ✅ **Aggregator + workflow security**: aggregator (`required` job) and
+   SHA-pinned actions were already in place; **zizmor** gate added at
+   high severity — its 4 pre-existing high findings (workflow-level
+   `actions:/issues:/id-token: write` permissions, template injection in
+   `test-matrix.yml`) fixed. 24 medium findings (persist-credentials on
+   checkouts) tracked as follow-up.
+6. ✅ `.config/nextest.toml`: was already in place (trybuild serial group,
+   ci/agent/chaos profiles).
+7. ✅ **Async-footgun lints** (C14): `or_fun_call`, `assigning_clones`,
+   `large_futures`, `await_holding_lock` now warn; 13 call sites fixed;
+   `large_futures`/`await_holding_lock` had zero hits — the architecture
+   was already clean.
 
 ### Tier 2 — medium (a week of focused work each)
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 # Nebula rustfmt configuration.
 #
 # Stable-only: runs cleanly on the toolchain pinned in `rust-toolchain.toml`
-# (currently 1.95). Apply locally with:
+# (currently 1.96). Apply locally with:
 #
 #     cargo fmt --all
 #


### PR DESCRIPTION
## Summary

Ships **Tier 1 of `docs/ENGINEERING_2026.md`** — the CI/tooling quick wins distilled from the ten-codebase study. Three commits:

### 1. Async-footgun lints (C14 — restate/turso/vector consensus)
`or_fun_call`, `assigning_clones` flipped from allow to warn; `large_futures`, `await_holding_lock` added. Fallout: 13 sites fixed (`clone_into`/`clone_from`/`or_else`); the two heavyweight lints (`large_futures`, `await_holding_lock`) had **zero hits** — the async architecture was already clean.

### 2. Dependency hygiene (C6 — reth pattern)
`#![cfg_attr(not(test), warn(unused_crate_dependencies))]` in all 36 lib.rs. Adoption immediately paid for itself: **15 dead dependencies purged**, including the never-implemented `redis`/`s3` storage features whose deps (aws-config, aws-sdk-s3, redis) had been hand-listed in machete's ignore block — invisible to every existing tool. Feature-conditional deps became honest: `smallvec` → optional under `rotation`, sdk `uuid` → optional under `testing`, `loom` cfg-anchored. Engine's `nebula-schema` moved to dev-dependencies (test-only user).

### 3. CI gates
- **Feature-matrix clippy** (C4): `check` job now lints workspace on default and `--no-default-features` after the all-features pass — closing the exact `cfg_attr(not(feature))` blind spot that survived #951.
- **`test-dep-leak`**: reth's `cargo tree -e normal` gate — test-only crates (proptest, mockall, loom, …) must never reach `nebula-server`/`nebula-worker-bin` release dep trees.
- **`external-types`**: `cargo-check-external-types` (pinned nightly-2026-03-20 ↔ tool 0.5.0) on the API-boundary crates with explicit allowlists in `crates/{sdk,api}/Cargo.toml` — new third-party types in the public API are now a conscious decision.
- **`zizmor`** workflow-security gate (high severity) — its 4 pre-existing high findings fixed: workflow-level `actions:/issues:/id-token: write` narrowed to job level (cleanup, codspeed, security-audit), template-injection in `test-matrix.yml` hoisted to `env:`. 24 medium findings (persist-credentials) left as tracked follow-up, deliberately non-blocking.
- All new jobs wired into the `required` aggregator.

## Verification

- clippy workspace × {all-features, default, no-default}: **0 warnings**
- `cargo hack check --each-feature` (108 configs): clean
- Full workspace tests: **6074/6074 passed**
- Doc gate (`RUSTDOCFLAGS=-D warnings --document-private-items`): clean
- `check-external-types` on sdk + api: 0 errors, 0 warnings (allowlists exact)
- test-dep-leak dry-run: both binaries clean
- fmt, typos, cargo-deny: clean; all workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)