### PR TITLE
chore: tighten the clippy allowlist — 62 → 45 named allows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,10 +272,8 @@ use_self = "allow"                      # fires inside macro expansions
 redundant_pub_crate = "allow"           # conflicts with the sdk re-export façade
 significant_drop_tightening = "allow"   # too many false positives
 significant_drop_in_scrutinee = "allow"
-branches_sharing_code = "allow"         # often makes branches less readable
 cognitive_complexity = "allow"          # threshold lives in clippy.toml
 future_not_send = "allow"               # `Send` bound on futures is runtime's call
-ignore_without_reason = "allow"         # gated by clippy-cargo, too strict for tests
 
 # ── pedantic stylistic noise that is not worth churning code over ─────────
 items_after_statements = "allow" # late-initialised helpers inside fn bodies
@@ -298,24 +296,9 @@ unnecessary_wraps = "allow"                  # API-consistency `Result` on built
 # taste or a micro-optimisation that would mean an API break. Revisit when a
 # refactor naturally touches the site.
 wildcard_imports = "allow"                    # kept noisy but shelved: prelude / re-export patterns
-trivially_copy_pass_by_ref = "allow"
-needless_pass_by_ref_mut = "allow"
-needless_collect = "allow"
 map_unwrap_or = "allow"
 excessive_nesting = "allow"                   # threshold lives in clippy.toml
-useless_let_if_seq = "allow"
-unused_peekable = "allow"
-type_repetition_in_bounds = "allow"
-trivial_regex = "allow"
-struct_field_names = "allow"                  # threshold lives in clippy.toml
-literal_string_with_formatting_args = "allow"
-into_iter_without_iter = "allow"
 inline_always = "allow"                       # `#[inline(always)]` on cold happy paths is intentional
-implicit_hasher = "allow"
-doc_link_with_quotes = "allow"
-iter_on_single_items = "allow"
-from_iter_instead_of_collect = "allow"
-enum_glob_use = "allow"
 
 # ── cargo: expected noise in a multi-crate workspace ───────────────────────
 multiple_crate_versions = "allow" # transitive dep version skew is unavoidable

--- a/crates/action/tests/schema_validator_expression_pipeline.rs
+++ b/crates/action/tests/schema_validator_expression_pipeline.rs
@@ -57,6 +57,10 @@ impl HasSchema for PipelineInput {
     }
 }
 
