### PR TITLE
chore: enable unreachable_pub workspace-wide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,10 +220,10 @@ unused_lifetimes = "warn"
 unused_qualifications = "warn"
 trivial_numeric_casts = "warn"
 redundant_lifetimes = "warn"
+unreachable_pub = "warn"
 # Deliberately NOT enabled workspace-wide (revisit once the core stabilises):
 # - `missing_docs` — too noisy on internal modules; will land crate-by-crate.
 # - `missing_debug_implementations` — same.
-# - `unreachable_pub` — conflicts with re-export chains in the sdk façade.
 # - `let_underscore_drop` — `let _ = tokio::spawn(...)` / `let _ = tx.send(_)`
 #   is the standard idiom for fire-and-forget; forcing `drop(x)` hurts clarity.
 #
@@ -269,7 +269,7 @@ cast_lossless = "allow"
 option_if_let_else = "allow"            # `match` often reads cleaner than .map_or
 missing_const_for_fn = "allow"          # churns with every generic bound change
 use_self = "allow"                      # fires inside macro expansions
-redundant_pub_crate = "allow"           # conflicts with the sdk re-export façade
+redundant_pub_crate = "allow"           # loses to `unreachable_pub` (the two fight; iroh precedent)
 significant_drop_tightening = "allow"   # too many false positives
 significant_drop_in_scrutinee = "allow"
 cognitive_complexity = "allow"          # threshold lives in clippy.toml

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -24,7 +24,7 @@ use crate::{
 
 /// Runtime errors for transport binaries.
 #[derive(Debug, Error)]
-pub enum ServerRunError {
+pub(crate) enum ServerRunError {
     /// API configuration cannot be loaded from environment.
     #[error("failed to load API config")]
     Config(#[from] ApiConfigError),
@@ -62,7 +62,7 @@ pub enum ServerRunError {
 
 /// Transport-specific initialization failure.
 #[derive(Debug, Error)]
-pub enum TransportInitError {
+pub(crate) enum TransportInitError {
     /// Webhook transport was not attached to `AppState`.
     #[error(
         "webhook transport is not configured; attach it with AppState::with_webhook_transport before running nebula-webhook"
@@ -492,7 +492,7 @@ fn warn_execution_memory_outside_dev() {
 /// runtime attaches the OTLP metrics pipeline against the shared [`MetricsRegistry`] once
 /// `AppState` is built and holds the guard until the transport returns so spans and metric
 /// batches are flushed deterministically on shutdown.
-pub async fn run_transport<T: ServerTransport>(
+pub(crate) async fn run_transport<T: ServerTransport>(
     transport: T,
     telemetry_guard: TelemetryGuard,
 ) -> Result<(), ServerRunError> {
@@ -502,16 +502,16 @@ pub async fn run_transport<T: ServerTransport>(
 }
 
 /// Transport runtime orchestrator for binary composition roots.
-pub struct ServerRuntime;
+pub(crate) struct ServerRuntime;
 
 impl ServerRuntime {
     /// Create a new runtime.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self
     }
 
     /// Run a selected transport with this runtime.
-    pub async fn run_transport<T: ServerTransport>(
+    pub(crate) async fn run_transport<T: ServerTransport>(
         &self,
         transport: T,
         mut telemetry_guard: TelemetryGuard,
@@ -758,7 +758,9 @@ pub(crate) fn default_state(
 /// operator who set `API_SMTP_HOST` never silently boots with the
 /// in-process echo sink. `SmtpTlsMode::None` emits a startup
 /// `tracing::warn!` because plaintext SMTP is a dev-only posture.
-pub fn build_email_port(api_config: &ApiConfig) -> Result<Arc<dyn EmailPort>, TransportInitError> {
+pub(crate) fn build_email_port(
+    api_config: &ApiConfig,
+) -> Result<Arc<dyn EmailPort>, TransportInitError> {
     if let Some(smtp_cfg) = api_config.smtp.as_ref() {
         if matches!(smtp_cfg.tls, SmtpTlsMode::None) {
             tracing::warn!(
@@ -802,7 +804,7 @@ pub fn build_email_port(api_config: &ApiConfig) -> Result<Arc<dyn EmailPort>, Tr
 /// Today this builder constructs its own `sqlx::Pool<Postgres>`
 /// alongside the idempotency pool; consolidating the two onto one
 /// shared pool is a follow-up.
-pub async fn build_auth_backend(
+pub(crate) async fn build_auth_backend(
     api_config: &ApiConfig,
     email_port: Arc<dyn EmailPort>,
     metrics_registry: Option<Arc<MetricsRegistry>>,
@@ -834,7 +836,7 @@ pub async fn build_auth_backend(
 /// reachable `DATABASE_URL`; either missing component fails closed with
 /// [`TransportInitError::IdempotencyBackendUnavailable`] (silent
 /// fallback to memory is rejected per `feedback_no_shims.md`).
-pub async fn build_idempotency_store(
+pub(crate) async fn build_idempotency_store(
     api_config: &ApiConfig,
 ) -> Result<Arc<dyn IdempotencyStore>, TransportInitError> {
     match api_config.idempotency.backend {

--- a/apps/server/src/email/mod.rs
+++ b/apps/server/src/email/mod.rs
@@ -16,6 +16,6 @@
 //! `EmailError::Transport` redaction discipline that keeps the SMTP
 //! password out of `tracing` lines and `problem-details` bodies.
 
-pub mod smtp;
+pub(crate) mod smtp;
 
-pub use smtp::{SmtpEmailPort, SmtpEmailPortBuildError};
+pub(crate) use smtp::{SmtpEmailPort, SmtpEmailPortBuildError};

--- a/apps/server/src/email/smtp.rs
+++ b/apps/server/src/email/smtp.rs
@@ -61,7 +61,7 @@ use thiserror::Error;
 /// a typed error instead of a string-formatted runtime path.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum SmtpEmailPortBuildError {
+pub(crate) enum SmtpEmailPortBuildError {
     /// `from_address` failed to parse as an RFC 5321 mailbox. The
     /// `from_env` validator already enforces the `@` test but does
     /// not parse the full local-part / domain grammar; lettre's
@@ -94,7 +94,7 @@ pub enum SmtpEmailPortBuildError {
 /// metadata (no credentials), and lettre's stub transport carries only
 /// the test-recorded message log.
 #[derive(Debug)]
-pub struct SmtpEmailPort {
+pub(crate) struct SmtpEmailPort {
     transport: TransportImpl,
     from_address: Mailbox,
 }
@@ -122,7 +122,7 @@ impl SmtpEmailPort {
     /// TLS parameters. The composition root treats both as
     /// startup-fatal (per the fail-closed contract documented on
     /// [`nebula_api::ApiConfig::smtp`]).
-    pub fn new(config: &SmtpEmailConfig) -> Result<Self, SmtpEmailPortBuildError> {
+    pub(crate) fn new(config: &SmtpEmailConfig) -> Result<Self, SmtpEmailPortBuildError> {
         let from_address = config
             .from_address
             .parse::<Mailbox>()

--- a/apps/server/src/transport.rs
+++ b/apps/server/src/transport.rs
@@ -21,7 +21,7 @@ use crate::compose::{TransportInitError, health_ok};
 
 /// Clap value-enum for `--transport` / `NEBULA_TRANSPORT`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum Transport {
+pub(crate) enum Transport {
     /// Full REST API (same behaviour as the former `nebula-server` binary).
     Api,
     /// Webhook ingress only (same behaviour as the former `nebula-webhook` binary).
@@ -33,7 +33,7 @@ pub enum Transport {
 }
 
 /// A server transport profile selected by a binary target.
-pub trait ServerTransport {
+pub(crate) trait ServerTransport {
     /// Human-readable transport name for logs.
     fn name(&self) -> &'static str;
 
@@ -63,7 +63,7 @@ pub trait ServerTransport {
 
 /// Full REST API transport.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ApiTransport;
+pub(crate) struct ApiTransport;
 
 impl ServerTransport for ApiTransport {
     fn name(&self) -> &'static str {
@@ -87,7 +87,7 @@ impl ServerTransport for ApiTransport {
 
 /// Webhook ingress transport.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct WebhookIngressTransport;
+pub(crate) struct WebhookIngressTransport;
 
 impl ServerTransport for WebhookIngressTransport {
     fn name(&self) -> &'static str {
@@ -170,7 +170,7 @@ impl ServerTransport for WebhookIngressTransport {
 
 /// Realtime transport placeholder.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct RealtimeTransport;
+pub(crate) struct RealtimeTransport;
 
 impl ServerTransport for RealtimeTransport {
     fn name(&self) -> &'static str {

--- a/crates/api/src/domain/workflow/resolver.rs
+++ b/crates/api/src/domain/workflow/resolver.rs
@@ -33,7 +33,7 @@ use semver::Version;
 /// the calling edge to be skipped. Unknown keys are already caught by the
 /// structural validator (`WorkflowError::InvalidActionKey`) before the schema
 /// check runs, so fail-open here is safe.
-pub struct CatalogSchemaResolver {
+pub(crate) struct CatalogSchemaResolver {
     registry: Option<Arc<ActionRegistry>>,
 }
 
@@ -43,7 +43,7 @@ impl CatalogSchemaResolver {
     /// Pass `state.action_registry.clone()` directly — the `Option<Arc<_>>`
     /// is cloned cheaply (one `Arc` increment or a `None` copy).
     #[must_use]
-    pub fn new(registry: Option<Arc<ActionRegistry>>) -> Self {
+    pub(crate) fn new(registry: Option<Arc<ActionRegistry>>) -> Self {
         Self { registry }
     }
 }

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -22,29 +22,29 @@ use nebula_storage_port::Scope;
 pub(crate) const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests-0123456789";
 
 /// Fixed test org ID — use this in all test URLs.
-pub const TEST_ORG: &str = "org_00000000000000000000000001";
+pub(crate) const TEST_ORG: &str = "org_00000000000000000000000001";
 /// Fixed test workspace ID — use this in all test URLs.
-pub const TEST_WS: &str = "ws_00000000000000000000000001";
+pub(crate) const TEST_WS: &str = "ws_00000000000000000000000001";
 
 /// CSRF token value used by tests for state-changing requests.
-pub const TEST_CSRF_TOKEN: &str = "test-csrf-token";
+pub(crate) const TEST_CSRF_TOKEN: &str = "test-csrf-token";
 /// Pre-formatted cookie header value for CSRF.
-pub const TEST_CSRF_COOKIE: &str = "nebula_csrf=test-csrf-token";
+pub(crate) const TEST_CSRF_COOKIE: &str = "nebula_csrf=test-csrf-token";
 
 /// Helper to build a tenant-scoped workspace API path.
 /// Example: `ws_path("/workflows")` → `/api/v1/orgs/org_.../workspaces/ws_.../workflows`
-pub fn ws_path(suffix: &str) -> String {
+pub(crate) fn ws_path(suffix: &str) -> String {
     format!("/api/v1/orgs/{TEST_ORG}/workspaces/{TEST_WS}{suffix}")
 }
 
 /// Helper to build an org-scoped API path.
 #[expect(dead_code)]
-pub fn org_path(suffix: &str) -> String {
+pub(crate) fn org_path(suffix: &str) -> String {
     format!("/api/v1/orgs/{TEST_ORG}{suffix}")
 }
 
 /// Stub OrgResolver that accepts any slug and returns a fixed OrgId.
-pub struct TestOrgResolver;
+pub(crate) struct TestOrgResolver;
 
 #[async_trait::async_trait]
 impl OrgResolver for TestOrgResolver {
@@ -54,7 +54,7 @@ impl OrgResolver for TestOrgResolver {
 }
 
 /// Stub WorkspaceResolver that accepts any slug and returns a fixed WorkspaceId.
-pub struct TestWorkspaceResolver;
+pub(crate) struct TestWorkspaceResolver;
 
 #[async_trait::async_trait]
 impl WorkspaceResolver for TestWorkspaceResolver {

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -32,12 +32,12 @@ mod counting {
 
     /// Sentinel stamped on the test `Runtime` so the refresh hook can
     /// prove it received *this* live runtime by reference.
-    pub const RUNTIME_TAG: usize = 4_242;
+    pub(crate) const RUNTIME_TAG: usize = 4_242;
 
     /// A fake credential secret — `Zeroize` so it can sit inside a
     /// `CredentialGuard`.
     #[derive(Default)]
-    pub struct FakeCred(pub u32);
+    pub(crate) struct FakeCred(pub u32);
 
     impl Zeroize for FakeCred {
         fn zeroize(&mut self) {
@@ -49,7 +49,7 @@ mod counting {
     /// (which owns the `&self` hooks) and the `Runtime` handle (so a hook
     /// that received a live `&Runtime` can prove it).
     #[derive(Clone, Default)]
-    pub struct Ledger {
+    pub(crate) struct Ledger {
         /// Bumped by `on_credential_refresh`.
         pub refresh_calls: Arc<AtomicUsize>,
         /// Bumped by `on_credential_revoke`.
@@ -71,7 +71,7 @@ mod counting {
     /// The live runtime handle. Carries the ledger + a tag so the hook can
     /// prove it received *this* runtime by reference.
     #[derive(Clone)]
-    pub struct CountingRuntime {
+    pub(crate) struct CountingRuntime {
         pub ledger: Ledger,
         pub tag: usize,
     }
@@ -79,7 +79,7 @@ mod counting {
     /// The resource descriptor. Owns the `SlotCell` credential field and the
     /// `&self` rotation hooks.
     #[derive(Clone)]
-    pub struct CountingResource {
+    pub(crate) struct CountingResource {
         pub ledger: Ledger,
         /// `#[credential]`-shaped slot field (declared by the author per
         /// the Alternative (a) slot model). Pre-populated in the helper to
@@ -97,7 +97,7 @@ mod counting {
     // `crate::Error` directly (HasCredentialSlots redesign).
 
     #[derive(Clone)]
-    pub struct CountingConfig;
+    pub(crate) struct CountingConfig;
 
     nebula_schema::impl_empty_has_schema!(CountingConfig);
 
@@ -208,7 +208,7 @@ mod counting {
     /// way the (now-deleted) `register_resident[_with]` shorthands did.
     /// Centralised so the two-tenant isolation strong-net threads the
     /// identity through one verified path.
-    pub fn register_counting(
+    pub(crate) fn register_counting(
         mgr: &Manager,
         resource: CountingResource,
         opts: RegisterOptions,
@@ -227,7 +227,7 @@ mod counting {
     /// Builds a manager with a `CountingResource` registered as Resident,
     /// its `db` slot pre-populated, and the resident runtime warmed so the
     /// dispatch has a live `&Runtime` to borrow.
-    pub async fn registered() -> (Manager, ResourceKey, Ledger) {
+    pub(crate) async fn registered() -> (Manager, ResourceKey, Ledger) {
         let ledger = Ledger::default();
         let slot: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
         slot.store(Arc::new(CredentialGuard::new(FakeCred(7))));
@@ -246,7 +246,7 @@ mod counting {
     /// Same as [`registered`], but the manager is wired with a real
     /// `MetricsRegistry` so `manager.snapshot()` reflects the rotation
     /// outcome counters.
-    pub async fn registered_with_metrics() -> (
+    pub(crate) async fn registered_with_metrics() -> (
         Manager,
         ResourceKey,
         Ledger,
@@ -275,22 +275,22 @@ mod counting {
     /// `(key, Global)` occupy two distinct registry rows — each its own
     /// `ManagedResource` with its own per-resource in-flight counter
     /// (per-resource revoke deferral).
-    pub const SLOT_A: &[(&str, &str)] = &[("db", "cred-tenant-a")];
-    pub const SLOT_B: &[(&str, &str)] = &[("db", "cred-tenant-b")];
+    pub(crate) const SLOT_A: &[(&str, &str)] = &[("db", "cred-tenant-a")];
+    pub(crate) const SLOT_B: &[(&str, &str)] = &[("db", "cred-tenant-b")];
 
     /// Structural [`SlotIdentity`] for [`SLOT_A`] / [`SLOT_B`] — the
     /// collision-free row key the acquire / revoke ports pin on.
-    pub fn slot_a_id() -> nebula_resource::SlotIdentity {
+    pub(crate) fn slot_a_id() -> nebula_resource::SlotIdentity {
         nebula_resource::SlotIdentity::from_bindings(SLOT_A.iter().copied())
     }
-    pub fn slot_b_id() -> nebula_resource::SlotIdentity {
+    pub(crate) fn slot_b_id() -> nebula_resource::SlotIdentity {
         nebula_resource::SlotIdentity::from_bindings(SLOT_B.iter().copied())
     }
 
     /// Registers `CountingResource` twice as Resident at `SLOT_A` / `SLOT_B`
     /// so a revoke on one row can be proven isolated from in-flight traffic
     /// to the other. Returns the manager and per-row ledgers.
-    pub async fn registered_two_tenant() -> (Arc<Manager>, ResourceKey, Ledger, Ledger) {
+    pub(crate) async fn registered_two_tenant() -> (Arc<Manager>, ResourceKey, Ledger, Ledger) {
         use nebula_resource::RegisterOptions;
 
         let ledger_a = Ledger::default();

--- a/crates/storage/src/pg/user.rs
+++ b/crates/storage/src/pg/user.rs
@@ -31,10 +31,10 @@ use crate::{error::StorageError, pg::map_db_err, repos::UserRepo, rows::UserRow}
 
 /// Failed-login threshold before [`PgUserRepo::record_login_failure`]
 /// arms the lockout.
-pub const LOCKOUT_THRESHOLD: i32 = 5;
+pub(crate) const LOCKOUT_THRESHOLD: i32 = 5;
 
 /// Duration a user account stays locked once the threshold is hit.
-pub const LOCKOUT_DURATION: Duration = Duration::from_mins(15);
+pub(crate) const LOCKOUT_DURATION: Duration = Duration::from_mins(15);
 
 /// Postgres-backed user repository.
 #[derive(Clone)]

--- a/crates/storage/tests/common/mod.rs
+++ b/crates/storage/tests/common/mod.rs
@@ -7,7 +7,7 @@
 use nebula_credential::StoredCredential;
 
 /// Build a minimal [`StoredCredential`] for use in integration tests.
-pub fn make_credential(id: &str, data: &[u8]) -> StoredCredential {
+pub(crate) fn make_credential(id: &str, data: &[u8]) -> StoredCredential {
     StoredCredential {
         id: id.into(),
         name: None,

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -37,7 +37,7 @@ use nebula_storage_port::{FencingToken, Scope, StorageError, TransitionBatch, Tr
 /// A storage backend under conformance test. Returns port handles built on
 /// that backend's concrete adapter.
 #[async_trait::async_trait]
-pub trait Backend: Send + Sync {
+pub(crate) trait Backend: Send + Sync {
     /// Human-readable backend name (used in assertion messages).
     fn name(&self) -> &'static str;
     /// An execution store backed by this backend.
@@ -75,7 +75,7 @@ pub trait Backend: Send + Sync {
 /// `Arc<Mutex<…>>`), so the control queue, journal reader, job-dispatch queue,
 /// and trigger-dedup inbox all observe the same rows and operate atomically
 /// under one lock.
-pub struct InMemoryBackend {
+pub(crate) struct InMemoryBackend {
     store: nebula_storage::inmem::InMemoryExecutionStore,
     guard: nebula_storage::inmem::InMemoryIdempotencyGuard,
     idem_store: nebula_storage::inmem::InMemoryIdempotencyStore,
@@ -156,7 +156,7 @@ impl Backend for InMemoryBackend {
 /// lazily on first store request. Only built when the `sqlite` feature is
 /// on; without it the case skips like Postgres.
 #[derive(Default)]
-pub struct SqliteBackend {
+pub(crate) struct SqliteBackend {
     #[cfg(feature = "sqlite")]
     pool: tokio::sync::OnceCell<sqlx::SqlitePool>,
 }
@@ -300,7 +300,7 @@ impl Backend for SqliteBackend {
 /// a database. Each `Backend` instance owns one pool created lazily on
 /// first store request; the port schema is installed once.
 #[derive(Default)]
-pub struct PostgresBackend {
+pub(crate) struct PostgresBackend {
     #[cfg(feature = "postgres")]
     pool: tokio::sync::OnceCell<sqlx::PgPool>,
 }
@@ -477,7 +477,7 @@ fn sqlite_skip() -> Option<&'static str> {
 /// `None` if the case should run. Postgres skips without `DATABASE_URL` or
 /// the `postgres` feature; SQLite skips without the `sqlite` feature.
 #[must_use]
-pub fn skip_reason(backend: &dyn Backend) -> Option<&'static str> {
+pub(crate) fn skip_reason(backend: &dyn Backend) -> Option<&'static str> {
     match backend.name() {
         "Postgres" => postgres_skip(),
         "Sqlite(:memory:)" => sqlite_skip(),
@@ -496,7 +496,7 @@ fn scope_b() -> Scope {
 // ── shared contract assertions ────────────────────────────────────────────
 
 /// create → get returns the row within the same scope.
-pub async fn assert_create_get_roundtrip(backend: &dyn Backend) {
+pub(crate) async fn assert_create_get_roundtrip(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let s = scope_a();
     store
@@ -511,7 +511,7 @@ pub async fn assert_create_get_roundtrip(backend: &dyn Backend) {
 
 /// A commit whose `expected_version` does not match the row returns
 /// `VersionConflict { actual }`.
-pub async fn assert_cas_conflict(backend: &dyn Backend) {
+pub(crate) async fn assert_cas_conflict(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let s = scope_a();
     store
@@ -540,7 +540,7 @@ pub async fn assert_cas_conflict(backend: &dyn Backend) {
 }
 
 /// A commit carrying a superseded fencing token returns `FencedOut`.
-pub async fn assert_stale_fencing_is_fenced_out(backend: &dyn Backend) {
+pub(crate) async fn assert_stale_fencing_is_fenced_out(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let s = scope_a();
     store
@@ -584,7 +584,7 @@ pub async fn assert_stale_fencing_is_fenced_out(backend: &dyn Backend) {
 /// two concurrent runners must see exactly one winner, and a
 /// crashed-then-restarted runner reusing its holder id cannot revive its
 /// pre-crash token.
-pub async fn assert_live_lease_blocks_acquire(backend: &dyn Backend) {
+pub(crate) async fn assert_live_lease_blocks_acquire(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let s = scope_a();
     store
@@ -677,7 +677,7 @@ pub async fn assert_live_lease_blocks_acquire(backend: &dyn Backend) {
 
 /// The atomic triple commits state + outbox + journal together; a reader
 /// observes all three after a successful commit.
-pub async fn assert_atomic_triple(backend: &dyn Backend) {
+pub(crate) async fn assert_atomic_triple(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let s = scope_a();
     store
@@ -739,7 +739,7 @@ pub async fn assert_atomic_triple(backend: &dyn Backend) {
 /// Idempotency key shape `{execution_id}:{node_id}:{attempt}` is
 /// first-writer-wins: the first `check_and_mark` returns true, the second
 /// false.
-pub async fn assert_idempotency_first_writer_wins(backend: &dyn Backend) {
+pub(crate) async fn assert_idempotency_first_writer_wins(backend: &dyn Backend) {
     let guard = backend.idempotency_guard().await;
     let s = scope_a();
     let first = guard
@@ -760,7 +760,7 @@ pub async fn assert_idempotency_first_writer_wins(backend: &dyn Backend) {
 
 /// A `get` with a mismatched scope yields `Ok(None)` — never another
 /// tenant's row, never an error that leaks existence.
-pub async fn assert_cross_scope_get_is_none(backend: &dyn Backend) {
+pub(crate) async fn assert_cross_scope_get_is_none(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     store
         .create(&scope_a(), "exe_x", "wf_1", serde_json::json!({}))
@@ -776,7 +776,7 @@ pub async fn assert_cross_scope_get_is_none(backend: &dyn Backend) {
 
 /// A `commit` against an id that exists only in another tenant's scope
 /// must not Apply (the row is invisible cross-tenant).
-pub async fn assert_cross_scope_commit_is_rejected(backend: &dyn Backend) {
+pub(crate) async fn assert_cross_scope_commit_is_rejected(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     store
         .create(&scope_a(), "exe_y", "wf_1", serde_json::json!({}))
@@ -822,7 +822,7 @@ pub async fn assert_cross_scope_commit_is_rejected(backend: &dyn Backend) {
 /// and the version store round-trips a version and lists newest-first.
 /// Asserted across every backend so the SQL adapters match the in-memory
 /// reference exactly.
-pub async fn assert_workflow_store_contract(backend: &dyn Backend) {
+pub(crate) async fn assert_workflow_store_contract(backend: &dyn Backend) {
     let wf = backend.workflow_store().await;
     let ver = backend.workflow_version_store().await;
     let s = scope_a();
@@ -1032,7 +1032,7 @@ pub async fn assert_workflow_store_contract(backend: &dyn Backend) {
 /// orphan-row invariant (a workflow row with no published version is
 /// invisible to readers — "the workflow vanished") that the previous
 /// two-await sequence could violate on a partial failure.
-pub async fn assert_save_with_published_version_is_atomic(backend: &dyn Backend) {
+pub(crate) async fn assert_save_with_published_version_is_atomic(backend: &dyn Backend) {
     let wf = backend.workflow_store().await;
     let ver = backend.workflow_version_store().await;
     let s = scope_a();
@@ -1164,7 +1164,7 @@ pub async fn assert_save_with_published_version_is_atomic(backend: &dyn Backend)
 /// cleared). The original in-memory `find` returned an arbitrary
 /// `HashMap`-order row; this locks the deterministic
 /// `ORDER BY number DESC LIMIT 1` contract across every backend.
-pub async fn assert_get_published_is_highest_numbered(backend: &dyn Backend) {
+pub(crate) async fn assert_get_published_is_highest_numbered(backend: &dyn Backend) {
     let ver = backend.workflow_version_store().await;
     let s = scope_a();
     // Two published versions for the same workflow (1 and 3) plus an
@@ -1203,7 +1203,7 @@ pub async fn assert_get_published_is_highest_numbered(backend: &dyn Backend) {
 /// the claiming processor fences `mark_completed` (a stale runner whose
 /// row was reclaimed cannot flip a newer claim). Also exercises the
 /// typed-16-byte-id contract end to end.
-pub async fn assert_control_queue_outbox_and_fencing(backend: &dyn Backend) {
+pub(crate) async fn assert_control_queue_outbox_and_fencing(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let queue = backend.control_queue().await;
     let s = scope_a();
@@ -1294,7 +1294,7 @@ pub async fn assert_control_queue_outbox_and_fencing(backend: &dyn Backend) {
 /// **Falsifiability**: before the `resume_target TEXT` column was added to
 /// `port_control_queue`, `claim_pending` hardcoded `resume_target: None` and
 /// the `Some(target)` assertion failed → RED.
-pub async fn assert_resume_target_survives_queue_round_trip(backend: &dyn Backend) {
+pub(crate) async fn assert_resume_target_survives_queue_round_trip(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let queue = backend.control_queue().await;
     let s = scope_a();
@@ -1505,7 +1505,7 @@ async fn enqueue_and_climb_reclaim_count(
 /// `OR command = 'Resume'` redeliver complement) → the row at `reclaim_count >=
 /// max` is force-Failed → the post-sweep `claim_pending` finds nothing → the
 /// "still claimable" assertion fails → RED.
-pub async fn assert_resume_row_exempt_from_reclaim_budget(backend: &dyn Backend) {
+pub(crate) async fn assert_resume_row_exempt_from_reclaim_budget(backend: &dyn Backend) {
     let max_reclaim_count = 2;
     let row_id =
         enqueue_and_climb_reclaim_count(backend, ControlCommand::Resume, max_reclaim_count).await;
@@ -1561,7 +1561,7 @@ pub async fn assert_resume_row_exempt_from_reclaim_budget(backend: &dyn Backend)
 /// `Start` row at `reclaim_count >= max` redelivers instead of failing → the
 /// post-sweep `claim_pending` returns it → the "must be Failed (not claimable)"
 /// assertion fails → RED.
-pub async fn assert_non_resume_row_still_exhausts(backend: &dyn Backend) {
+pub(crate) async fn assert_non_resume_row_still_exhausts(backend: &dyn Backend) {
     let max_reclaim_count = 2;
     let row_id =
         enqueue_and_climb_reclaim_count(backend, ControlCommand::Start, max_reclaim_count).await;
@@ -1596,7 +1596,7 @@ pub async fn assert_non_resume_row_still_exhausts(backend: &dyn Backend) {
 /// Journal entries appended by a `commit` are readable in order, and a
 /// cross-tenant read yields an empty journal (never another tenant's
 /// entries).
-pub async fn assert_journal_visibility_and_scope(backend: &dyn Backend) {
+pub(crate) async fn assert_journal_visibility_and_scope(backend: &dyn Backend) {
     let store = backend.execution_store().await;
     let reader = backend.journal_reader().await;
     let s = scope_a();
@@ -1659,7 +1659,7 @@ pub async fn assert_journal_visibility_and_scope(backend: &dyn Backend) {
 /// `put` on the same key keeps the original record + fingerprint (replay
 /// race). Purely within `scope_a`, so it is decorator-transparent and runs
 /// in both the raw and scoped matrices.
-pub async fn assert_idempotency_store_first_writer(backend: &dyn Backend) {
+pub(crate) async fn assert_idempotency_store_first_writer(backend: &dyn Backend) {
     let store = backend.idempotency_store().await;
     let raw_key = "POST /x:idem-1".to_string();
     let first = CachedRecord {
@@ -1723,7 +1723,7 @@ pub async fn assert_idempotency_store_first_writer(backend: &dyn Backend) {
 /// only in the raw matrix. The decorator substitutes the per-call scope
 /// away by design, so decorator-level cross-tenant denial is proven in
 /// `cross_tenant_denial.rs` instead.
-pub async fn assert_idempotency_store_cross_scope_isolated(backend: &dyn Backend) {
+pub(crate) async fn assert_idempotency_store_cross_scope_isolated(backend: &dyn Backend) {
     let store = backend.idempotency_store().await;
     let raw_key = "POST /x:idem-1".to_string();
     let record = CachedRecord {
@@ -1764,7 +1764,7 @@ pub async fn assert_idempotency_store_cross_scope_isolated(backend: &dyn Backend
 /// Also covers the ADR-0096 extended fields: safe-default round-trip
 /// (new fields default to `Test` / `None` / zero-sentinel) and full
 /// round-trip of `workflow_id`, `mode`, and `token_hash`.
-pub async fn assert_webhook_activation_and_scope(backend: &dyn Backend) {
+pub(crate) async fn assert_webhook_activation_and_scope(backend: &dyn Backend) {
     let store = backend.webhook_store().await;
     let s = scope_a();
     // Use the constructor so the call site is future-proof against further
@@ -1881,7 +1881,7 @@ pub async fn assert_webhook_activation_and_scope(backend: &dyn Backend) {
 /// - Unknown hash returns `None` (no false-positive).
 /// - `list_all_active` enumerates rows from both tenants (cross-tenant
 ///   bootstrap enumeration).
-pub async fn assert_webhook_system_surface(backend: &dyn Backend) {
+pub(crate) async fn assert_webhook_system_surface(backend: &dyn Backend) {
     let store = backend.webhook_store().await;
     let sa = scope_a();
     let sb = scope_b();
@@ -2049,7 +2049,7 @@ pub async fn assert_webhook_system_surface(backend: &dyn Backend) {
 /// own `WHERE` filtering with an explicit foreign-scope argument, which
 /// the decorator *substitutes away* — a different mechanism, tested in
 /// its own suite.
-pub struct ScopedBackend<B: Backend> {
+pub(crate) struct ScopedBackend<B: Backend> {
     inner: B,
 }
 
@@ -2173,7 +2173,7 @@ fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg 
 
 /// `claim_pending` only delivers rows whose required plugin is in the worker's
 /// `available_plugins`; a row requiring an unavailable plugin is not delivered.
-pub async fn assert_job_dispatch_routes_by_plugin(backend: &dyn Backend) {
+pub(crate) async fn assert_job_dispatch_routes_by_plugin(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
     let job_a = make_job(0x10, "plugin.alpha", &["plugin.alpha"]);
@@ -2221,7 +2221,7 @@ pub async fn assert_job_dispatch_routes_by_plugin(backend: &dyn Backend) {
 
 /// `mark_dispatched` and `mark_failed` are both fenced by processor id: a
 /// stale processor cannot transition a row it did not claim.
-pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
+pub(crate) async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
     let plugin_tags = &["plugin.x".parse::<PluginKey>().unwrap()];
 
@@ -2303,7 +2303,7 @@ pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
 /// is provided: the second call with the same `(trigger_id, event_id)` must
 /// return `Duplicate` and must NOT enqueue a second job.  The `Duplicate`
 /// outcome carries the winner's execution id, not the candidate's.
-pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
+pub(crate) async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let q = backend.job_dispatch_queue().await;
 
@@ -2378,7 +2378,7 @@ pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
 
 /// `claim_and_materialize_start` with `row = None` always dispatches without
 /// a dedup row (unconditional dispatch path).
-pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
+pub(crate) async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let q = backend.job_dispatch_queue().await;
 
@@ -2441,7 +2441,7 @@ pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
 /// from scope_b (cross-scope `exists` returns false), and after a Dispatched
 /// compose the execution row is visible in the store and exactly one Start job
 /// is claimable from the dispatch queue.
-pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
+pub(crate) async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let store = backend.execution_store().await;
     let q = backend.job_dispatch_queue().await;
@@ -2538,7 +2538,7 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
 /// 4. Advertised `["plugin.alpha", "plugin.beta", "plugin.gamma"]` → claimed
 ///    (strict superset); claimed job identity verified.
 /// 5. Empty advertised set → claims nothing (parity across all backends).
-pub async fn assert_job_dispatch_routes_by_plugin_superset(backend: &dyn Backend) {
+pub(crate) async fn assert_job_dispatch_routes_by_plugin_superset(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
     // Job requires alpha AND beta (required_plugins covers both; invariant upheld).
@@ -2667,7 +2667,7 @@ pub async fn assert_job_dispatch_routes_by_plugin_superset(backend: &dyn Backend
 ///    still fires).
 /// 4. `exists` confirms the row is visible inside each scope and invisible
 ///    across scopes.
-pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
+pub(crate) async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
 
     let row_a = TriggerDedupRow::new("trg_iso", "evt_iso", scope_a(), "2026-01-01T00:00:00Z");
@@ -2777,7 +2777,7 @@ pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
 ///    `execution_id` matches — must return `Err(StorageError::Duplicate)`.
 /// 3. Assert: no dedup guard was inserted (`exists` returns false), and no
 ///    Start job was enqueued (`claim_pending` returns empty).
-pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backend) {
+pub(crate) async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let store = backend.execution_store().await;
     let q = backend.job_dispatch_queue().await;
@@ -2841,7 +2841,7 @@ pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backe
 /// The second compose reuses the SAME job id but a DIFFERENT execution id and a
 /// DIFFERENT `(trigger, event)`, so it is not a dedup duplicate — the only
 /// collision is on the job-dispatch primary key.
-pub async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend) {
+pub(crate) async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let q = backend.job_dispatch_queue().await;
     let s = scope_a();
@@ -2913,7 +2913,7 @@ pub async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend
 ///    `winner_id = outcome.execution_id`.
 /// 2. Second compose with the same `(trg_rb2, evt_rb2)` → `Duplicate`;
 ///    `outcome.execution_id` must equal `winner_id`.
-pub async fn assert_dedup_duplicate_returns_winner_id(backend: &dyn Backend) {
+pub(crate) async fn assert_dedup_duplicate_returns_winner_id(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let s = scope_a();
 

--- a/crates/validator/src/macros.rs
+++ b/crates/validator/src/macros.rs
@@ -537,7 +537,7 @@ macro_rules! validator {
         impl $($gd)* $name $($gu)* {
             /// Creates a new instance.
             #[must_use] #[inline]
-            pub fn new() -> Self {
+            $vis fn new() -> Self {
                 Self { $($ei)+ }
             }
         }
@@ -551,7 +551,7 @@ macro_rules! validator {
         impl $($gd)* $name $($gu)* {
             /// Creates a new instance.
             #[must_use] #[inline]
-            pub fn new($($field: $fty),+) -> Self {
+            $vis fn new($($field: $fty),+) -> Self {
                 Self { $($field,)+ $($ei)* }
             }
         }
@@ -566,7 +566,7 @@ macro_rules! validator {
         impl $($gd)* $name $($gu)* {
             /// Creates a new instance.
             #[must_use] #[inline]
-            pub fn new($($args)*) -> Self $body
+            $vis fn new($($args)*) -> Self $body
         }
     };
 
@@ -578,7 +578,7 @@ macro_rules! validator {
         impl $($gd)* $name $($gu)* {
             /// Creates a new instance, returning an error if configuration is invalid.
             #[inline]
-            pub fn new($($args)*) -> ::std::result::Result<Self, $ety> $body
+            $vis fn new($($args)*) -> ::std::result::Result<Self, $ety> $body
         }
     };
 


### PR DESCRIPTION
## Summary

First campaign from the measured backlog (`ENGINEERING_2026.md §4`, cheapest entry: 55 hits).

- **`unreachable_pub = "warn"`** joins `[workspace.lints.rust]` — `pub` items not actually reachable from outside their crate must be `pub(crate)`, so the public surface is honest (iroh denies this; reth/uv warn). The `redundant_pub_crate` allow stays with an updated rationale: the two lints fight, and `unreachable_pub` wins (iroh precedent).
- ~50 sites mechanically rewritten `pub` → `pub(crate)` by `cargo fix` across apps/server, api, storage, resource tests, and test harness modules. By definition these were unreachable from outside, so no public-API change — `cargo-semver-checks` in CI confirms.
- **Real find**: the `validator` constructor-generating macros emitted hardcoded `pub fn new()` regardless of the struct's declared visibility — all four arms now emit `$vis fn new()`, so a `pub(crate)` validator struct no longer gets a wider-than-struct constructor.

## Verification

- clippy workspace × {all-features, default, no-default}: **0 warnings**
- Committed-tree check (in-progress local files stashed): clean
- Full workspace tests: **6074/6074 passed**; doctests clean; fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened workspace lint settings to catch more visibility-related issues during development.
* **Refactor**
  * Reduced exposure of several internal server, storage, API, and test utilities.
  * Kept public behavior unchanged while narrowing access to internal-only components.
* **Bug Fixes**
  * Improved encapsulation to help prevent accidental use of internal APIs and reduce future compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->