### PR TITLE
perf(resource): drop async_trait boxing from the Topology hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,18 @@ changes are expected between minor releases — call them out here.
 
 ### Changed
 
+- **(breaking) `Topology<R>` async hooks are RPITIT, not `#[async_trait]`** —
+  the five async hooks (`create_entry`, `accept`, `prepare`, `on_release`,
+  `dispatch_credential_hook`) now return `impl Future<Output = …> + Send`
+  instead of going through `async_trait`'s `Box<dyn Future>` shim. Custom
+  topology authors: drop `#[async_trait]` from your `impl Topology<R>` block;
+  keep plain `async fn` bodies. The same applies to the provider-hook traits
+  the built-in topologies drive — `PoolProvider::recycle` /
+  `PoolProvider::prepare` and `BoundedProvider::reset` are also RPITIT; drop
+  `#[async_trait]` from those overrides too if you had one.
+  `ResidentProvider` has no async hooks (nothing to migrate there).
+  `Provider` is unchanged and still uses `#[async_trait]`. Drops three heap
+  allocations per cache-hit acquire+release round trip on the default hook path.
 - **(breaking) Public error and open taxonomy enums are now `#[non_exhaustive]`**
   for additive semver evolution — 10 error enums (credential, core, schema,
   resource, plugin, metadata) and 22 open outcome/event/state enums (credential

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,6 +3433,7 @@ dependencies = [
 name = "nebula-sdk"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "insta",
  "nebula-action",

--- a/crates/resource/README.md
+++ b/crates/resource/README.md
@@ -2,7 +2,7 @@
 name: nebula-resource
 role: Bulkhead Pool (Release It! ch "Stability Patterns — Bulkhead"; resource lifecycle acquire / health / release)
 status: frontier
-last-reviewed: 2026-07-02
+last-reviewed: 2026-07-09
 canon-invariants: [L2-11.4, L2-13.3]
 related: [nebula-core, nebula-schema, nebula-error, nebula-resilience, nebula-credential, nebula-action]
 ---
@@ -23,11 +23,15 @@ The v4 surface — singular `type Credential` is dropped in favor of typed crede
 
 ### `Provider` trait — 3 associated types, slot fields on Self
 
+Only `Config` / `Instance` / `Topology`, `key()`, and `create()` are required;
+every other method has a default.
+
 ```rust
-pub trait Provider: Send + Sync + 'static {
+pub trait Provider: HasCredentialSlots + Send + Sync + Sized + 'static {
     type Config:   ResourceConfig;
     type Instance: Send + Sync + 'static;
-    type Topology: Topology<Self>;  // Pooled<Self> | Resident<Self> | custom Topology<R>
+    // Pooled<Self> | Resident<Self> | Bounded<Self> | custom Topology<R>
+    type Topology: Topology<Self>;
 
     fn key() -> ResourceKey;
 
@@ -49,9 +53,30 @@ pub trait Provider: Send + Sync + 'static {
     async fn on_credential_revoke(&self, slot_name: &str, instance: &Self::Instance)
         -> Result<(), Error> { Ok(()) }
 
-    async fn check    (&self, instance: &Self::Instance) -> Result<(), Error>;
-    async fn shutdown (&self, instance: &Self::Instance) -> Result<(), Error>;
-    async fn destroy  (&self, instance: Self::Instance)  -> Result<(), Error>;
+    /// Health probe. Default `Ok(())`; `check_cost` sets the maintenance
+    /// reaper's probe cadence (`Cheap` / `Moderate` / `Expensive`).
+    async fn check(&self, instance: &Self::Instance) -> Result<(), Error> { Ok(()) }
+    fn check_cost(&self) -> CheckCost { CheckCost::Cheap }
+
+    /// Quiesce before teardown. Default `Ok(())`.
+    async fn shutdown(&self, instance: &Self::Instance) -> Result<(), Error> { Ok(()) }
+
+    /// Consuming teardown, bounded by `cx.deadline` (ADR-0093). Default
+    /// `Ok(())` — the `Instance`'s sync `Drop` releases OS resources.
+    async fn destroy(&self, instance: Self::Instance, cx: TeardownCx)
+        -> Result<(), Error> { Ok(()) }
+
+    /// Wall-clock budget `TeardownCx` turns into `cx.deadline`.
+    fn teardown_budget(&self) -> Duration { Duration::from_secs(30) }
+
+    /// `None` disables the hold-deadline leak watchdog (diagnostic only —
+    /// it never force-releases a lease).
+    fn max_hold_duration() -> Option<Duration> { None }
+
+    /// Defaults derive from `Config`'s schema and `key()`; override to add
+    /// a description, version, or tags.
+    fn schema() -> ValidSchema { <Self::Config as HasSchema>::schema() }
+    fn metadata() -> ResourceMetadata { /* derived from Self::key() */ }
 }
 ```
 
@@ -105,7 +130,7 @@ impl Provider for Postgres {
 - A read accessor per slot field: `pub fn <field>_slot(&self) -> Option<Arc<CredentialGuard<C>>>` returning the resolved guard, or `None` until the framework binds it. Implementations read the credential through this accessor — never off the raw cell field. A pure derive cannot add or rewrite struct fields and `ManagedResource` hands out `Arc<R>` (no `&mut R`), so the author declares the `SlotCell` cell and the framework populates / rotates it through `&self` via `SlotCell::store`.
 - `impl HasCredentialSlots for Postgres` — order-sensitive epoch fold used by the engine's hot-reload path.
 
-Topology traits (`Pooled`, `Resident`, etc.) are always hand-written — the derive does not emit them.
+The per-topology hook trait (`PoolProvider` / `ResidentProvider` / `BoundedProvider`) is always hand-written — the derive does not emit it. Every hook has a default, so an empty `impl PoolProvider for Postgres {}` is enough to opt into pool topology.
 
 #### Field-type shape
 
@@ -135,14 +160,16 @@ The framework resolves declared `#[credential]` slots **before** invoking `Provi
 - `ResourceGuard` — RAII instance guard with `Owned`/`Guarded` modes; derefs to `R::Instance`, releases on drop; implements `Debug` (key + topology, no instance leak).
 - `ResourceRef<R>` — lazy reference type holding a `ResourceId` string + `PhantomData<R>`. Resolves to a `ResourceGuard<R>` via `.resolve(ctx).await`.
 - `RegistrationSpec` — the single registration param aggregate (see above).
-- `SlotIdentity` — collision-free structural resolved-credential identity (`Unbound` / `Structural`); the cross-tenant barrier.
+- `AcquireOptions` — per-call acquire knobs (`deadline`, `acquire_slow_threshold`); every `acquire_*` takes one.
+- `SlotIdentity`, `DedupKey` — collision-free structural resolved-credential identity (`Unbound` / `Structural`); the cross-tenant barrier, and the `(key, scope, slot_identity)` registry dedup key.
 - `ManagerConfig`, `RegisterOptions` — configuration surface.
 - `Registry`, `ManagedHandle` (sealed), `LookupOutcome` — type-erased storage + lookup result for registered resource instances.
 - `ResourceMetadata` — static descriptor: key, name, description, schema, version, tags.
 - `ResourceConfig` — operational config trait (no secrets); supertype `HasSchema`.
 - `SlotCell` — lock-free `ArcSwap`-based slot cell the framework populates/rotates (the public cell type; the internal `Cell` alias is no longer exported).
+- `TeardownCx`, `TeardownReason` — deadline + cause handed to `Provider::destroy` (ADR-0093 teardown contract).
 - `ReleaseQueue` — background worker pool for async cleanup. Drain on crash is best-effort; see §11.4 canon note.
-- `DrainTimeoutPolicy` — policy controlling drain operation timeout.
+- `DrainTimeoutPolicy`, `ShutdownConfig`, `ShutdownReport`, `ShutdownError` — `Manager::graceful_shutdown` drain policy, outcome, and typed failure.
 - `ReloadOutcome` — result of `Manager::reload_config` (`NoChange` / `SwappedImmediately`).
 - `Error`, `ErrorKind` — typed error with retry classification.
 - `ResourceContext` — execution context with cancellation and capability traits (`HasResources`, `HasCredentials`).
@@ -154,10 +181,18 @@ The framework resolves declared `#[credential]` slots **before** invoking `Provi
 - Open `Topology<R>` trait + framework topology structs `Pooled<R>` / `Resident<R>` / `Bounded<R>` (reached monomorphically through `Provider::Topology`; no dispatch enum — the framework owns the acquire loop).
 - Per-topology hook traits: `PoolProvider`, `ResidentProvider`, `BoundedProvider`.
 - Topology configs / constructors: `PoolConfig`, `ResidentConfig`, `BoundedMode` (`Bounded::capped`/`exclusive`/`unbounded`).
+- `PoolStats` — point-in-time pool snapshot (`idle`, `capacity`, `available_permits`, `in_use`) via `Manager::pool_stats`.
+- `TopologyTag` — the runtime topology discriminant (`Pool` / `Resident` / `Bounded` / custom) carried on a `ResourceGuard`; read via `guard.topology_tag()`.
+- Custom-topology surface: the framework-owned `InstanceStore` idle queue plus `Checkout`, `CheckedOut`, `ReturnOutcome`, `Ticket`, `Unavailable`, `Load`, `MaintenanceSchedule`, `AdmissionPhase`, `AdmissionStatus`, `PoolStrategy`, `NoTopology`.
+- `HasCredentialSlots` — per-resource credential epoch fold; emitted by `#[derive(Resource)]`, or by `no_credential_slots!(R)` for a slot-less resource.
+- `HasResourcesExt` — the `ctx.resource::<R>().await?` access surface for action code.
+- `ResourceFactory`, `KindActivator`, `ResourceActivatorRegistry`, `RegisterRequest`, `RegistrarError`, `ResourceRegistrationOutcome`, `SlotBinding`, `BoxFut` — the erased plugin-registration bridge.
 - `CheckCost` — relative `check` probe cost driving the maintenance reaper's health-probe cadence.
+- Re-exports so consumers need no direct sibling dep: `Subscriber` (`nebula-eventbus`), `Credential` / `CredentialContext` / `CredentialId` (`nebula-credential`), `HasSchema` / `Schema` / `ValidSchema` / `impl_empty_has_schema!` (`nebula-schema`).
+- Feature `rotation`: `ResourceFanoutDriver`, `ResourceFanoutIndex`, `Bind`, `RotationOutcome`.
 - `#[derive(Resource)]`, `#[derive(ResourceConfig)]`, `#[derive(ClassifyError)]` — proc-macro derivations.
 - `resource_key!` — re-exported from `nebula_core` for declaring resource keys at compile time.
-- `prelude` — `use nebula_resource::prelude::*` for the common author surface (`Provider`, `Manager`, topologies, errors).
+- `prelude` — `use nebula_resource::prelude::*` for the common author surface (`Provider`, `Manager`, topologies, errors). Note the per-topology hook traits (`PoolProvider` / `ResidentProvider` / `BoundedProvider`) are **not** in this prelude; import them from `nebula_resource::topology`. Integration authors normally consume the same surface through `nebula_sdk::prelude` — which does re-export `PoolProvider` / `ResidentProvider` / `BoundedProvider` (plus `BoundedMode`) and the three derives, and deliberately omits engine-only types (`Manager`, `Registry`, `ReleaseQueue`, `credential_fanout`); reach those via `nebula_sdk::nebula_resource`.
 
 ## Migration recipe (pre-v4 → v4)
 
@@ -167,7 +202,7 @@ The slot-binding break is hard. To migrate an existing `Resource` impl:
 2. **Drop the `scheme: &<R::Credential as Credential>::Scheme` parameter** from `create`. The framework populates the slot cells before `create` runs; read the resolved guard via `self.<field>_slot()` (`Option<Arc<CredentialGuard<C>>>`) and handle the `None` (unbound) case explicitly.
 3. **Replace `on_credential_refresh(scheme, ctx)` with `on_credential_refresh(&self, slot_name, instance)`** and add an `on_credential_revoke(&self, slot_name, instance)` override where the resource held revoke logic. The engine swaps the rotated guard into the slot cell before the call; `&self` is an immutable descriptor, so blue-green / re-auth acts on `instance`'s interior mutability. Multi-credential resources can branch on `slot_name` to refresh only the affected sub-system.
 4. **Drop `nebula_credential::NoCredential`.** Resources without credentials simply have no `#[credential]` fields. The `NoCredential` opt-out is no longer needed.
-5. **Use the two-derive pattern**: annotate the struct with `#[derive(Resource)]` (emits slot plumbing only); write a hand-written `impl Provider` with real `create` / `check` / `shutdown` / `destroy` bodies. No `#[resource(...)]` container attribute. Topology traits (`Pooled`, `Resident`, `Bounded`) are still hand-written.
+5. **Use the two-derive pattern**: annotate the struct with `#[derive(Resource)]` (emits slot plumbing only); write a hand-written `impl Provider` with real `create` / `check` / `shutdown` / `destroy` bodies. No `#[resource(...)]` container attribute. The per-topology hook trait (`PoolProvider` / `ResidentProvider` / `BoundedProvider`) is still hand-written.
 6. **Update test code** — registration now goes through one funnel: `Manager::register::<R>(RegistrationSpec { resource, config, scope, slot_identity, topology, recovery_gate })`. The per-topology `register_<topo>[_with]` shorthands and the previous `acquire_*_default` shorthand were removed; acquire is the single `acquire_<topo>` / `acquire_<topo>_for_identity` family (or the type-erased `acquire_any`).
 7. **For credential slot identity**, pass `SlotIdentity::Unbound` for the historical single-row dedup, or build a `SlotIdentity::Structural` from the resolved `(slot, credential)` pairs for per-binding row separation. The old `u64` `slot_identity` digest was removed.
 
@@ -178,6 +213,7 @@ for the full sequence.
 
 ## Runnable examples
 
+- `cargo run -p nebula-examples --example resource_pooled_http_prelude` — the smallest end-to-end `Pooled` registration, driven from `nebula_resource::prelude::*` (plus the `PoolProvider` hook trait, which the prelude does not re-export)
 - `cargo run -p nebula-examples --example resource_postgres_pool` — `Pooled` topology + `ResourceAction` for per-execution test schema (configure / cleanup ordering)
 - `cargo run -p nebula-examples --example resource_resident_http` — `Resident` topology + OAuth-style credential refresh hook
 - `cargo run -p nebula-examples --example resource_telegram_multi_workflow` — `Resident` topology + cross-workflow shared-resource dedupe (1 bot, 10 workflows, 1 `Provider::create`)
@@ -246,7 +282,7 @@ multi-tenant, credential-rotating workflow engine is:
 
 ## Maturity
 
-See `docs/MATURITY.md` row for `nebula-resource`.
+See the `nebula-resource` row in the workspace [`docs/MATURITY.md`](../../docs/MATURITY.md).
 
 - API stability: `frontier` — slot-binding pattern shipped; 3 topologies (`Pooled` / `Resident` / `Bounded`), `Manager`, `ReleaseQueue`, and `ResourceGuard` are the authoritative lifecycle surface; topology runtime variants are actively evolving.
 - `#![forbid(unsafe_code)]` enforced, `#![deny(missing_docs)]` +
@@ -294,7 +330,10 @@ supplies only thin R-aware hooks (`create_entry`, `entry_instance`,
 `into_instance`, `accept`, `prepare`, `on_release`, `pools`, `store_capacity`,
 `dispatch_credential_hook`, …). A custom topology therefore writes **zero**
 store / checkout / destroy / revoke-fence code — the credential-revoke fence is
-framework-owned for every topology, built-in and custom alike. A non-pooling
+framework-owned for every topology, built-in and custom alike. The async hooks
+are plain `async fn` in trait (RPITIT) — do **not** annotate your
+`impl Topology<R>` block with `#[async_trait]` (`Provider` still needs it;
+`Topology` does not). A non-pooling
 topology that carries credential slots (a shared/multiplexed singleton) must
 override `dispatch_credential_hook` for revoke teardown; the registrar emits a
 loud warning when it does not.

--- a/crates/resource/docs/DESIGN.md
+++ b/crates/resource/docs/DESIGN.md
@@ -11,34 +11,34 @@
 
 ## 1. Назначение и границы
 
-`nebula-resource` владеет **engine-owned жизненным циклом внешних ресурсов** — пулы БД, HTTP-клиенты, SDK-клиенты. Это реализация паттерна Bulkhead (Release It!): изоляция истощения по топологиям, чтобы одна выбранная-до-дна группа не каскадила на несвязанные пути. Action-код получает `ResourceGuard<R>`, который дерефится в `R::Instance` и освобождается на drop; framework гарантирует здоровье инстанса до выдачи гварда (`src/resource.rs:366`, `src/guard.rs:99`).
+`nebula-resource` владеет **engine-owned жизненным циклом внешних ресурсов** — пулы БД, HTTP-клиенты, SDK-клиенты. Это реализация паттерна Bulkhead (Release It!): изоляция истощения по топологиям, чтобы одна выбранная-до-дна группа не каскадила на несвязанные пути. Action-код получает `ResourceGuard<R>`, который дерефится в `R::Instance` и освобождается на drop; framework гарантирует здоровье инстанса до выдачи гварда (`src/resource.rs`, `src/guard.rs`).
 
 **Владеет:** acquire-петлёй (framework-owned, не у топологии), health-check / hot-reload / scope-bounded release, fenced idle-queue (`InstanceStore`), двухфазным credential-revoke (taint→drain), structural cross-tenant барьером (`SlotIdentity`), generation-stamped слот-ячейками (`SlotCell`), per-slot ротационным fan-out (под feature `rotation`), типизированной ошибкой с retry-классификацией.
 
-**ЯВНО НЕ делает:** не хранит ключи и не шифрует (это `nebula-storage` / `nebula-crypto`); не определяет credential-типы и не выполняет refresh/lease/rotation-state (это `nebula-credential`); не содержит long-running worker'ов и pull-подписок — `Daemon` / `EventSource` живут в `nebula_engine::daemon` (канон §3.5 резервирует «Resource» под pool/SDK-клиенты, README.md:18); внутренний epoch-blind `cell::Cell` намеренно НЕ реэкспортируется (`src/lib.rs:65`).
+**ЯВНО НЕ делает:** не хранит ключи и не шифрует (это `nebula-storage` / `nebula-crypto`); не определяет credential-типы и не выполняет refresh/lease/rotation-state (это `nebula-credential`); не содержит long-running worker'ов и pull-подписок — `Daemon` / `EventSource` живут в `nebula_engine::daemon` (канон §3.5 резервирует «Resource» под pool/SDK-клиенты, README.md); внутренний epoch-blind `cell::Cell` намеренно НЕ реэкспортируется (`src/lib.rs`).
 
 ## 2. Публичная поверхность
 
 | Элемент | Где |
 |---------|-----|
-| `Provider` — центральный трейт: assoc `Config`/`Instance`/`Topology`, `key()`, `create/check/shutdown/destroy`, per-slot `on_credential_refresh`/`on_credential_revoke` | `src/resource.rs:366` |
-| `HasCredentialSlots` — epoch-fold по слотам, эмитится derive `Resource` | `src/resource.rs:618` |
-| `ResourceConfig` (supertrait `HasSchema`, `validate`+`fingerprint`); `TeardownCx`/`TeardownReason` (ADR-0093); `CheckCost` | `src/resource.rs:61,250,271,294` |
-| `Topology<R>` — открытый slot-centric трейт; framework владеет петлёй, топология НЕ может достать revoke-fence (storage-safety через lifetime-bound `&InstanceStore`) | `src/topology/contract.rs:379` |
-| `InstanceStore<S>`, `Checkout`, `CheckedOut`, `ReturnOutcome` — fenced idle-queue | `src/topology/store.rs:92,417,444,475` |
-| Встроенные топологии `Pooled<R>` / `Resident<R>` / `Bounded<R>` (capped/exclusive/unbounded) + hook-трейты `PoolProvider`/`ResidentProvider`/`BoundedProvider` | `src/runtime/pool.rs:126`, `resident.rs:56`, `bounded.rs:54`; `src/topology/pooled.rs:83`, `resident.rs:20`, `bounded.rs:68` |
-| `Manager` — единая воронка `register(RegistrationSpec)`, acquire-dispatch, revoke (`TaintedSlot`/`RevokeTail`), shutdown | `src/manager/mod.rs:485,386,432` |
-| `RegistrationSpec<R>` — plain struct (без builder): resource/config/scope/slot_identity/topology/recovery_gate | `src/manager/options.rs:230` |
-| `SlotIdentity` (`Unbound`/`Structural`) — структурный cross-tenant барьер; `DedupKey` | `src/dedup.rs:54,113` |
-| `SlotCell<S>` — публичная generation-stamped lock-free ячейка слота | `src/slot.rs:57` |
-| `ResourceGuard<R>` (RAII Owned/Guarded); `ResourceRef<R>` (lazy-ссылка) | `src/guard.rs:99`; `src/resource_ref.rs:55` |
-| `Registry`, sealed `ManagedHandle`, `LookupOutcome` — type-erased хранилище, scope-aware lookup | `src/registry.rs:391,61,297` |
-| `ReleaseQueue` — best-effort async drain (§11.4); `RecoveryGate`+`RecoveryTicket`/`RecoveryWaiter`/`GateState` — thundering-herd | `src/release_queue.rs:106`; `src/recovery/gate.rs:327` |
-| `Error`/`ErrorKind`; `ResourceEvent`; `ResourceOpsMetrics`/`ResourceOpsSnapshot` | `src/error.rs:13,113`; `src/events.rs:20`; `src/metrics.rs:78,370` |
-| `ResourceContext` + scope-хелперы; `AcquireOptions`; `ReloadOutcome`; `ResourcePhase`/`ResourceStatus` | `src/context.rs:103,213-246`; `src/options.rs:24`; `src/reload.rs:18`; `src/state.rs:9,52` |
+| `Provider` — центральный трейт: assoc `Config`/`Instance`/`Topology`, `key()`, `create/check/shutdown/destroy`, per-slot `on_credential_refresh`/`on_credential_revoke` | `src/resource.rs` |
+| `HasCredentialSlots` — epoch-fold по слотам, эмитится derive `Resource` | `src/resource.rs` |
+| `ResourceConfig` (supertrait `HasSchema`, `validate`+`fingerprint`); `TeardownCx`/`TeardownReason` (ADR-0093); `CheckCost` | `src/resource.rs` |
+| `Topology<R>` — открытый slot-centric трейт; framework владеет петлёй, топология НЕ может достать revoke-fence (storage-safety через lifetime-bound `&InstanceStore`) | `src/topology/contract.rs` |
+| `InstanceStore<S>`, `Checkout`, `CheckedOut`, `ReturnOutcome` — fenced idle-queue | `src/topology/store.rs` |
+| Встроенные топологии `Pooled<R>` / `Resident<R>` / `Bounded<R>` (capped/exclusive/unbounded) + hook-трейты `PoolProvider`/`ResidentProvider`/`BoundedProvider` | `src/runtime/pool.rs`, `resident.rs`, `bounded.rs`; `src/topology/pooled.rs`, `resident.rs`, `bounded.rs` |
+| `Manager` — единая воронка `register(RegistrationSpec)`, acquire-dispatch, revoke (`TaintedSlot`/`RevokeTail`), shutdown | `src/manager/mod.rs` |
+| `RegistrationSpec<R>` — plain struct (без builder): resource/config/scope/slot_identity/topology/recovery_gate | `src/manager/options.rs` |
+| `SlotIdentity` (`Unbound`/`Structural`) — структурный cross-tenant барьер; `DedupKey` | `src/dedup.rs` |
+| `SlotCell<S>` — публичная generation-stamped lock-free ячейка слота | `src/slot.rs` |
+| `ResourceGuard<R>` (RAII Owned/Guarded); `ResourceRef<R>` (lazy-ссылка) | `src/guard.rs`; `src/resource_ref.rs` |
+| `Registry`, sealed `ManagedHandle`, `LookupOutcome` — type-erased хранилище, scope-aware lookup | `src/registry.rs` |
+| `ReleaseQueue` — best-effort async drain (§11.4); `RecoveryGate`+`RecoveryTicket`/`RecoveryWaiter`/`GateState` — thundering-herd | `src/release_queue.rs`; `src/recovery/gate.rs` |
+| `Error`/`ErrorKind`; `ResourceEvent`; `ResourceOpsMetrics`/`ResourceOpsSnapshot` | `src/error.rs`; `src/events.rs`; `src/metrics.rs` |
+| `ResourceContext` + scope-хелперы; `AcquireOptions`; `ReloadOutcome`; `ResourcePhase`/`ResourceStatus` | `src/context.rs`; `src/options.rs`; `src/reload.rs`; `src/state.rs` |
 | feature `rotation`: `ResourceFanoutDriver`, `ResourceFanoutIndex`, `Bind`, `RotationOutcome` | `src/credential_fanout/` |
 | Derive (subcrate `macros/`): `Resource`, `ResourceConfig`, `ClassifyError` | `macros/src/lib.rs` |
-| Реэкспорты чужого: `Credential`/`CredentialContext`/`CredentialId`, `HasSchema`/`Schema`/`ValidSchema`, `Subscriber`, `ResourceKey`/`ScopeLevel`/`resource_key!`; `prelude` | `src/lib.rs:84-118,180` |
+| Реэкспорты чужого: `Credential`/`CredentialContext`/`CredentialId`, `HasSchema`/`Schema`/`ValidSchema`, `Subscriber`, `ResourceKey`/`ScopeLevel`/`resource_key!`; `prelude` | `src/lib.rs` |
 
 ## 3. Зависимости и зависимые
 
@@ -64,13 +64,13 @@
 
 ## 5. Инварианты и контракты
 
-- **Framework владеет acquire-петлёй и revoke-fence.** Открытый `Topology<R>` намеренно НЕ возвращает `ResourceGuard<R>` и не даёт топологии доступ к store/fence (storage-safety через lifetime-bound `&InstanceStore`, `src/topology/contract.rs:379`) — закрывает failure-mode «façade-twice» из bind-inversion (ADR-0093).
-- **Release best-effort on crash (L2-§11.4).** Drop гварда никогда не паникует и не блокирует; недослитое уходит в `ReleaseQueue` (`src/release_queue.rs:106`).
+- **Framework владеет acquire-петлёй и revoke-fence.** Открытый `Topology<R>` намеренно НЕ возвращает `ResourceGuard<R>` и не даёт топологии доступ к store/fence (storage-safety через lifetime-bound `&InstanceStore`, `src/topology/contract.rs`) — закрывает failure-mode «façade-twice» из bind-inversion (ADR-0093).
+- **Release best-effort on crash (L2-§11.4).** Drop гварда никогда не паникует и не блокирует; недослитое уходит в `ReleaseQueue` (`src/release_queue.rs`).
 - **Attributable lifecycle (L2-§13.3).** Каждая операция несёт `ResourceContext`/scope; `ResourceEvent` + `ResourceOpsMetrics` дают трассируемость по умолчанию.
-- **Cross-tenant barrier by-construction.** `SlotIdentity::Structural` входит в dedup-ключ (`src/dedup.rs:54,113`, `src/registry.rs`), поэтому инстанс одного тенанта структурно не может быть отдан другому — это не runtime-проверка, а форма ключа.
-- **Revoke без TOCTOU.** Двухфазный taint→drain (`src/manager/mod.rs:485`) гарантирует, что после revoke ни один уже выданный гвард не продолжит работать на отозванном credential.
-- **Generation-stamped слоты.** `SlotCell<S>` lock-free и штампует поколение; epoch-blind `cell::Cell` скрыт (`src/lib.rs:65`), чтобы автор не прочитал слот мимо epoch-инварианта.
-- **Teardown-контракт (ADR-0093).** `reset`/`destroy` — fallible-async; safe-by-default reset; deadline (а не `Duration`) через `TeardownCx`/`TeardownReason` (`src/resource.rs:250,271`).
+- **Cross-tenant barrier by-construction.** `SlotIdentity::Structural` входит в dedup-ключ (`src/dedup.rs`, `src/registry.rs`), поэтому инстанс одного тенанта структурно не может быть отдан другому — это не runtime-проверка, а форма ключа.
+- **Revoke без TOCTOU.** Двухфазный taint→drain (`src/manager/mod.rs`) гарантирует, что после revoke ни один уже выданный гвард не продолжит работать на отозванном credential.
+- **Generation-stamped слоты.** `SlotCell<S>` lock-free и штампует поколение; epoch-blind `cell::Cell` скрыт (`src/lib.rs`), чтобы автор не прочитал слот мимо epoch-инварианта.
+- **Teardown-контракт (ADR-0093).** `reset`/`destroy` — fallible-async; safe-by-default reset; deadline (а не `Duration`) через `TeardownCx`/`TeardownReason` (`src/resource.rs`).
 
 ## 6. Известные напряжения / долг (честно)
 
@@ -103,6 +103,17 @@
 8. ~~**README отстаёт от кода.**~~ **Fixed.** `last-reviewed` bumped to
    2026-07-02; "Public API (v4)" cross-checked against the current
    `Provider`/`RegistrationSpec`/topology shape.
+
+**Batch E (2026-07-09)** — повторный прогон доков против кода: `Provider`-скетч
+в README приведён к реальной сигнатуре (супертрейты `HasCredentialSlots + … +
+Sized`, `destroy(…, cx: TeardownCx)`, дефолты у `check`/`shutdown`/`destroy`);
+`docs/events.md` дополнен пропущенным `MaintenanceEvicted` (счётчики 14→16);
+в `src/lib.rs` убраны битые относительные ссылки `](../docs/*.md)` — rustdoc
+резолвил их в `target/doc/docs/*`.
+
+**Номера строк (`file.rs:NNN`) вычищены из §2 намеренно.** 22 из 29 указывали
+мимо цели (часть — в пустые строки). Путь к файлу + имя символа в той же ячейке
+не дрейфуют; номер строки дрейфует на каждом коммите. Не возвращать.
 
 ## 7. Роль в пост-0092 credential/resource модели
 

--- a/crates/resource/docs/events.md
+++ b/crates/resource/docs/events.md
@@ -31,14 +31,14 @@ need to handle a lag error explicitly.
 
 ## Event Catalog
 
-Fourteen `#[non_exhaustive]` variants; new variants may be added in minor
+Sixteen `#[non_exhaustive]` variants; new variants may be added in minor
 releases without a major bump. Every variant carries a `ResourceKey` — this
 crate reports strictly per-resource (the per-slot rotation fan-out lives **in
 this crate**, co-located with `Manager` and relocated from `nebula-engine` per
 ADR-0092; it reports per-resource, so there is no aggregate `CredentialRefreshed` /
 `CredentialRevoked` event and no `CredentialId` in any payload).
 
-### Generic lifecycle variants (10)
+### Generic lifecycle variants (12)
 
 | Variant | Emitted when | Key fields |
 |---------|-------------|------------|
@@ -52,7 +52,8 @@ ADR-0092; it reports per-resource, so there is no aggregate `CredentialRefreshed
 | `RetryAttempt` | A retry is about to sleep after a transient acquire failure | `key`, `attempt: u32`, `backoff: Duration`, `error: String` |
 | `BackpressureDetected` | Pool backpressure was detected (semaphore full) | `key` |
 | `RecoveryGateChanged` | A recovery gate transitioned | `key`, `state: String` |
-| `HoldDeadlineExceeded` | A lease was still held past `Provider::max_hold_duration` (leak/hang detection, warn-only) | `key`, `held: Duration`, `deadline: Duration` |
+| `MaintenanceEvicted` | A background pool-maintenance sweep evicted idle-timed-out, max-lifetime-exceeded, stale-fingerprint, or revoked idle instances. Emitted only when at least one instance was evicted | `key`, `evicted: usize` |
+| `HoldDeadlineExceeded` | A lease was still held past `Provider::max_hold_duration` (leak/hang detection, warn-only) | `key`, `held: Duration`, `deadline: Duration`, `execution_id: Option<ExecutionId>`, `workflow_id: Option<WorkflowId>`, `span_id: Option<SpanId>` |
 
 ### Slot-rotation variants (4)
 

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -841,7 +841,6 @@ mod tests {
     /// are never exercised — `create_entry` therefore just errors.
     struct FixtureTopology;
 
-    #[async_trait::async_trait]
     impl<R: Provider> Topology<R> for FixtureTopology {
         type Entry = R::Instance;
 

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -205,8 +205,8 @@
 //! | [`RecoveryGateConfig::base_backoff`] | `1 s` | Doubled per attempt (capped at 5 min), then equal-jittered (`[nominal/2, nominal]`) so a synchronized-failure cohort does not retry in lockstep. |
 //! | `ShutdownConfig::drain_timeout` | `30 s` | Bounds how long [`Manager::graceful_shutdown`] waits for in-flight handles before applying [`DrainTimeoutPolicy`]. |
 //!
-//! Full field references: [`pooling.md`](../docs/pooling.md) for the pool
-//! config, [`recovery.md`](../docs/recovery.md) for the gate, and the
+//! Full field references: `crates/resource/docs/pooling.md` for the pool
+//! config, `crates/resource/docs/recovery.md` for the gate, and the
 //! rustdoc on each type above for the rest.
 //!
 //! ## Canon note — §11.4

--- a/crates/resource/src/runtime/bounded.rs
+++ b/crates/resource/src/runtime/bounded.rs
@@ -26,7 +26,6 @@ use std::{
     },
 };
 
-use async_trait::async_trait;
 use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::{
@@ -201,7 +200,6 @@ impl<R: Provider> Bounded<R> {
 // reused instance, reset on release); `Capped` / `Unbounded` destroy every
 // instance on release.
 
-#[async_trait]
 impl<R> Topology<R> for Bounded<R>
 where
     R: Provider<Topology = Bounded<R>>
@@ -348,6 +346,7 @@ where
 mod tests {
     use std::sync::atomic::AtomicBool;
 
+    use async_trait::async_trait;
     use nebula_core::{ExecutionId, ResourceKey, resource_key};
 
     use super::*;

--- a/crates/resource/src/runtime/bounded.rs
+++ b/crates/resource/src/runtime/bounded.rs
@@ -411,7 +411,6 @@ mod tests {
 
     crate::no_credential_slots!(MockBounded);
 
-    #[async_trait]
     impl BoundedProvider for MockBounded {
         async fn reset(&self, _instance: &mut u32) -> Result<(), Error> {
             self.reset_calls.fetch_add(1, Ordering::Relaxed);

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -23,7 +23,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_trait::async_trait;
 use tokio::sync::Semaphore;
 
 use crate::{
@@ -426,7 +425,6 @@ where
 // runs no checkout/destroy/fence loop, and never compares epochs — that is all
 // the framework's job.
 
-#[async_trait]
 impl<R> Topology<R> for Pooled<R>
 where
     R: Provider<Topology = Pooled<R>> + PoolProvider + Clone + Send + Sync + 'static,

--- a/crates/resource/src/runtime/resident.rs
+++ b/crates/resource/src/runtime/resident.rs
@@ -26,7 +26,6 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use async_trait::async_trait;
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -416,7 +415,6 @@ where
 // reach the master cell (it is not in the store), so revoke teardown runs
 // through `dispatch_credential_hook`.
 
-#[async_trait]
 impl<R> Topology<R> for Resident<R>
 where
     R: Provider<Topology = Resident<R>>

--- a/crates/resource/src/topology/bounded.rs
+++ b/crates/resource/src/topology/bounded.rs
@@ -23,9 +23,7 @@
 //! [`BoundedProvider`] hook trait so the framework
 //! [`Bounded`](crate::topology::Bounded) topology can drive its reset policy.
 
-use std::num::NonZeroUsize;
-
-use async_trait::async_trait;
+use std::{future::Future, num::NonZeroUsize};
 
 use crate::{error::Error, resource::Provider};
 
@@ -64,7 +62,6 @@ pub enum BoundedMode {
 /// calls [`reset`](BoundedProvider::reset); `Capped` / `Unbounded` destroy
 /// every instance on release and never reset, so the default no-op suffices for
 /// them.
-#[async_trait]
 pub trait BoundedProvider: Provider {
     /// Reset the single exclusive instance before it is reissued to the next
     /// acquirer (roll back a transaction, clear per-session state, re-arm a
@@ -81,7 +78,10 @@ pub trait BoundedProvider: Provider {
     /// surfaces the error to an awaited
     /// [`release()`](crate::guard::ResourceGuard::release); a fresh instance is
     /// built on the next acquire. The default implementation never fails.
-    async fn reset(&self, _instance: &mut Self::Instance) -> Result<(), Error> {
-        Ok(())
+    fn reset(
+        &self,
+        _instance: &mut Self::Instance,
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        async { Ok(()) }
     }
 }

--- a/crates/resource/src/topology/contract.rs
+++ b/crates/resource/src/topology/contract.rs
@@ -26,9 +26,8 @@
 //! [`SlotIdentity`]: crate::dedup::SlotIdentity
 //! [`InstanceStore`]: crate::topology::store::InstanceStore
 
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
-use async_trait::async_trait;
 use tokio::sync::OwnedSemaphorePermit;
 
 use crate::{
@@ -380,12 +379,16 @@ pub struct MaintenanceSchedule {
 ///
 /// # Async dispatch
 ///
-/// `#[async_trait]` is used because topologies are reached **monomorphically**
-/// inside `ManagedResource<R>` — the one `Box<dyn Future>` per call is
-/// negligible next to the I/O the hooks do. Sync hooks (`try_reserve`,
-/// `entry_instance`, `into_instance`, `phase`, `load`, `pools`, …) stay plain
-/// sync.
-#[async_trait]
+/// The async hooks are plain `async fn` in trait (RPITIT), **not**
+/// `#[async_trait]`: topologies are reached monomorphically inside
+/// `ManagedResource<R>` and are never trait objects (see "Not a trait object"
+/// above), so the boxed future `#[async_trait]` allocates per call bought
+/// nothing. It cost 3 heap allocations per cache-hit acquire (`accept`,
+/// `prepare`, `on_release`) — see `benches/acquire.rs`. An implementor writes
+/// plain `async fn` bodies; only the returned future must be `Send`.
+///
+/// Sync hooks (`try_reserve`, `entry_instance`, `into_instance`, `phase`,
+/// `load`, `pools`, …) stay plain sync.
 pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// The leasable unit the framework stores and the guard holds.
     ///
@@ -431,12 +434,12 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     ///
     /// Returns the create/clone error; the framework fails the acquire and
     /// drops the held permit, releasing capacity.
-    async fn create_entry(
+    fn create_entry(
         &self,
         resource: &R,
         config: &R::Config,
         ctx: &ResourceContext,
-    ) -> Result<Self::Entry, Error>;
+    ) -> impl Future<Output = Result<Self::Entry, Error>> + Send;
 
     /// Project a held entry to its leasable instance — the guard's `Deref`
     /// target. Pooled: `&entry.instance`; Resident: the entry itself.
@@ -463,13 +466,13 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// ([`into_instance`](Topology::into_instance) → [`Provider::destroy`]) and
     /// loops to the next idle entry, then `create_entry`. Default `true` (no
     /// post-checkout policy).
-    async fn accept(
+    fn accept(
         &self,
         _entry: &mut Self::Entry,
         _resource: &R,
         _ctx: &ResourceContext,
-    ) -> bool {
-        true
+    ) -> impl Future<Output = bool> + Send {
+        async { true }
     }
 
     /// Per-acquire session-init on the entry about to be leased (Pooled
@@ -478,13 +481,13 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// # Errors
     ///
     /// `Err` ⇒ the framework destroys the entry and fails the acquire.
-    async fn prepare(
+    fn prepare(
         &self,
         _entry: &mut Self::Entry,
         _resource: &R,
         _ctx: &ResourceContext,
-    ) -> Result<(), Error> {
-        Ok(())
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        async { Ok(()) }
     }
 
     /// Reset / recycle a released entry before the framework returns it (rollback
@@ -502,8 +505,12 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// the hook handles.
     ///
     /// Default `Ok(true)` (no reset; recycle if the topology pools).
-    async fn on_release(&self, _entry: &mut Self::Entry, _resource: &R) -> Result<bool, Error> {
-        Ok(true)
+    fn on_release(
+        &self,
+        _entry: &mut Self::Entry,
+        _resource: &R,
+    ) -> impl Future<Output = Result<bool, Error>> + Send {
+        async { Ok(true) }
     }
 
     /// Whether a released, kept entry returns to the framework idle store.
@@ -610,14 +617,14 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     ///
     /// Returns the first hook error; the framework surfaces it to the rotation
     /// dispatch caller.
-    async fn dispatch_credential_hook(
+    fn dispatch_credential_hook(
         &self,
         _resource: &R,
         _store: &InstanceStore<Self::Entry>,
         _slot: &str,
         _refresh: bool,
-    ) -> Result<(), Error> {
-        Ok(())
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        async { Ok(()) }
     }
 
     /// Update the config fingerprint so stale idle entries evict on the next
@@ -667,7 +674,6 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoTopology;
 
-#[async_trait]
 impl<R: Provider> Topology<R> for NoTopology {
     type Entry = R::Instance;
 

--- a/crates/resource/src/topology/contract.rs
+++ b/crates/resource/src/topology/contract.rs
@@ -377,15 +377,23 @@ pub struct MaintenanceSchedule {
 /// borrow does not exceed the call, so the topology cannot retain the store or
 /// build a cross-scope cache that bypasses the per-tenant `SlotIdentity` fence.
 ///
+/// # Not a trait object
+///
+/// `Topology<R>` is reached monomorphically through
+/// [`ManagedResource<R>`](crate::ManagedResource) — do not attempt
+/// `Box<dyn Topology<R>>`. The trait is intentionally not object-safe.
+///
 /// # Async dispatch
 ///
 /// The async hooks are plain `async fn` in trait (RPITIT), **not**
 /// `#[async_trait]`: topologies are reached monomorphically inside
-/// `ManagedResource<R>` and are never trait objects (see "Not a trait object"
-/// above), so the boxed future `#[async_trait]` allocates per call bought
-/// nothing. It cost 3 heap allocations per cache-hit acquire (`accept`,
-/// `prepare`, `on_release`) — see `benches/acquire.rs`. An implementor writes
-/// plain `async fn` bodies; only the returned future must be `Send`.
+/// `ManagedResource<R>`, so the boxed future `#[async_trait]` allocates per
+/// call bought nothing. A cache-hit acquire+release round trip previously paid
+/// 3 heap allocations on the default hook path (`accept` and `prepare` on
+/// acquire, `on_release` on release) that `#[async_trait]` inserted at the
+/// trait level — see `benches/acquire.rs` for the wall-clock regression guard.
+/// An implementor writes plain `async fn` bodies; only the returned future must
+/// be `Send`.
 ///
 /// Sync hooks (`try_reserve`, `entry_instance`, `into_instance`, `phase`,
 /// `load`, `pools`, …) stay plain sync.
@@ -532,7 +540,9 @@ pub trait Topology<R: Provider>: Send + Sync + 'static {
     /// [`dispatch_credential_hook`](Topology::dispatch_credential_hook). A
     /// topology that holds credential-bound state on `pools() == false` MUST
     /// override both this (to `true`) and the hook, or a revoked credential
-    /// keeps serving. The framework asserts this at registration.
+    /// keeps serving. Registration warns in release and `debug_assert!`s in
+    /// debug when resolved slot bindings are non-empty and this stays `false`
+    /// on a non-pooling topology.
     ///
     /// Ignored when [`pools`](Topology::pools) is `true` (the store fence
     /// covers pooled entries). Default `false` — a non-pooling topology opts in

--- a/crates/resource/tests/bounded_topology.rs
+++ b/crates/resource/tests/bounded_topology.rs
@@ -102,7 +102,6 @@ impl Provider for Seats {
 
 nebula_resource::no_credential_slots!(Seats);
 
-#[async_trait::async_trait]
 impl BoundedProvider for Seats {
     async fn reset(&self, _instance: &mut Seat) -> Result<(), Error> {
         self.reset_count.fetch_add(1, Ordering::SeqCst);

--- a/crates/resource/tests/custom_topology.rs
+++ b/crates/resource/tests/custom_topology.rs
@@ -83,7 +83,6 @@ impl EntryPool {
     }
 }
 
-#[async_trait]
 impl Topology<PermitRes> for EntryPool {
     type Entry = u32;
 

--- a/crates/resource/tests/custom_topology_manager.rs
+++ b/crates/resource/tests/custom_topology_manager.rs
@@ -156,7 +156,6 @@ impl FfmpegPool {
     }
 }
 
-#[async_trait::async_trait]
 impl Topology<Ffmpeg> for FfmpegPool {
     // The entry IS the leasable transcoder. The framework stores it, fences it,
     // and hands it back on checkout — the author never touches the store.

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -38,6 +38,8 @@ uuid = { workspace = true, optional = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
+# doctests only: `impl Provider` in the prelude resource example.
+async-trait = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -53,6 +53,21 @@ The SDK does not introduce a second OAuth façade on top of `nebula-credential`.
 
 **Migration:** When credential/OAuth types move or rename, follow `nebula-credential` release notes and this README; the SDK version tracks workspace `nebula-credential` and does not add its own parallel OAuth type aliases.
 
+### Resource authoring and the SDK
+
+Resource authoring types and traits are in the prelude; derive macros still need
+their target crates on the dependency graph:
+
+| Surface | What you use |
+|--------|----------------|
+| **Full crate** | `nebula_sdk::nebula_resource` (same as depending on `nebula-resource` directly). Engine-integrator types live here: `Manager`, `Registry`, `ReleaseQueue`, `credential_fanout`, metrics, recovery gates. |
+| **Prelude** | `nebula_sdk::prelude::*` re-exports the author surface: derives `Resource` / `ResourceConfig` / `ClassifyError`; traits `Provider`, `ResourceConfig`, `HasCredentialSlots`, `PoolProvider`, `ResidentProvider`, `BoundedProvider`; topologies `Pooled`, `Resident`, `Bounded` with `PoolConfig` / `ResidentConfig` / `BoundedMode`; and `AcquireOptions`, `RegistrationSpec`, `ResourceContext`, `ResourceGuard`, `ResourceMetadata`, `ResourceKey`, `resource_key!`, `ScopeLevel`, `SlotIdentity`, `SlotCell`, `TopologyTag`, `ReloadOutcome`, `Error`, `ErrorKind`, `no_credential_slots!`. See `prelude.rs` for a runnable pooled-resource example. |
+| **Direct deps for derives** | `#[derive(Resource)]` expands to `::nebula_resource::…` / `::nebula_core::…` paths — add `nebula-resource`, `nebula-core`, and `async-trait` as direct `Cargo.toml` dependencies (match the versions `nebula-sdk` pins). `impl Provider` needs `#[async_trait::async_trait]`. |
+
+**Not in the prelude:** the engine-owned lifecycle (`Manager::register` / `acquire_*`, `Registry`, `ReloadOutcome` dispatch, rotation fan-out). Authors implement `Provider`; the engine drives it. If you outgrow the prelude list, import from `nebula_sdk::nebula_resource` without adding another workspace dependency.
+
+Note that prelude `Error` is `nebula_resource::Error` (the resource error type); `thiserror::Error` is a derive macro in a separate namespace, so both coexist under the glob. The SDK's own error is exported as `SdkError`.
+
 Modules provided by this crate:
 
 - `prelude` — one-stop `use nebula_sdk::prelude::*` import for common types and traits.

--- a/crates/sdk/src/prelude.rs
+++ b/crates/sdk/src/prelude.rs
@@ -7,6 +7,57 @@
 //! ```rust,no_run
 //! use nebula_sdk::prelude::*;
 //! ```
+//!
+//! ## Authoring a pooled resource
+//!
+//! Types and traits for resource authoring live in the prelude. The derive
+//! macros (`#[derive(Resource)]`, `#[derive(ResourceConfig)]`,
+//! `#[derive(ClassifyError)]`) expand to `::nebula_resource::…` and
+//! `::nebula_core::…` paths, so list `nebula-resource`, `nebula-core`, and
+//! `async-trait` as direct dependencies alongside `nebula-sdk` (same versions
+//! the SDK pins). `#[derive(Resource)]` emits the credential-slot plumbing,
+//! [`Provider`] supplies the lifecycle, and `type Topology = Pooled<Self>` opts
+//! into pool checkout/recycle (every [`PoolProvider`] hook has a default, so an
+//! empty impl suffices).
+//!
+//! ```rust
+//! use nebula_sdk::prelude::*;
+//!
+//! #[derive(Clone, Debug)]
+//! struct HttpClient {
+//!     base_url: String,
+//! }
+//!
+//! #[derive(Resource, Clone)]
+//! struct HttpResource;
+//!
+//! #[async_trait::async_trait]
+//! impl Provider for HttpResource {
+//!     type Config = ();
+//!     type Instance = HttpClient;
+//!     type Topology = Pooled<Self>;
+//!
+//!     fn key() -> ResourceKey {
+//!         resource_key!("http.client.sdk_prelude")
+//!     }
+//!
+//!     async fn create(&self, _config: &(), _ctx: &ResourceContext) -> Result<HttpClient, Error> {
+//!         Ok(HttpClient {
+//!             base_url: "https://api.example.com".to_owned(),
+//!         })
+//!     }
+//! }
+//!
+//! impl PoolProvider for HttpResource {}
+//!
+//! // A resource with no `#[credential]` fields can skip the derive entirely.
+//! # struct Slotless;
+//! no_credential_slots!(Slotless);
+//! ```
+//!
+//! Engine-side registration ([`RegistrationSpec`]) and acquisition go through
+//! `nebula_sdk::nebula_resource::Manager`; action code receives a
+//! [`ResourceGuard`] that derefs to `Provider::Instance`.
 
 // Core traits and types
 // DX trait families: stateful, trigger
@@ -32,7 +83,8 @@ pub use nebula_action::{
 // without reaching into `nebula_action::`.
 pub use nebula_action::{impl_batch_action, impl_paginated_action};
 pub use nebula_core::{
-    ActionKey, ExecutionId, NodeKey, PluginKey, ScopeLevel, WorkflowId, action_key,
+    ActionKey, ExecutionId, NodeKey, PluginKey, ResourceKey, ScopeLevel, WorkflowId, action_key,
+    resource_key,
 };
 // Credential types (v2)
 pub use nebula_credential::{
@@ -65,7 +117,22 @@ pub use nebula_credential::{CredentialContext, CredentialId};
 pub use nebula_metadata::{BaseMetadata, DeprecationNotice, Icon, MaturityLevel, Metadata};
 // Plugin types
 pub use nebula_plugin::{Plugin, PluginManifest};
-pub use nebula_resource::{Resource, ResourceMetadata};
+// Resource authoring surface — mirrors `nebula_resource::prelude` plus the
+// `Resource` / `ResourceConfig` / `ClassifyError` derive macros, so an
+// integration author never needs a direct `nebula-resource` dependency.
+//
+// `Error` here is the resource error *type*; `thiserror::Error` below is a
+// derive *macro* — different namespaces, so both live in the glob.
+//
+// Engine-only types (`Manager`, `Registry`, `ReleaseQueue`,
+// `credential_fanout`) are deliberately absent — reach them through
+// `nebula_sdk::nebula_resource`.
+pub use nebula_resource::{
+    AcquireOptions, Bounded, BoundedMode, BoundedProvider, ClassifyError, Error, ErrorKind,
+    HasCredentialSlots, PoolConfig, PoolProvider, Pooled, Provider, RegistrationSpec, ReloadOutcome,
+    Resident, ResidentConfig, ResidentProvider, Resource, ResourceConfig, ResourceContext,
+    ResourceGuard, ResourceMetadata, SlotCell, SlotIdentity, TopologyTag, no_credential_slots,
+};
 // Derive macros (re-exported from their respective domain crates)
 // Action, Credential, and Plugin derive macros are already in scope from the
 // domain crate imports above (same names, macro namespace).

--- a/crates/sdk/src/prelude.rs
+++ b/crates/sdk/src/prelude.rs
@@ -129,9 +129,10 @@ pub use nebula_plugin::{Plugin, PluginManifest};
 // `nebula_sdk::nebula_resource`.
 pub use nebula_resource::{
     AcquireOptions, Bounded, BoundedMode, BoundedProvider, ClassifyError, Error, ErrorKind,
-    HasCredentialSlots, PoolConfig, PoolProvider, Pooled, Provider, RegistrationSpec, ReloadOutcome,
-    Resident, ResidentConfig, ResidentProvider, Resource, ResourceConfig, ResourceContext,
-    ResourceGuard, ResourceMetadata, SlotCell, SlotIdentity, TopologyTag, no_credential_slots,
+    HasCredentialSlots, PoolConfig, PoolProvider, Pooled, Provider, RegistrationSpec,
+    ReloadOutcome, Resident, ResidentConfig, ResidentProvider, Resource, ResourceConfig,
+    ResourceContext, ResourceGuard, ResourceMetadata, SlotCell, SlotIdentity, TopologyTag,
+    no_credential_slots,
 };
 // Derive macros (re-exported from their respective domain crates)
 // Action, Credential, and Plugin derive macros are already in scope from the


### PR DESCRIPTION
## What

`Topology<R>` is reached monomorphically through `ManagedResource<R>` and is never a trait object — `Box<dyn Topology>` is explicitly forbidden in its own docs. So the `Box<dyn Future>` that `#[async_trait]` allocates on every call bought nothing.

It cost **3 heap allocations per cache-hit acquire** (`accept`, `prepare`, `on_release`), out of the 7 the full acquire/release cycle did.

The trait's doc comment had assumed this away:

> `#[async_trait]` is used because topologies are reached **monomorphically** — the one `Box<dyn Future>` per call is negligible next to the I/O the hooks do.

That holds for a provider doing real I/O. It does not hold for the framework's own hit path, where `accept`/`prepare`/`on_release` default to no-ops.

This switches the five async hooks to native async-fn-in-trait (RPITIT). Implementors keep writing plain `async fn` bodies and simply drop the macro; only the returned future must stay `Send`, which the trait declaration now spells out explicitly. Net: one less macro in the open-trait surface.

## Numbers

`perf` is blocked on the dev box (`perf_event_paranoid=4`) and `valgrind` isn't installed, so the hot path was profiled by counting allocations with a temporary counting global allocator. `pooled_hit` goes from **7 to 4 allocations per cycle**.

For timing, the machine was under load 18 from sibling agents — single criterion runs of the *same* binary swung between `+105%` and `-39%`. Both versions were rebuilt as standalone bench binaries and run interleaved on pinned cores. Medians of 3 paired runs:

| bench | before | after | |
|---|---|---|---|
| `pooled_hit` | 2.205 µs | 2.032 µs | −7.8% |
| `pooled_create_destroy` | 2.504 µs | 2.325 µs | −7.1% |
| `resident_hit` | 1.309 µs | 1.277 µs | −2.4% |

Absolute values are inflated by pinning to two busy cores; the A/B delta is the meaningful number. An earlier 6-pair run at lower load put `resident_hit` at a consistent −8.6%, so its −2.4% here is the noisiest of the three.

## Verification

- `cargo nextest run -p nebula-resource --all-features` — 480 passed
- `cargo test -p nebula-resource --doc --all-features` — 21 passed
- `cargo clippy -p nebula-resource --all-features --all-targets -- -D warnings` — clean
- `cargo clippy -p nebula-resource --all-targets -- -D warnings` (default features) — clean

No semantic change: the revoke fence, cancel-safety guards, and hook-timeout ceilings are untouched. `Provider` keeps `#[async_trait]` (it *is* a public, widely-implemented trait, and its hooks do real I/O).

## Not done here

Two further wins found while profiling, both larger and riskier than this diff:

- `R::key()` re-validates, re-normalizes, and re-hashes its string literal on every call — **28 ns**, versus **1.2 ns** to clone the result — and runs twice per acquire (~5%). Fixing it means caching a key field on `ManagedResource`, which has 9 struct-literal construction sites.
- The guard's `Box<dyn FnOnce>` and `Box::pin(release_entry)` are the last 2 allocations, but removing them needs a type-erasure refactor of `guard.rs`.

`SlotCell` was left alone — its read path is already 10–15 ns and shows no fat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated async resource topology handling to use a more direct future-based approach.
  * Simplified several resource runtime implementations by removing unnecessary async wrapping.
* **Tests**
  * Adjusted test topologies to match the updated async handling, with no behavioral changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->