+#[expect(
+    clippy::struct_field_names,
+    reason = "field names mirror the pipeline wire format asserted by this test"
+)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct PipelineOutput {
     seen_name: String,

--- a/crates/api/src/domain/execution/handler.rs
+++ b/crates/api/src/domain/execution/handler.rs
@@ -58,10 +58,10 @@ pub async fn list_executions(
     // Apply pagination over the running list.
     let offset = params.offset();
     let limit = params.limit();
-    let page_ids: Vec<&ExecutionId> = running_ids.iter().skip(offset).take(limit).collect();
-
-    let executions: Vec<RunningExecutionSummary> = page_ids
-        .into_iter()
+    let executions: Vec<RunningExecutionSummary> = running_ids
+        .iter()
+        .skip(offset)
+        .take(limit)
         .map(|id| RunningExecutionSummary { id: id.to_string() })
         .collect();
 

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -162,17 +162,9 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
     fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
         // `iter_compatible(empty)` enumerates every registered type
         // (registry.rs:212 — empty is a subset of any capability set).
-        let keys: Vec<String> = self
-            .registry
+        self.registry
             .iter_compatible(Capabilities::empty())
-            .map(|(k, _caps)| k.to_owned())
-            .collect();
-        keys.into_iter()
-            .filter_map(|k| {
-                self.registry
-                    .resolve_any(&k)
-                    .map(|any| self.descriptor(any))
-            })
+            .filter_map(|(k, _caps)| self.registry.resolve_any(k).map(|any| self.descriptor(any)))
             .collect()
     }
 

--- a/crates/api/src/telemetry_init.rs
+++ b/crates/api/src/telemetry_init.rs
@@ -268,9 +268,8 @@ pub fn init_api_telemetry() -> Result<TelemetryGuard, TelemetryInitError> {
 fn build_tracer_provider() -> Result<(SdkTracerProvider, Tracer, bool), TelemetryInitError> {
     let resource = build_resource();
     let mut builder = SdkTracerProvider::builder().with_resource(resource);
-    let mut otlp_attached = false;
 
-    if let Some(endpoint) = resolve_otlp_endpoint() {
+    let otlp_attached = if let Some(endpoint) = resolve_otlp_endpoint() {
         let exporter = build_otlp_span_exporter(&endpoint).map_err(|source| {
             TelemetryInitError::SpanExporter {
                 endpoint: endpoint.clone(),
@@ -285,8 +284,10 @@ fn build_tracer_provider() -> Result<(SdkTracerProvider, Tracer, bool), Telemetr
         } else {
             builder = builder.with_simple_exporter(exporter);
         }
-        otlp_attached = true;
-    }
+        true
+    } else {
+        false
+    };
 
     let provider = builder.build();
     let tracer = provider.tracer(TRACER_INSTRUMENTATION_NAME);

--- a/crates/api/tests/org_e2e.rs
+++ b/crates/api/tests/org_e2e.rs
@@ -216,13 +216,13 @@ async fn add_member_grants_role_and_is_listed() {
     // Now visible in the list.
     let app = app::build_app(state, &api_config);
     let listed = body_json(app.oneshot(get(&members_path(), &admin.jwt)).await.unwrap()).await;
-    let ids: Vec<&str> = listed["members"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|m| m["principal_id"].as_str().unwrap())
-        .collect();
-    assert!(ids.contains(&newcomer.as_str()));
+    assert!(
+        listed["members"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|m| m["principal_id"].as_str().unwrap() == newcomer.as_str())
+    );
 }
 
 #[tokio::test]

--- a/crates/core/src/scope.rs
+++ b/crates/core/src/scope.rs
@@ -367,6 +367,10 @@ mod tests {
         let workflow_id = WorkflowId::new();
         let execution_id = ExecutionId::new();
 
+        #[expect(
+            clippy::struct_field_names,
+            reason = "fields mirror the ScopeResolver vocabulary one-to-one"
+        )]
         struct MockResolver {
             org_id: OrgId,
             ws_id: WorkspaceId,

--- a/crates/credential/tests/registry_capabilities_iter.rs
+++ b/crates/credential/tests/registry_capabilities_iter.rs
@@ -287,12 +287,11 @@ fn iter_compatible_with_anded_filter_requires_every_flag() {
 
     // Asking for a flag the refreshable probe does NOT declare (TESTABLE)
     // returns nothing.
-    let none: Vec<&str> = registry
-        .iter_compatible(Capabilities::REFRESHABLE | Capabilities::TESTABLE)
-        .map(|(k, _)| k)
-        .collect();
     assert!(
-        none.is_empty(),
+        registry
+            .iter_compatible(Capabilities::REFRESHABLE | Capabilities::TESTABLE)
+            .next()
+            .is_none(),
         "AND filter requires every flag; missing TESTABLE must exclude every entry"
     );
 }

--- a/crates/engine/src/credential_accessor.rs
+++ b/crates/engine/src/credential_accessor.rs
@@ -288,8 +288,7 @@ mod tests {
 
     #[tokio::test]
     async fn allows_declared_key_and_delegates_to_resolver() {
-        let allowed_keys: HashSet<String> =
-            ["my_credential"].iter().map(ToString::to_string).collect();
+        let allowed_keys: HashSet<String> = HashSet::from(["my_credential".to_string()]);
 
         let accessor = EngineCredentialAccessor::new(
             allowed_keys,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2309,13 +2309,7 @@ impl WorkflowEngine {
             // non-terminal conflicts before surfacing a typed
             // `CasConflict` error.
             match self
-                .persist_final_state(
-                    scope,
-                    execution_id,
-                    &mut exec_state,
-                    &mut repo_version,
-                    fencing,
-                )
+                .persist_final_state(scope, execution_id, &exec_state, &mut repo_version, fencing)
                 .await
             {
                 Ok(None) => final_status,
@@ -2690,7 +2684,7 @@ fn evaluate_edge(
     result: Option<&ActionResult<serde_json::Value>>,
     node_failed: bool,
 ) -> bool {
-    use ActionResult::*;
+    use ActionResult::{Branch, Drop, MultiOutput, Route, Skip, Terminate, Wait};
 
     // Skip / Drop / Terminate never activate any edge.
     if matches!(result, Some(Skip { .. } | Drop { .. } | Terminate { .. })) {

--- a/crates/engine/src/engine/persistence.rs
+++ b/crates/engine/src/engine/persistence.rs
@@ -472,7 +472,7 @@ impl WorkflowEngine {
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
-        exec_state: &mut ExecutionState,
+        exec_state: &ExecutionState,
         repo_version: &mut u64,
         fencing: Option<nebula_storage_port::FencingToken>,
     ) -> Result<Option<ExecutionStatus>, EngineError> {
@@ -509,7 +509,7 @@ impl WorkflowEngine {
         scope: &Scope,
         stores: &crate::store_seam::ExecutionStores,
         execution_id: ExecutionId,
-        exec_state: &mut ExecutionState,
+        exec_state: &ExecutionState,
         repo_version: &mut u64,
         token: nebula_storage_port::FencingToken,
     ) -> Result<Option<ExecutionStatus>, EngineError> {
@@ -532,7 +532,7 @@ impl WorkflowEngine {
         };
 
         let state_json =
-            serde_json::to_value(&*exec_state).map_err(|e| EngineError::CheckpointFailed {
+            serde_json::to_value(exec_state).map_err(|e| EngineError::CheckpointFailed {
                 node_key: final_state_node_key(),
                 reason: format!("serialize final state: {e}"),
             })?;
@@ -623,7 +623,7 @@ impl WorkflowEngine {
                     return Ok(observed_status_enum);
                 }
 
-                let retry_json = match serde_json::to_value(&*exec_state) {
+                let retry_json = match serde_json::to_value(exec_state) {
                     Ok(v) => v,
                     Err(e) => {
                         return Err(EngineError::CheckpointFailed {

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -482,13 +482,7 @@ impl WorkflowEngine {
             // reach this point when the spec-16 bundle is configured.
             // Mirrors `execute_workflow` — see its comment for the full contract.
             match self
-                .persist_final_state(
-                    scope,
-                    execution_id,
-                    &mut exec_state,
-                    &mut repo_version,
-                    fencing,
-                )
+                .persist_final_state(scope, execution_id, &exec_state, &mut repo_version, fencing)
                 .await
             {
                 Ok(None) => final_status,

--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -4469,7 +4469,7 @@ async fn persist_final_state_retries_once_on_nonterminal_conflict() {
             &scope,
             &stores.execution_stores(),
             execution_id,
-            &mut engine_final_state,
+            &engine_final_state,
             &mut repo_version,
             token,
         )
@@ -4589,7 +4589,7 @@ async fn persist_final_state_honors_external_terminal_transition() {
             &scope,
             &stores.execution_stores(),
             execution_id,
-            &mut engine_final_state,
+            &engine_final_state,
             &mut repo_version,
             token,
         )

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -632,13 +632,12 @@ async fn reclaim_sweep_recovers_orphaned_processing_row_end_to_end() {
 
     // The dispatch observed exactly one successful Cancel (second call).
     let observed = dispatch_flaky.snapshot();
-    let cancels_for_exec: Vec<_> = observed
+    let cancels_for_exec = observed
         .iter()
         .filter(|(cmd, id)| *cmd == ControlCommand::Cancel && *id == exec)
-        .collect();
+        .count();
     assert_eq!(
-        cancels_for_exec.len(),
-        1,
+        cancels_for_exec, 1,
         "exactly one successful dispatch recorded (first stalled), got {observed:?}"
     );
 }

--- a/crates/expression/src/context.rs
+++ b/crates/expression/src/context.rs
@@ -20,7 +20,7 @@ use crate::policy::EvaluationPolicy;
 /// the same owner are in-place.
 #[derive(Debug, Clone)]
 pub struct EvaluationContext {
-    /// Node data ($node['name'].data)
+    /// Node data (`$node['name'].data`)
     nodes: Arc<HashMap<Arc<str>, Arc<Value>>>,
     /// Execution variables ($execution.id, $execution.mode, etc.)
     execution_vars: Arc<HashMap<Arc<str>, Arc<Value>>>,

--- a/crates/log/src/builder/telemetry.rs
+++ b/crates/log/src/builder/telemetry.rs
@@ -12,6 +12,13 @@
 ///
 /// # Feature flags
 /// - `sentry`: Enables Sentry integration
+#[cfg_attr(
+    not(feature = "sentry"),
+    expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "only the sentry integration mutates the inner state"
+    )
+)]
 pub(super) fn init_telemetry(
     #[cfg_attr(
         not(feature = "sentry"),

--- a/crates/log/src/observability/span.rs
+++ b/crates/log/src/observability/span.rs
@@ -16,26 +16,29 @@ use super::{
 ///
 /// This mimics `tracing` span behavior where child spans inherit parent attributes.
 pub fn get_current_logger_resource() -> Option<LoggerResource> {
-    let mut base = LoggerResource::default();
-    let mut found_any = false;
+    let mut acc: Option<LoggerResource> = None;
 
     // 1. Merge from Execution context (lower priority)
     if let Some(exec) = ExecutionContext::current()
         && let Some(logger) = exec.resources.get::<LoggerResource>()
     {
-        base = merge_logger_resources(base, (*logger).clone());
-        found_any = true;
+        acc = Some(merge_logger_resources(
+            acc.unwrap_or_default(),
+            (*logger).clone(),
+        ));
     }
 
     // 2. Merge from Node context (highest priority)
     if let Some(node) = NodeContext::current()
         && let Some(logger) = node.get_resource::<LoggerResource>()
     {
-        base = merge_logger_resources(base, (*logger).clone());
-        found_any = true;
+        acc = Some(merge_logger_resources(
+            acc.unwrap_or_default(),
+            (*logger).clone(),
+        ));
     }
 
-    if found_any { Some(base) } else { None }
+    acc
 }
 
 /// Merge two LoggerResources (second overrides first)

--- a/crates/log/tests/integration_tests.rs
+++ b/crates/log/tests/integration_tests.rs
@@ -102,6 +102,10 @@ fn test_concurrent_registration() {
     shutdown_hooks();
 
     // Spawn multiple threads registering hooks concurrently
+    #[expect(
+        clippy::needless_collect,
+        reason = "all threads must be spawned before the first join; collecting is the barrier"
+    )]
     let handles: Vec<_> = (0..5)
         .map(|_i| {
             thread::spawn(move || {

--- a/crates/metadata/src/base.rs
+++ b/crates/metadata/src/base.rs
@@ -61,6 +61,10 @@ pub struct BaseMetadata<K> {
     pub deprecation: Option<DeprecationNotice>,
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires the &T signature"
+)]
 fn is_default_maturity(m: &MaturityLevel) -> bool {
     *m == MaturityLevel::default()
 }

--- a/crates/metadata/src/manifest.rs
+++ b/crates/metadata/src/manifest.rs
@@ -92,6 +92,10 @@ fn is_default_version(v: &Version) -> bool {
     v == &default_version()
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if requires the &T signature"
+)]
 fn is_default_maturity(m: &MaturityLevel) -> bool {
     *m == MaturityLevel::default()
 }

--- a/crates/plugin/src/registry.rs
+++ b/crates/plugin/src/registry.rs
@@ -246,7 +246,6 @@ mod tests {
         let mut reg = PluginRegistry::new();
         reg.register(make("a")).unwrap();
         reg.register(make("b")).unwrap();
-        let keys: Vec<_> = reg.iter().map(|(k, _)| k.as_str().to_owned()).collect();
-        assert_eq!(keys.len(), 2);
+        assert_eq!(reg.iter().count(), 2);
     }
 }

--- a/crates/resource/tests/recovery_and_shutdown.rs
+++ b/crates/resource/tests/recovery_and_shutdown.rs
@@ -1028,7 +1028,7 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
     }
     assert!(
         saw_health_change,
-        "drain-abort must emit HealthChanged{{healthy:false}} per resource"
+        "drain-abort must emit HealthChanged(healthy=false) per resource"
     );
 }
 

--- a/crates/validator/src/foundation/error/pointer.rs
+++ b/crates/validator/src/foundation/error/pointer.rs
@@ -29,7 +29,7 @@ pub(crate) fn to_json_pointer(path: &str) -> Option<String> {
 
     let mut segments: Vec<String> = Vec::new();
     let mut current = String::new();
-    let mut chars = path.chars().peekable();
+    let mut chars = path.chars();
 
     while let Some(ch) = chars.next() {
         match ch {

--- a/crates/validator/src/foundation/error/validation_error.rs
+++ b/crates/validator/src/foundation/error/validation_error.rs
@@ -399,11 +399,9 @@ pub(crate) fn render_template<'a>(
                 out.push('}');
             }
         } else if c == '}' {
+            out.push('}');
             if matches!(chars.peek(), Some((_, '}'))) {
-                out.push('}');
                 chars.next();
-            } else {
-                out.push('}');
             }
         } else {
             out.push(c);

--- a/crates/validator/src/foundation/error/validation_errors.rs
+++ b/crates/validator/src/foundation/error/validation_errors.rs
@@ -46,6 +46,11 @@ impl ValidationErrors {
         self.errors.len()
     }
 
+    /// Iterate over the collected errors by reference.
+    pub fn iter(&self) -> std::slice::Iter<'_, ValidationError> {
+        self.errors.iter()
+    }
+
     /// Returns true if empty.
     #[must_use]
     #[inline]

--- a/crates/validator/src/rule/value.rs
+++ b/crates/validator/src/rule/value.rs
@@ -186,6 +186,10 @@ impl ValueRule {
                     .map(|v| format!("{v}"))
                     .collect::<Vec<_>>()
                     .join(", ");
+                #[expect(
+                    clippy::literal_string_with_formatting_args,
+                    reason = "{allowed} is a ValidationError message-template placeholder, not a format arg"
+                )]
                 Err(
                     ValidationError::new("one_of", "Value must be one of {allowed}")
                         .with_param("allowed", allowed)

--- a/crates/validator/tests/derive_tests.rs
+++ b/crates/validator/tests/derive_tests.rs
@@ -573,6 +573,10 @@ fn canonical_inner_nested_rejects_invalid_nested_element() {
 // 11. Custom validator
 // ============================================================================
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "custom-validator contract passes fields by reference"
+)]
 fn validate_even(value: &i32) -> Result<(), ValidationError> {
     if value % 2 == 0 {
         Ok(())

--- a/crates/validator/tests/integration/error_semantics.rs
+++ b/crates/validator/tests/integration/error_semantics.rs
@@ -87,7 +87,11 @@ fn validate_fields_returns_collection_validate_returns_single() {
     let single: ValidationError = creds.validate(&creds).unwrap_err();
     assert_eq!(single.nested().len(), 2);
     assert_has_code(
-        &ValidationErrors::from_iter(single.nested().iter().cloned()),
+        &single
+            .nested()
+            .iter()
+            .cloned()
+            .collect::<ValidationErrors>(),
         "min_length",
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to the "our setup is too lenient" observation: measured the actual violation count behind every one of the 62 named `allow`s in `[workspace.lints.clippy]`, then removed everything that was free or cheap.

**Removed 17 allows:**
- **4 with zero violations** (`type_repetition_in_bounds`, `trivial_regex`, `implicit_hasher`, `ignore_without_reason`) — pure future-leniency, deleted.
- **13 with 1–10 violations each**, all fixed (~25 unique sites): merged duplicate parser branches in validator, chained needless `collect()`s in the API pagination handler and credential-schema registry, dropped never-mutated `&mut` params (cascading through three engine `persist_final_state*` signatures and their call sites), removed a dead `.peekable()`, added the missing `ValidationErrors::iter()` that `into_iter_without_iter` demanded, restructured two `let mut flag = false; … flag = true` sequences.

**6 site-level `#[expect(..., reason)]`** where the flagged signature is framework-mandated: serde `skip_serializing_if` requires `&T`, the derive-validator contract passes by reference, validator's `{param}` message-template DSL is not a format string, and a thread-spawn `collect()` is the spawn-all-before-join barrier.

**Kept (documented, with measured cost):** the genuinely noisy allows stay — `module_name_repetitions` (1135), `missing_const_for_fn` (1423), `doc_markdown` (2063), `redundant_pub_crate` (1140 — conflicts with `unreachable_pub`; iroh precedent says enable the latter instead, tracked as a campaign), plus the documented macro false-positive set (`float_cmp`, `used_underscore_binding`, `use_self`).

Campaign backlog surfaced by the same measurement (each needs its own PR): restriction pack for prod code (~140 `unwrap`, ~150 `expect`, ~17 `panic!` in src — the edit-hook only guards agent edits), `indexing_slicing` (~360), `missing_docs` (450) / `missing_debug_implementations` (228) / `unreachable_pub` (55) crate-by-crate, `cargo_common_metadata` (fill 36 crates' metadata).

## Verification

- clippy workspace × {all-features, default, no-default}: **0 warnings**
- Full workspace tests: **6074/6074 passed**; doctests clean
- `cargo hack check -p nebula-log --each-feature` (the crate with cfg_attr surgery): clean
- fmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to iterate over collected validation errors by reference.

* **Bug Fixes**
  * Improved validation error handling and JSON pointer parsing behavior.
  * Refined execution persistence and resume flow to keep final-state handling consistent.

* **Chores**
  * Tightened lint rules and added targeted lint suppressions in tests and supporting code.
  * Simplified several internal implementations and test assertions for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->