### PR TITLE
chore: Rust 1.97.1, retire deprecated shims, syn 3, and three --all-features defects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
       prefix: "chore(ci)"
     ignore:
       # `dtolnay/rust-toolchain` is SHA-pinned with a `# v1` comment in
-      # ci.yml; the MSRV (currently 1.96) is passed via the `toolchain:`
+      # ci.yml; the MSRV (currently 1.97) is passed via the `toolchain:`
       # input, not the action ref. Dependabot would otherwise open weekly
       # PRs bumping the action's SHA — we prefer to review and roll that
       # action by hand since it installs the compiler for every CI job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,8 +307,18 @@ jobs:
   # only expose third-party types from their explicit allowlists
   # (`[package.metadata.cargo_check_external_types]` in each Cargo.toml).
   # The nightly toolchain is pinned to the rustdoc JSON format the tool's
-  # version understands (0.5.x ↔ format 57 ↔ nightly-2026-03-20); bump the
-  # two together.
+  # version understands (0.5.x ↔ format 57); bump the two together.
+  #
+  # The pin is squeezed from both sides, so it is not free to move:
+  #   * below the workspace `rust-version`, cargo refuses to build at all
+  #     ("rustc X is not supported by the following packages") — this is why
+  #     the 1.97 MSRV bump retired the previous nightly-2026-03-20 pin, which
+  #     is 1.96.0-nightly;
+  #   * above format 57, the tool rejects the JSON (current nightly emits 60,
+  #     and 0.5.0 is the latest release, so there is no newer tool to move to).
+  # nightly-2026-04-20 (1.97.0-nightly) is inside that window. When the MSRV
+  # next moves, find a nightly at or above it that still emits the format the
+  # installed tool requires, or bump the tool first if one exists.
   external-types:
     name: Public API surface (sdk, api)
     runs-on: ubuntu-latest
@@ -319,7 +329,7 @@ jobs:
       - name: Install pinned nightly (rustdoc JSON format 57)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly-2026-03-20
+          toolchain: nightly-2026-04-20
       - name: Install cargo-check-external-types
         uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
@@ -332,10 +342,10 @@ jobs:
           cache-on-failure: true
       - name: Check sdk public surface
         working-directory: crates/sdk
-        run: cargo +nightly-2026-03-20 check-external-types --all-features
+        run: cargo +nightly-2026-04-20 check-external-types --all-features
       - name: Check api public surface
         working-directory: crates/api
-        run: cargo +nightly-2026-03-20 check-external-types --all-features
+        run: cargo +nightly-2026-04-20 check-external-types --all-features
 
   # ── Required aggregator ───────────────────────────────────────────────────
   # Single required check for branch protection. Treats `skipped` (draft-gated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -76,7 +76,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
           components: clippy
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
@@ -116,7 +116,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Install cargo-hack
         uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
@@ -127,7 +127,14 @@ jobs:
           shared-key: ci-feature-hygiene
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+      # `build.warnings = deny` (Cargo 1.97) turns a rustc lint warning into a
+      # build error for local packages. The clippy job only covers the
+      # workspace-level all / default / no-default configurations, so a
+      # warning that fires *only* under a single isolated feature — the exact
+      # blind spot this job exists for — was previously invisible here.
       - name: cargo hack check (each feature, workspace)
+        env:
+          CARGO_BUILD_WARNINGS: deny
         run: cargo hack check --each-feature --no-dev-deps --workspace
 
   # ── Doctests (workspace-wide, off the critical path) ──────────────────────
@@ -147,7 +154,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -160,7 +167,7 @@ jobs:
   # ── MSRV ───────────────────────────────────────────────────────────────────
   # Tier 2: skipped on draft PRs.
   msrv:
-    name: MSRV (1.96)
+    name: MSRV (1.97)
     needs: [check]
     if: >-
       github.event_name != 'pull_request' ||
@@ -171,17 +178,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Rust 1.96
+      - name: Install Rust 1.97
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
           shared-key: ci-msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+      # A deprecation or future-compat warning that only the MSRV toolchain
+      # emits is a real signal; `build.warnings = deny` (Cargo 1.97) makes it
+      # fail the job instead of scrolling past in the log.
       - name: Run cargo check
+        env:
+          CARGO_BUILD_WARNINGS: deny
         run: cargo check --workspace --all-targets
 
   # ── Documentation ──────────────────────────────────────────────────────────
@@ -203,7 +215,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -229,7 +241,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -255,7 +267,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Install cargo-deny
         uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
         with:
@@ -278,7 +290,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.96"
+          toolchain: "1.97"
       - name: Assert test-only crates absent from binary dep trees
         run: |
           set -euo pipefail

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -56,5 +56,6 @@ jobs:
           allow-dependencies-licenses: >-
             pkg:cargo/brotli-decompressor,
             pkg:cargo/futures-timer,
-            pkg:cargo/generator
+            pkg:cargo/generator,
+            pkg:cargo/rustc-demangle
           comment-summary-in-pr: on-failure

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
@@ -93,7 +93,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
@@ -128,7 +128,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Select packages to test
         id: select
@@ -134,7 +134,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
@@ -209,7 +209,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: 1.96.1
+          toolchain: 1.97.1
 
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Use these instead of standard Unix equivalents — they're installed and better.
 
 ## Tech Stack
 
-- **Language:** Rust 1.96+ (edition 2024, resolver 3)
+- **Language:** Rust 1.97+ (edition 2024, resolver 3)
 - **Async:** Tokio
 - **Errors:** `thiserror` (libs) / `anyhow` (bins)
 - **Storage:** PostgreSQL, SQLite (`crates/storage/migrations/`)
@@ -161,7 +161,7 @@ nebula/
 ├── deny.toml           # cargo-deny: layer wrappers (CI gate)
 ├── lefthook.yml        # local pre-commit / pre-push (mirrors CI)
 ├── rustfmt.toml        # rustfmt config (stable-only)
-├── clippy.toml         # lint thresholds (msrv 1.96)
+├── clippy.toml         # lint thresholds (msrv 1.97)
 ├── crates/             # workspace members
 ├── tools/xtask/        # repository automation; outside the product layer graph
 ├── scripts/            # worktree.sh + lefthook helpers
@@ -359,7 +359,7 @@ Slash commands: `.claude/commands/` (project-specific, load on demand).
 |------|---------|
 | `Cargo.toml` | Workspace members, pinned deps, `[workspace.lints]` |
 | `deny.toml` | Layer wrappers, licenses, advisories — CI gate |
-| `clippy.toml` | Lint thresholds (msrv 1.96) |
+| `clippy.toml` | Lint thresholds (msrv 1.97) |
 | `rustfmt.toml` | rustfmt config (stable-only, pinned toolchain) |
 | `Taskfile.yml` | `task dev:check` = full pre-PR gate |
 | `.mcp.json` | MCP server config (Serena, rust-analyzer, cratesio, etc.) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,46 @@ changes are expected between minor releases — call them out here.
 
 ### Fixed
 
+- **`task db:up` / `db:down` / `db:up:cache` were broken.** `Taskfile.yml`
+  points `COMPOSE_LOCAL` at `deploy/docker/docker-compose.yml`, which commit
+  `b1138dff` ("chore: remove stale docs") deleted as collateral alongside the
+  genuinely stale blueprints. The local Postgres (+ optional Redis `cache`
+  profile) stack is restored, on `postgres:17-alpine` to match the major that
+  `test-matrix.yml` runs against instead of the 16 it was deleted on.
+- **SQLite migration README documented a destructive, wrong procedure.** It
+  claimed `0027_port_adapter_schema.sql` is byte-identical to
+  `crates/storage/src/sqlite/schema.sql` and told the reader to regenerate it
+  with `cp` on every port-schema change. The two have legitimately diverged —
+  later port changes landed as migrations 0032–0035 — so following the
+  instruction would rewrite an already-applied migration and duplicate them.
+  The README now states the real invariant (replaying the migration chain must
+  end in the same schema `init_schema` builds in one shot, verified by
+  `pragma table_info`) and its "schema parity" section documents the four
+  deliberately PostgreSQL-only migrations instead of claiming total parity.
+
+- **Plugin load order was not deterministic across registries describing the
+  same graph.** `dependency::resolve` sorted the *nodes* by key but left each
+  node's edge list in manifest declaration order, so the DFS emitted
+  dependencies in the order they happened to be declared. Two registries with
+  the same plugins and the same dependency relationships could freeze to
+  different `load_order`s — and therefore different `PluginSet` identities.
+  Edge lists are now sorted (indices are assigned in ascending key order, so
+  this sorts by dependency key) and deduplicated; a key declared more than once
+  is still version-checked per occurrence but walked once.
+- **A cargo feature changed the wire shape of a versioned config.**
+  `nebula_log::Config::telemetry` is `#[cfg(feature = "telemetry")]`, so a
+  `schema_version: 1` config serialized to `{"telemetry": null, …}` from a
+  telemetry-enabled build and omitted the key otherwise. The field is now
+  `skip_serializing_if = "Option::is_none"`, so v1 output is identical in both
+  builds. The schema snapshot tests now hold as a cross-feature contract.
+- **Stale source-text assertion in the Postgres refresh-retry test.** The
+  snapshot statement gained a `material_epoch` column, which broke a verbatim
+  `SELECT version, reauth_required, record_state` match. The test now asserts
+  each required column is read in that one statement, which is the actual
+  guarantee (the clock sample must come from the statement that observes
+  version / reauth / record state); column order and extra projections are not
+  part of it.
+
 - **Library-first: doc-output collision** — the `nebula-worker` binary target
   and the `nebula-worker` library both emitted `doc/nebula_worker/index.html`,
   so one silently clobbered the other's published documentation. The binary now
@@ -239,6 +279,29 @@ changes are expected between minor releases — call them out here.
 
 ### Changed
 
+- **(breaking) Rust 1.97.1 is the pinned toolchain and the MSRV.** `rust-version`
+  moves `1.96` → `1.97` across the workspace, together with
+  `rust-toolchain.toml`, `clippy.toml` `msrv`, every CI/nightly workflow pin, and
+  the documented requirement in `README.md` / `AGENTS.md` / `CONTRIBUTING.md`.
+  Consumers building on 1.96 must upgrade. Note that 1.97 enables the v0 symbol
+  mangling scheme by default, so profiler and debugger symbol output changes
+  shape (`rustc -C symbol-mangling-version=legacy` restores the old form).
+- **Dependencies refreshed to latest, and `syn` upgraded to 3.0.** The
+  proc-macro toolchain (`syn` / `quote` / `proc-macro2`) moved into
+  `[workspace.dependencies]`; the eight derive crates now take it with
+  `workspace = true` instead of eight independent pins that had already drifted
+  between `"2.0"` and `"2"`. syn 3 migration was two call sites: `TypePath`
+  gained an `attrs` field (all `Type` variants now carry attributes), and
+  `ItemImpl::trait_` dropped its `Option<Bang>` element — negative-impl
+  detection moved to `ImplModifiers`, which this workspace does not inspect
+  (any trait impl is rejected by `#[credential]` regardless of polarity).
+  `cargo update` picked up the remaining compatible bumps.
+- **Feature-hygiene and MSRV CI jobs now deny rustc warnings** via Cargo 1.97's
+  `build.warnings` (`CARGO_BUILD_WARNINGS: deny`). The clippy job only sees the
+  workspace-level all / default / no-default configurations; a warning that
+  fires solely under one isolated feature previously passed unnoticed through
+  `cargo hack check --each-feature`, which is exactly the blind spot that job
+  exists to cover.
 - **(breaking) `nebula-sdk` is curated by persona, not workspace topology.**
   Broad `nebula_sdk::nebula_{action,core,credential,plugin,resource,schema,
   validator,workflow}` re-exports are gone. The currently verified one-dependency
@@ -438,6 +501,25 @@ changes are expected between minor releases — call them out here.
 
 ### Removed
 
+- **(breaking) Migration fossils retired ahead of the first release.** The
+  workspace kept several `#[deprecated]` shims whose only job was to keep a
+  pre-carve-out import path alive; each one is now gone rather than shipping
+  into 0.1.0:
+  - `nebula-credential`: the deprecated `AuthStyle` re-exports on
+    `credentials`, `credentials::oauth2`, and `credentials::oauth2_config`.
+    `AuthStyle` is owned by the scheme contract layer — import
+    `nebula_credential::AuthStyle` or `scheme::oauth2::AuthStyle`.
+  - `nebula-log`: the `field::NODE_ID` alias (use `field::NODE_KEY`) and the
+    dead private `emit_to_hooks` dispatcher (`emit_to_hooks_inline` /
+    `emit_to_hooks_bounded` are the real entry points).
+  - `nebula-validator`: the `compose!` and `any_of!` macros. Composition is
+    `ValidateExt` method chaining — `v1.and(v2)` / `v1.or(v2)` — which is what
+    the macros expanded to anyway. This closes the removal already planned in
+    the crate's `docs/DESIGN.md`.
+  - `nebula-api`: the `EmailEnvelope` snapshot shim.
+    `InMemoryAuthBackend::emails()` now returns the port's own
+    `Vec<EmailMessage>`, so tests read the token from `body` and compare
+    `kind` against the typed `EmailKind` instead of a stringly label.
 - **(breaking, security) Legacy credential authority/store surfaces.** Removed
   the credential-local `CredentialStore`/erased dyn bridge, tenancy's
   metadata-keyed credential scope layer/resolver, public optional-owner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ lefthook install
 
 | Tool             | Why                                                      |
 |------------------|----------------------------------------------------------|
-| `cargo`          | Rust 1.96+, edition 2024, resolver 3                     |
+| `cargo`          | Rust 1.97+, edition 2024, resolver 3                     |
 | `task`           | `Taskfile.yml` is the canonical entry point              |
 | `lefthook`       | Local pre-commit / pre-push (mirrors CI required jobs)   |
 | `convco`         | Conventional-Commits validation                          |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.12.1"
+version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -34,7 +34,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "encoding_rs",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "futures-core",
  "http 0.2.12",
  "httparse",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.13.0"
+version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -129,7 +129,7 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "encoding_rs",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -144,7 +144,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "time",
  "tracing",
  "url",
@@ -230,9 +230,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -361,9 +361,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -389,7 +389,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -401,7 +401,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -465,13 +465,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -497,9 +497,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -508,14 +508,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -635,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -676,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -705,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -715,12 +716,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -737,9 +738,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -800,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -818,15 +819,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -894,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -904,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -916,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1081,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1193,18 +1194,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1221,18 +1222,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1314,7 +1315,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1404,7 +1405,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1426,7 +1427,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1460,7 +1461,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1484,7 +1485,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1565,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -1673,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1783,9 +1784,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1798,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1808,15 +1809,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1836,32 +1837,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1871,9 +1872,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1932,25 +1933,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1971,15 +1970,15 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2032,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2193,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -2203,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2228,18 +2227,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2302,7 +2301,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2415,12 +2414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2459,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.1.9"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
 name = "indexmap"
@@ -2573,7 +2566,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2592,24 +2585,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2630,7 +2623,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
@@ -2666,12 +2659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lettre"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,7 +2678,7 @@ dependencies = [
  "percent-encoding",
  "quoted_printable",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tokio-rustls",
  "url",
@@ -2700,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2750,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -2806,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -2844,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2877,7 +2864,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2949,7 +2936,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2994,7 +2981,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pretty_assertions",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rcgen",
  "reqwest 0.13.4",
  "rstest",
@@ -3072,7 +3059,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pretty_assertions",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rstest",
  "secrecy",
  "semver",
@@ -3098,7 +3085,7 @@ dependencies = [
  "nebula-macro-support",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3108,7 +3095,7 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "nebula-error",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "thiserror",
  "zeroize",
@@ -3147,7 +3134,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rstest",
  "scopeguard",
  "secrecy",
@@ -3192,7 +3179,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3321,7 +3308,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3434,7 +3421,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3498,7 +3485,7 @@ dependencies = [
  "nebula-macro-support",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3515,7 +3502,7 @@ dependencies = [
  "nebula-validator",
  "pretty_assertions",
  "proptest",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "rstest",
  "schemars",
@@ -3538,7 +3525,7 @@ dependencies = [
  "nebula-macro-support",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3701,7 +3688,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3829,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3848,7 +3835,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3870,11 +3857,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -4193,7 +4179,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4312,9 +4298,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4322,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4332,25 +4318,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4400,7 +4385,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4478,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -4544,16 +4529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,9 +4548,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4590,7 +4565,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4619,7 +4594,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4630,9 +4605,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4641,7 +4616,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -4650,15 +4625,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4672,23 +4648,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4713,9 +4689,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4724,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4734,12 +4710,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4786,6 +4762,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -4840,29 +4825,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4872,9 +4857,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5065,15 +5050,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -5082,38 +5067,39 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -5148,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5176,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5225,9 +5211,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -5287,7 +5273,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5361,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
+checksum = "d631477761f57c76148456e55e80e9a479ff3fa4c65b2b4a0c3acf1167fd4638"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -5382,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
+checksum = "119ede4e37790ec04e8a14073c8414f0a4b2648402856c0563495a9a5cf54d57"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -5395,9 +5381,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
+checksum = "448b0981fbde6cdc9eb087ba3dc01035a253fef9a0d9e79aaf198fc26acb2e64"
 dependencies = [
  "backtrace",
  "regex",
@@ -5406,9 +5392,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
+checksum = "9e5e909d02170ba6d1dc5ebd05bef7999280f5d960e3eaee5d1a18d88d41b334"
 dependencies = [
  "hostname",
  "libc",
@@ -5420,11 +5406,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
+checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -5433,9 +5419,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
+checksum = "f81d7749c57fc78ed52134889e8121da874065bc40da788d5798cce0f8c19f15"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -5443,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
+checksum = "0b7d93d6ecb55d2251c5fc084c55c03a2bc68904918d76117e602c999e92f00f"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -5453,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
+checksum = "58d26379236c4ef97eaf081bca3c7bf0ef6f06b3aa881eca2ee8e8dbc923e5b8"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
@@ -5466,13 +5452,13 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
+checksum = "2239099d47e76857b0825a182ecdb90159add7aa1097b60247c6e7ca6bf49c6a"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -5483,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5493,22 +5479,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5519,14 +5505,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -5569,9 +5555,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5648,15 +5634,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -5731,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5828,7 +5814,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5851,7 +5837,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.119",
  "thiserror",
  "tokio",
  "url",
@@ -5909,7 +5895,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6001,9 +5987,20 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6027,7 +6024,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6038,9 +6035,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -6049,7 +6046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6072,38 +6069,38 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6121,9 +6118,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6151,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6166,9 +6163,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6176,20 +6173,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6204,9 +6201,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6216,23 +6213,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6254,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -6275,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -6318,14 +6316,14 @@ dependencies = [
 
 [[package]]
 name = "totp-rs"
-version = "5.7.1"
+version = "5.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
+checksum = "50e69a15e21b2ff22c415446983978bded3244195f17d59cb113551c1e806f91"
 dependencies = [
  "base32",
  "constant_time_eq 0.3.1",
  "hmac 0.12.1",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "url",
  "urlencoding",
@@ -6419,7 +6417,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6499,9 +6497,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "glob",
  "serde",
@@ -6530,7 +6528,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "web-time",
 ]
 
@@ -6721,7 +6719,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6744,11 +6742,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6808,27 +6806,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6839,9 +6828,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6849,9 +6838,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6859,46 +6848,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -6915,22 +6882,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6948,18 +6903,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7022,7 +6977,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7033,7 +6988,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7066,7 +7021,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7075,16 +7030,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7102,31 +7048,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -7136,22 +7065,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7160,22 +7077,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7184,22 +7089,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7208,28 +7101,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -7259,97 +7140,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -7410,28 +7203,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7451,7 +7244,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7472,7 +7265,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7505,7 +7298,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7524,15 +7317,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.97"
 keywords = ["workflow", "integrations", "no-code", "low-code", "automation"]
 authors = ["Vanya Stafford <vanya.john.stafford@gmail.com>"]
 description = "Workflow automation toolkit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,10 +184,7 @@ pretty_assertions = "1.4.1"
 rstest = "0.24.0"
 wiremock = "0.6"
 rcgen = { version = "0.14.8", default-features = false, features = ["aws_lc_rs"] }
-tokio-rustls = { version = "0.26.4", default-features = false, features = [
-  "aws_lc_rs",
-  "tls12",
-] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws_lc_rs", "tls12"] }
 
 # Semantic versioning
 semver = { version = "1", features = ["serde"] }
@@ -200,6 +197,15 @@ compact_str = { version = "0.9", features = ["serde"] }
 
 # Compile-time layout assertions
 static_assertions = "1"
+
+# Proc-macro toolchain — pinned here so the eight derive crates
+# (action, credential, error, plugin, resource, schema, sdk/macros-support,
+# validator) can never resolve onto different `syn` majors. A split here
+# means two copies of the parser in every macro build and, worse, two
+# incompatible `syn::Error` types across the shared macro-support helpers.
+syn = { version = "3", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
 
 # Nebula internal
 nebula-env = { path = "crates/env" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nebula
 
 [![CI](https://github.com/vanyastaff/nebula/actions/workflows/ci.yml/badge.svg)](https://github.com/vanyastaff/nebula/actions/workflows/ci.yml)
-[![Rust](https://img.shields.io/badge/rust-1.96%2B-orange)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.97%2B-orange)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE)
 
 **Modular, type-safe workflow automation engine written in Rust.**
@@ -112,7 +112,7 @@ cargo build
 cargo nextest run --workspace
 ```
 
-Requires **Rust 1.96+** (edition 2024). Uses [cargo-nextest](https://nexte.st/) for test runs.
+Requires **Rust 1.97+** (edition 2024). Uses [cargo-nextest](https://nexte.st/) for test runs.
 
 ### Local Infrastructure
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 # Keep lint interpretation aligned with workspace toolchain.
-msrv = "1.96"
+msrv = "1.97"
 
 # ── Complexity thresholds (balanced for a heavily generic Rust workspace) ──
 cognitive-complexity-threshold = 25
@@ -57,7 +57,7 @@ allow-dbg-in-tests = true
 allow-print-in-tests = true
 allow-indexing-slicing-in-tests = true
 allow-useless-vec-in-tests = true
-# Enforce MSRV checks in test code as well (no `1.96` APIs sneaking in).
+# Enforce MSRV checks in test code as well (no `1.97` APIs sneaking in).
 check-incompatible-msrv-in-tests = true
 
 # ── Const-context ergonomics ───────────────────────────────────────────────

--- a/crates/action/macros/Cargo.toml
+++ b/crates/action/macros/Cargo.toml
@@ -19,9 +19,9 @@ doctest = false
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
 semver = { workspace = true }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -198,57 +198,6 @@ impl Default for InMemoryAuthBackend {
     }
 }
 
-/// Legacy snapshot shape of an outbound email.
-///
-/// Kept for backward compatibility with tests that still assert on
-/// `EmailEnvelope.token` + `EmailEnvelope.kind` via
-/// [`InMemoryAuthBackend::emails`]. New code SHOULD use
-/// [`crate::ports::email::EmailMessage`] directly through an
-/// [`EchoSink::peek`] call.
-#[derive(Clone)]
-#[deprecated(
-    since = "0.2.0",
-    note = "Use crate::ports::email::EmailMessage and EchoSink::peek for new code"
-)]
-pub struct EmailEnvelope {
-    /// Recipient address.
-    pub to: String,
-    /// Token included in the email link. Mirrors the dev `EchoSink`
-    /// convention of putting the raw token in [`EmailMessage::body`].
-    pub token: String,
-    /// Email category label — [`EmailKind::as_str`] output
-    /// (`"EmailVerify"` / `"PasswordReset"`).
-    pub kind: &'static str,
-}
-
-#[expect(
-    deprecated,
-    reason = "redaction is part of the deprecated shim's safety contract"
-)]
-impl std::fmt::Debug for EmailEnvelope {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("EmailEnvelope")
-            .field("to", &"[redacted]")
-            .field("token", &"[redacted]")
-            .field("kind", &self.kind)
-            .finish()
-    }
-}
-
-// guard-justified: the `From` impl exists exclusively to feed the
-// deprecated `EmailEnvelope` type and cannot itself avoid touching it.
-#[expect(deprecated, reason = "shim feeds the deprecated public type")]
-impl From<EmailMessage> for EmailEnvelope {
-    fn from(m: EmailMessage) -> Self {
-        Self {
-            to: m.to,
-            token: m.body,
-            kind: m.kind.as_str(),
-        }
-    }
-}
-
 impl InMemoryAuthBackend {
     /// Construct an empty backend with the default in-process
     /// [`EchoSink`] email port.
@@ -307,18 +256,15 @@ impl InMemoryAuthBackend {
     /// Returns an empty vector when [`Self::with_email_port`] has
     /// swapped the default [`EchoSink`] for a custom transport; the
     /// in-process inbox is only meaningful for the default port.
-    // guard-justified: this accessor IS the back-compat shim and must
-    // return the deprecated `EmailEnvelope` type by contract.
+    ///
+    /// The dev [`EchoSink`] puts the verification / reset token straight
+    /// into [`EmailMessage::body`], so a test reads the token from there.
     #[must_use]
-    #[expect(deprecated, reason = "deliberate back-compat shim over EmailEnvelope")]
-    pub fn emails(&self) -> Vec<EmailEnvelope> {
+    pub fn emails(&self) -> Vec<EmailMessage> {
         self.default_echo
             .as_ref()
-            .map(|s| s.peek())
+            .map(|sink| sink.peek())
             .unwrap_or_default()
-            .into_iter()
-            .map(EmailEnvelope::from)
-            .collect()
     }
 
     fn now_secs() -> u64 {
@@ -1300,13 +1246,7 @@ impl AuthBackend for InMemoryAuthBackend {
     }
 }
 
-// guard-justified: the tests below intentionally exercise the
-// deprecated `EmailEnvelope` shim and `emails()` accessor.
 #[cfg(test)]
-#[expect(
-    deprecated,
-    reason = "tests still assert on the deprecated `EmailEnvelope` back-compat shim"
-)]
 mod tests {
     use super::*;
     use crate::domain::auth::backend::dto::SecretString;
@@ -1388,22 +1328,8 @@ mod tests {
         b.register_user(signup_req("a@b.c")).await.unwrap();
         let emails = b.emails();
         assert_eq!(emails.len(), 1);
-        assert_eq!(emails[0].kind, "EmailVerify");
+        assert_eq!(emails[0].kind, EmailKind::Verification);
         assert_eq!(emails[0].to, "a@b.c");
-    }
-
-    #[test]
-    fn legacy_email_envelope_debug_redacts_token_and_recipient() {
-        const CANARY: &str = "LEGACY_EMAIL_AUTHORITY_CANARY-e9b2";
-        let envelope = EmailEnvelope {
-            to: format!("{CANARY}@example.test"),
-            token: CANARY.to_owned(),
-            kind: "PasswordReset",
-        };
-
-        let debug = format!("{envelope:?}");
-        assert!(!debug.contains(CANARY));
-        assert!(debug.contains("PasswordReset"));
     }
 
     #[tokio::test]
@@ -1467,7 +1393,7 @@ mod tests {
     async fn email_verification_flips_flag() {
         let b = InMemoryAuthBackend::new();
         b.register_user(signup_req("v@e.f")).await.unwrap();
-        let token = b.emails()[0].token.clone();
+        let token = b.emails()[0].body.clone();
         b.verify_email(&token).await.unwrap();
         let user = b.lookup_user_by_email("v@e.f").unwrap();
         assert!(user.email_verified);
@@ -1486,7 +1412,7 @@ mod tests {
             .expect("default echo sink is wired when no custom port is injected")
             .drain();
         b.request_password_reset("p@e.f").await.unwrap();
-        let token = b.emails()[0].token.clone();
+        let token = b.emails()[0].body.clone();
         b.complete_password_reset(&token, "newpass1").await.unwrap();
         let outcome = b
             .authenticate_password("p@e.f", "newpass1", None)

--- a/crates/api/src/domain/webhook/handler.rs
+++ b/crates/api/src/domain/webhook/handler.rs
@@ -231,7 +231,7 @@ pub async fn register_webhook(
         &scope,
         CredentialGatewayCommand::Create(CreateCredentialRequest {
             credential_key: "signing_key".to_owned(),
-            name: format!("webhook-signing-key-{}", &body.trigger_id),
+            name: format!("webhook-signing-key-{}", body.trigger_id),
             description: None,
             data: json!({
                 "key": whsec,
@@ -289,7 +289,7 @@ pub async fn register_webhook(
         workspace_id: scope.workspace_id.clone(),
         workflow_id: body.workflow_id.clone(),
         slug: body.trigger_id.clone(),
-        display_name: format!("webhook-{}", &body.trigger_id),
+        display_name: format!("webhook-{}", body.trigger_id),
         kind: "webhook".to_string(),
         config: trigger_config,
         state: "active".to_string(),

--- a/crates/api/src/ports/email.rs
+++ b/crates/api/src/ports/email.rs
@@ -37,8 +37,8 @@ pub enum EmailKind {
 }
 
 impl EmailKind {
-    /// Stable string label. Used in tracing fields and by the legacy
-    /// `EmailEnvelope.kind` back-compat shim on the in-memory backend.
+    /// Stable string label — used in tracing fields, where the variant
+    /// name itself must not be the wire contract.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -270,9 +270,9 @@ mod tests {
 
     #[test]
     fn email_kind_as_str_matches_legacy_labels() {
-        // The legacy `EmailEnvelope.kind` strings — keep stable across
-        // the trait refactor so the `InMemoryAuthBackend::emails()`
-        // back-compat shim and downstream test assertions still match.
+        // Operator-visible category labels: they appear in logs and in
+        // downstream assertions, so the strings are a stable contract
+        // independent of the enum variant names.
         assert_eq!(EmailKind::Verification.as_str(), "EmailVerify");
         assert_eq!(EmailKind::PasswordReset.as_str(), "PasswordReset");
         assert_eq!(EmailKind::Generic.as_str(), "Generic");

--- a/crates/credential/macros/Cargo.toml
+++ b/crates/credential/macros/Cargo.toml
@@ -18,9 +18,9 @@ doctest = false
 
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/credential/macros/src/credential_attr.rs
+++ b/crates/credential/macros/src/credential_attr.rs
@@ -97,7 +97,7 @@ struct Items {
 fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStream2> {
     let item: ItemImpl = syn::parse(input)?;
 
-    if let Some((_, path, _)) = &item.trait_ {
+    if let Some((path, _)) = &item.trait_ {
         return Err(diag::error_spanned(
             path,
             "#[credential] applies to an inherent `impl Type { … }`, not a trait impl — \

--- a/crates/credential/src/credentials/mod.rs
+++ b/crates/credential/src/credentials/mod.rs
@@ -29,13 +29,8 @@ pub use oauth2_config::{
 pub use shared_key::{SharedKeyCredential, SharedKeyProperties};
 pub use signing_key::{SigningKeyCredential, SigningKeyProperties};
 
-// AuthStyle lives in scheme::oauth2 as of Task 8 (M12.3 carve-out prep).
-// Re-exported here so `credentials::AuthStyle` still resolves; deprecated.
-#[deprecated(
-    since = "0.1.0",
-    note = "use `nebula_credential::scheme::oauth2::AuthStyle` or the crate-root re-export `nebula_credential::AuthStyle`"
-)]
-pub use crate::scheme::oauth2::AuthStyle;
+// `AuthStyle` is owned by the scheme contract layer — import it from
+// `crate::scheme::oauth2` (or the crate root re-export), not from here.
 
 /// Register the first-party **reference** credentials — `bearer_token`,
 /// `shared_key`, and `signing_key` — into `registry`.

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -17,25 +17,10 @@ use std::{fmt, fmt::Formatter, time::Duration};
 
 use chrono::{DateTime, Utc};
 use nebula_schema::{FieldValues, Schema};
-// Re-exports for backward compatibility with `credentials::oauth2::` paths.
-// `AuthStyle` now lives in `scheme::oauth2`; re-exported here under the
-// deprecated shim so the old import path still resolves during migration.
-// Other config types remain in `oauth2_config`.
-// guard-justified: suppress deprecated warning on the deprecated re-export within the same crate's migration shim
-/// OAuth2 client authentication style.
-///
-/// Moved to [`crate::scheme::oauth2::AuthStyle`]. This re-export keeps the
-/// `credentials::oauth2::AuthStyle` path alive during migration (deprecated).
-#[deprecated(
-    since = "0.1.0",
-    note = "use `nebula_credential::scheme::oauth2::AuthStyle` or the crate-root re-export `nebula_credential::AuthStyle`"
-)]
-pub use crate::scheme::oauth2::AuthStyle;
-// guard-justified: re-export block intentionally bridges deprecated
-// `oauth2_config` paths for downstream API consumers still importing
-// from this submodule; the inner items themselves are NOT deprecated,
-// only the legacy `AuthStyle` constant on `oauth2_config` is, and the
-// deprecation surfaces at the caller's import site, not here.
+// The grant/config types stay reachable from this module because the
+// credential and its configuration are one API surface for consumers;
+// `AuthStyle` is imported privately from the scheme contract layer that
+// owns it.
 pub use oauth2_config::{
     AuthCodeBuilder, ClientCredentialsBuilder, DeviceCodeBuilder, GrantType, OAuth2Config,
     PkceMethod,
@@ -58,7 +43,7 @@ use crate::{
         CompletedTokenRefresh, PrepareTokenRefreshError, interpret_oauth2_refresh_response,
         prepare_oauth2_refresh,
     },
-    scheme::OAuth2Token,
+    scheme::{AuthStyle, OAuth2Token},
 };
 
 // ── OAuth2State ────────────────────────────────────────────────────────

--- a/crates/credential/src/credentials/oauth2_config.rs
+++ b/crates/credential/src/credentials/oauth2_config.rs
@@ -17,17 +17,9 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// OAuth2 client authentication style (RFC 6749 §2.3.1).
-///
-/// Moved to [`crate::scheme::oauth2::AuthStyle`] — the scheme contract layer,
-/// not the credential implementation.
-/// This re-export is deprecated; migrate to
-/// `nebula_credential::AuthStyle` or `nebula_credential::scheme::oauth2::AuthStyle`.
-#[deprecated(
-    since = "0.1.0",
-    note = "use `nebula_credential::scheme::oauth2::AuthStyle` or the crate-root re-export `nebula_credential::AuthStyle`"
-)]
-pub use crate::scheme::oauth2::AuthStyle;
+// `AuthStyle` (RFC 6749 §2.3.1) is owned by the scheme contract layer, not by
+// this credential-configuration module — imported, never re-exported.
+use crate::scheme::oauth2::AuthStyle;
 
 /// OAuth2 grant type (RFC 6749 / RFC 8628).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/error/macros/Cargo.toml
+++ b/crates/error/macros/Cargo.toml
@@ -17,9 +17,9 @@ test = false
 doctest = false
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/log/src/builder/mod.rs
+++ b/crates/log/src/builder/mod.rs
@@ -145,7 +145,7 @@ impl LoggerBuilder {
         // Create the filter
         let filter = EnvFilter::try_new(&self.config.level).map_err(|e| {
             use crate::core::LogError;
-            LogError::Filter(format!("{}: {}", &self.config.level, e))
+            LogError::Filter(format!("{}: {e}", self.config.level))
         })?;
 
         // Get writer for the format layer

--- a/crates/log/src/config/base.rs
+++ b/crates/log/src/config/base.rs
@@ -31,8 +31,14 @@ pub struct Config {
     /// Enable runtime reload capability
     pub reloadable: bool,
 
-    /// Telemetry configuration
+    /// Telemetry configuration.
+    ///
+    /// Skipped when unset so the serialized shape of a `schema_version: 1`
+    /// config is identical whether or not the `telemetry` feature is
+    /// compiled in — a cargo feature must not change the wire form of a
+    /// versioned schema.
     #[cfg(feature = "telemetry")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub telemetry: Option<TelemetryConfig>,
 }
 

--- a/crates/log/src/observability/registry.rs
+++ b/crates/log/src/observability/registry.rs
@@ -81,31 +81,6 @@ fn emit_to_hooks_bounded(hooks: &HookList, event: &dyn ObservabilityEvent, timeo
     }
 }
 
-/// Emit an event to a hook list (legacy, kept for compatibility).
-///
-/// Calls `on_event()` on each registered hook with the provided event.
-/// If a hook panics, the panic is caught and logged, and other hooks
-/// continue to receive events.
-///
-/// # Panic Safety
-///
-/// Hooks **must** be internally panic-safe. If a hook panics while holding
-/// internal locks (e.g., a `Mutex`), those locks will be poisoned. The
-/// registry catches the panic and continues dispatching to remaining hooks,
-/// but the panicked hook's internal state may be corrupted. Consider wrapping
-/// fallible hook internals in `catch_unwind` or using lock-free data structures.
-#[deprecated(note = "use emit_to_hooks_inline or emit_to_hooks_bounded directly")]
-#[expect(
-    dead_code,
-    reason = "deprecated function retained for semver compatibility; callers should migrate to emit_to_hooks_inline or emit_to_hooks_bounded"
-)]
-fn emit_to_hooks(hooks: &HookList, event: &dyn ObservabilityEvent, policy: HookPolicy) {
-    match policy {
-        HookPolicy::Inline => emit_to_hooks_inline(hooks, event),
-        HookPolicy::Bounded { timeout_ms, .. } => emit_to_hooks_bounded(hooks, event, timeout_ms),
-    }
-}
-
 /// Initialize a hook, catching panics.
 ///
 /// Returns `true` if initialization succeeded, `false` if the hook panicked.

--- a/crates/log/src/observability/semantic.rs
+++ b/crates/log/src/observability/semantic.rs
@@ -22,10 +22,6 @@ pub mod field {
     pub const TRACE_ID: &str = "trace_id";
     /// Node key (author-defined workflow node identifier).
     pub const NODE_KEY: &str = "node_key";
-
-    /// Deprecated alias -- use [`NODE_KEY`] instead.
-    #[deprecated(since = "0.1.0", note = "renamed to NODE_KEY")]
-    pub const NODE_ID: &str = NODE_KEY;
     /// Action type ID (e.g., "http.request")
     pub const ACTION_ID: &str = "action_id";
     /// Retry attempt count

--- a/crates/orchestrator/src/sink.rs
+++ b/crates/orchestrator/src/sink.rs
@@ -30,7 +30,7 @@ use nebula_storage_port::dto::JobDispatchMsg;
 /// ## Dyn-dispatch
 ///
 /// `async-trait` is required because `async fn` in traits is not yet
-/// dyn-compatible in stable Rust 1.96 (native AFIT/RPITIT is not dyn-safe).
+/// dyn-compatible in stable Rust 1.97 (native AFIT/RPITIT is not dyn-safe).
 /// The orchestrator holds an `Arc<dyn ExecutionSink>`, so object safety is
 /// load-bearing here — the same rationale as `JobDispatchQueue` and
 /// `ControlDispatch`.

--- a/crates/plugin/macros/Cargo.toml
+++ b/crates/plugin/macros/Cargo.toml
@@ -19,9 +19,9 @@ doctest = false
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
 semver = { workspace = true }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plugin/src/dependency.rs
+++ b/crates/plugin/src/dependency.rs
@@ -187,6 +187,14 @@ pub(crate) fn resolve(reg: &PluginRegistry) -> Result<Vec<PluginKey>, PluginDepe
             }
             edges.push(dep_index);
         }
+        // Canonicalize the edge list. Indices were assigned in ascending key
+        // order, so sorting by index sorts by dependency key — without this the
+        // DFS emits dependencies in *manifest declaration* order and the load
+        // order of two registries describing the same graph differs. Dedup
+        // collapses a key declared more than once (each occurrence is still
+        // version-checked above) so it is not re-walked.
+        edges.sort_unstable();
+        edges.dedup();
         adjacency.push(edges);
     }
 

--- a/crates/resource/macros/Cargo.toml
+++ b/crates/resource/macros/Cargo.toml
@@ -22,9 +22,9 @@ doctest = false
 
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 nebula-core = { path = "../../core" }

--- a/crates/schema/macros/Cargo.toml
+++ b/crates/schema/macros/Cargo.toml
@@ -15,9 +15,9 @@ proc-macro = true
 
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
-syn = { version = "2", features = ["full", "extra-traits"] }
-quote = "1"
-proc-macro2 = "1"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 # Case conversion for `#[derive(EnumSelect)]` option values — `heck` splits
 # acronym runs correctly (`HTTPProxy` → `http_proxy`) where a hand-rolled pass
 # does not. Small, maintained, the de-facto standard (used by serde/clap).

--- a/crates/schema/macros/src/type_infer.rs
+++ b/crates/schema/macros/src/type_infer.rs
@@ -83,7 +83,10 @@ pub(crate) fn classify(ty: &Type) -> FieldKind {
 /// Handles both bare idents (`String`, `bool`) and fully-qualified paths
 /// (`std::string::String`).
 fn last_segment_ident(ty: &Type) -> Option<String> {
-    if let Type::Path(TypePath { qself: None, path }) = ty {
+    if let Type::Path(TypePath {
+        qself: None, path, ..
+    }) = ty
+    {
         path.segments.last().map(|s| s.ident.to_string())
     } else {
         None
@@ -92,7 +95,9 @@ fn last_segment_ident(ty: &Type) -> Option<String> {
 
 /// If `ty` is `Wrapper<Inner>`, return the inner type.
 fn unwrap_single_generic<'t>(ty: &'t Type, wrapper: &str) -> Option<&'t Type> {
-    if let Type::Path(TypePath { qself: None, path }) = ty
+    if let Type::Path(TypePath {
+        qself: None, path, ..
+    }) = ty
         && let Some(seg) = path.segments.last()
         && seg.ident == wrapper
         && let PathArguments::AngleBracketed(args) = &seg.arguments

--- a/crates/sdk/macros-support/Cargo.toml
+++ b/crates/sdk/macros-support/Cargo.toml
@@ -12,9 +12,9 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 proc-macro-crate = "3"
 
 [lib]

--- a/crates/storage/migrations/sqlite/README.md
+++ b/crates/storage/migrations/sqlite/README.md
@@ -31,17 +31,30 @@ credential refresh-retry admission gate in parity with PostgreSQL.
 
 ## Storage-port adapter schema (0027)
 
-`0027_port_adapter_schema.sql` is **byte-identical** to
-`crates/storage/src/sqlite/schema.sql`, which the spec-16 SQLite adapters
-apply via `nebula_storage::sqlite::init_schema` for `:memory:` and test
-pools. It is the canonical source for a rebuilt file-backed SQLite
-database — the spec-16 port (execution + the atomic `TransitionBatch`,
-control-queue outbox, idempotency, webhook activations,
-workflows/versions, and the identity stores) persists through these
-`port_*` tables. Keep this file and `schema.sql` in lockstep —
-regenerate with `cp crates/storage/src/sqlite/schema.sql \
-crates/storage/migrations/sqlite/0027_port_adapter_schema.sql` whenever
-the port schema changes.
+`crates/storage/src/sqlite/schema.sql` is the **cumulative** `port_*` schema,
+applied in one shot by `nebula_storage::sqlite::init_schema` for `:memory:`
+and test pools. The spec-16 port (execution + the atomic `TransitionBatch`,
+control-queue outbox, idempotency, webhook activations, workflows/versions,
+and the identity stores) persists through those `port_*` tables.
+
+`0027_port_adapter_schema.sql` was that schema *at the time it was written*.
+It is now a historical migration and **must not be regenerated from
+`schema.sql`** — the two have legitimately diverged because later port
+changes landed as their own migrations (0032 webhook activation fields,
+0033 spec link, 0034 control-queue resume target, 0035 resume tokens).
+Copying the cumulative schema over 0027 would rewrite an already-applied
+migration and duplicate what those later ones already do.
+
+When the port schema changes, do both:
+
+1. add a **new** numbered migration for the delta, and
+2. edit `schema.sql` so the one-shot install stays current.
+
+The invariant to hold is *end-state equality*, not file equality: replaying
+`0001..NNNN` into a file-backed database must produce the same tables,
+columns, types and constraints as `init_schema` builds in one shot. Verify
+by diffing `pragma table_info(...)` for every `port_*` table across a
+migrated database and a freshly `init_schema`-built one.
 
 ## Rebuilding the local dev database
 
@@ -51,5 +64,22 @@ run via `init_schema`, so tests need no migration step.
 
 ## Schema parity
 
-This directory and `../postgres/` must define logically identical tables.
-Types differ by dialect; table/column names and constraints must match.
+Where both dialects define a table, they must define it *logically
+identically*: types differ by dialect, but table/column names and
+constraints must match.
+
+Parity is **not** total, and the gaps are deliberate — these tables are
+PostgreSQL-only because their adapters are (`crates/storage/src/pg/`, with
+no SQLite counterpart):
+
+| PostgreSQL migration | Why it has no SQLite counterpart |
+|----------------------|----------------------------------|
+| `0029_external_identities` | `external_identities` — OAuth identity linking, `pg/external_identity.rs` only |
+| `0036_plane_a_oauth_state_cleanup_index` | partial index over `NOW()`; SQLite requires constant expressions (see *Dialect notes*) |
+| `0037_mfa_enrollment_candidates` | `mfa_enrollment_candidates` — `pg/mfa_enrollment.rs` only |
+| `0038_identity_secret_authority` | `pg/identity_secret.rs` only |
+
+A fresh SQLite database therefore has two fewer tables than a fresh
+PostgreSQL one (`external_identities`, `mfa_enrollment_candidates`). Adding
+a SQLite adapter for any of those features means adding its migration here
+at the same time.

--- a/crates/storage/migrations/sqlite/README.md
+++ b/crates/storage/migrations/sqlite/README.md
@@ -52,9 +52,23 @@ When the port schema changes, do both:
 
 The invariant to hold is *end-state equality*, not file equality: replaying
 `0001..NNNN` into a file-backed database must produce the same tables,
-columns, types and constraints as `init_schema` builds in one shot. Verify
-by diffing `pragma table_info(...)` for every `port_*` table across a
-migrated database and a freshly `init_schema`-built one.
+columns, types and constraints as `init_schema` builds in one shot.
+
+Verify across a migrated database and a freshly `init_schema`-built one:
+
+1. the `port_%` object sets in `sqlite_master` match (tables **and** indexes
+   and triggers — a migration that forgets an index still passes a
+   column-only comparison);
+2. `pragma table_info(<table>)` matches per table (names, declared types,
+   `NOT NULL`, defaults, primary-key position);
+3. `pragma index_list` / `index_info` and `pragma foreign_key_list` match per
+   table, which is what covers uniqueness and referential constraints.
+
+`CHECK` constraints live only in the stored `CREATE TABLE` text, so compare
+the `sqlite_master.sql` bodies too — but normalize whitespace and strip `--`
+comments first: `ALTER TABLE` rewrites that text, so a migrated table and an
+`init_schema` one legitimately differ in comments and column order while
+being semantically identical.
 
 ## Rebuilding the local dev database
 

--- a/crates/storage/src/credential/postgres.rs
+++ b/crates/storage/src/credential/postgres.rs
@@ -1312,18 +1312,37 @@ mod tests {
             .expect("the following port method must delimit the snapshot body")
             .0;
         assert_eq!(snapshot_body.matches("sqlx::query_as(").count(), 1);
+
         // The clock sample is only meaningful if the same statement also reads
         // the version / reauthentication / record state it is compared against.
-        // Assert each column is selected here rather than pinning the column
-        // list verbatim — the order and any additional projected column
-        // (`material_epoch`, …) are not part of that guarantee.
+        // Assert those are *projected*, rather than pinning the column list
+        // verbatim — order and extra projections (`material_epoch`, …) are not
+        // part of the guarantee. Narrowing to the projection and stripping `--`
+        // comments matters: the body carries a comment mentioning "version",
+        // so a substring search over the whole statement would hold even if the
+        // column itself were dropped.
+        let projection = snapshot_body
+            .split_once("SELECT ")
+            .expect("the snapshot statement must open with a SELECT projection")
+            .1
+            .split_once("FROM credentials")
+            .expect("the snapshot statement must read from `credentials`")
+            .0;
+        let projected: Vec<&str> = projection
+            .lines()
+            .map(|line| line.split_once("--").map_or(line, |(code, _comment)| code))
+            .flat_map(|line| line.split(','))
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .collect();
         for column in ["version", "reauth_required", "record_state"] {
             assert!(
-                snapshot_body.contains(column),
-                "the snapshot statement must read `{column}` alongside its clock sample"
+                projected.contains(&column),
+                "the snapshot statement must project `{column}` alongside its \
+                 clock sample; projected: {projected:?}"
             );
         }
-        assert!(snapshot_body.contains("clock_timestamp() AS backend_now"));
+        assert!(projected.contains(&"clock_timestamp() AS backend_now"));
         assert!(!snapshot_body.contains("self.get("));
     }
 

--- a/crates/storage/src/credential/postgres.rs
+++ b/crates/storage/src/credential/postgres.rs
@@ -1312,7 +1312,17 @@ mod tests {
             .expect("the following port method must delimit the snapshot body")
             .0;
         assert_eq!(snapshot_body.matches("sqlx::query_as(").count(), 1);
-        assert!(snapshot_body.contains("SELECT version, reauth_required, record_state"));
+        // The clock sample is only meaningful if the same statement also reads
+        // the version / reauthentication / record state it is compared against.
+        // Assert each column is selected here rather than pinning the column
+        // list verbatim — the order and any additional projected column
+        // (`material_epoch`, …) are not part of that guarantee.
+        for column in ["version", "reauth_required", "record_state"] {
+            assert!(
+                snapshot_body.contains(column),
+                "the snapshot statement must read `{column}` alongside its clock sample"
+            );
+        }
         assert!(snapshot_body.contains("clock_timestamp() AS backend_now"));
         assert!(!snapshot_body.contains("self.get("));
     }

--- a/crates/validator/docs/DESIGN.md
+++ b/crates/validator/docs/DESIGN.md
@@ -82,7 +82,7 @@
   голого `bool`.
 - `proof.rs` — `Validated<T>` proof-token (canon §4.5).
 - `error.rs` — `ValidatorError` (операционная), отделённая от `ValidationError`-на-вход.
-- `macros.rs` (приватный) — `validator!` + deprecated `compose!`/`any_of!`.
+- `macros.rs` (приватный) — `validator!`; композиция — методы `.and()`/`.or()` из `ValidateExt`.
 - `macros/` — subcrate `nebula-validator-macros`: `parse/` → `model.rs` → `emit/` для
   `#[derive(Validator)]`.
 
@@ -115,17 +115,14 @@
    дублирует канонический `nebula-error::ValidationError`. Унификация **сделана** на ветке
    `refactor/error-unify-validation`, но **не смёржена** — в `main` крейт всё ещё определяет
    собственный тип, а `nebula-error` нужен только ради `Classify` (`src/error.rs:28`).
-2. **Deprecated макросы живы.** `compose!` (`src/macros.rs:684`) и `any_of!`
-   (`src/macros.rs:715`) ещё существуют; тесты явно глушат deprecation-warning
-   (`macros.rs:868-884`) — кандидаты на удаление.
-3. **Док-ложь про `Cached`.** `combinators/mod.rs:14,57` описывает комбинатор
+2. **Док-ложь про `Cached`.** `combinators/mod.rs:14,57` описывает комбинатор
    `Cached`/`cached()`, которого нет в exports (`mod.rs:93-110`).
-4. **Три prelude.** `crate::prelude`, `foundation::prelude` (:84) и `combinators::prelude`
+3. **Три prelude.** `crate::prelude`, `foundation::prelude` (:84) и `combinators::prelude`
    (:127) — расползание поверхности импорта.
-5. **Wire/коды как обязательство совместимости.** Externally-tagged tuple-compact + замороженный
+4. **Wire/коды как обязательство совместимости.** Externally-tagged tuple-compact + замороженный
    `error_registry_v1.json` означают, что любая правка сериализации/кодов — breaking для
    сохранённых правил.
-6. **`#![allow(clippy::result_large_err)]` на весь крейт** (`src/lib.rs:50`) — осознанно,
+5. **`#![allow(clippy::result_large_err)]` на весь крейт** (`src/lib.rs:50`) — осознанно,
    из-за 80-байтовой ошибки по значению.
 
 ## 7. Роль в пост-0092 credential/resource модели
@@ -162,9 +159,6 @@
   единственную причину тянуть `nebula-error` (сейчас только ради `Classify`) и закрывает
   напряжение №1. Риск: затрагивает RFC 6901 пути и contract-fixtures — нужна сверка
   `error_registry_v1.json`.
-- **Удалить deprecated `compose!`/`any_of!`.** Под прикрытием «validator = приватная
-  impl-деталь за sdk» это уже не breaking для внешних — выпилить вместе с глушением
-  warning'ов в тестах (`macros.rs:868-884`).
 - **Починить док-ложь про `Cached`.** Либо реализовать `cached()` комбинатор, либо вычистить
   упоминания из `combinators/mod.rs:14,57`. Сейчас это прямое расхождение doc vs exports.
 - **Сократить prelude'ы до одного.** Свести `foundation::prelude`/`combinators::prelude` к

--- a/crates/validator/docs/DESIGN.md
+++ b/crates/validator/docs/DESIGN.md
@@ -82,7 +82,9 @@
   голого `bool`.
 - `proof.rs` — `Validated<T>` proof-token (canon §4.5).
 - `error.rs` — `ValidatorError` (операционная), отделённая от `ValidationError`-на-вход.
-- `macros.rs` (приватный) — `validator!`; композиция — методы `.and()`/`.or()` из `ValidateExt`.
+- `macros.rs` — `validator!`. Модуль приватный, но сам макрос под `#[macro_export]`,
+  т.е. виден downstream-крейтам из корня. Композиция — методы `.and()`/`.or()`
+  из `ValidateExt`.
 - `macros/` — subcrate `nebula-validator-macros`: `parse/` → `model.rs` → `emit/` для
   `#[derive(Validator)]`.
 

--- a/crates/validator/docs/README.md
+++ b/crates/validator/docs/README.md
@@ -147,7 +147,7 @@ nebula-validator/
 │   ├── engine.rs              validate_rules, ExecutionMode
 │   ├── error.rs               ValidatorError, ValidatorResult
 │   ├── proof.rs               Validated<T> proof token
-│   ├── macros.rs              validator! macro (private)
+│   ├── macros.rs              validator! macro (`#[macro_export]`; module private)
 │   ├── foundation/
 │   │   ├── traits.rs          Validate<T>, ValidateExt<T>, Validatable
 │   │   ├── any.rs             AnyValidator<T>

--- a/crates/validator/docs/README.md
+++ b/crates/validator/docs/README.md
@@ -147,7 +147,7 @@ nebula-validator/
 │   ├── engine.rs              validate_rules, ExecutionMode
 │   ├── error.rs               ValidatorError, ValidatorResult
 │   ├── proof.rs               Validated<T> proof token
-│   ├── macros.rs              validator!, compose!, any_of! macros (private)
+│   ├── macros.rs              validator! macro (private)
 │   ├── foundation/
 │   │   ├── traits.rs          Validate<T>, ValidateExt<T>, Validatable
 │   │   ├── any.rs             AnyValidator<T>

--- a/crates/validator/docs/api-reference.md
+++ b/crates/validator/docs/api-reference.md
@@ -10,7 +10,7 @@ see [`architecture.md`](architecture.md). For combinator-specific usage patterns
 
 | Tier | Items |
 |------|-------|
-| **Stable** | `Validate<T>`, `ValidateExt<T>`, `Validatable`, `ValidationError`, `ValidationErrors`, `AnyValidator<T>`, `ErrorSeverity`, `Validated<T>`, `ValidatorError`, all built-in validators, core combinators, `validator!` / `compose!` / `any_of!` macros |
+| **Stable** | `Validate<T>`, `ValidateExt<T>`, `Validatable`, `ValidationError`, `ValidationErrors`, `AnyValidator<T>`, `ErrorSeverity`, `Validated<T>`, `ValidatorError`, all built-in validators, core combinators, the `validator!` macro |
 | **Experimental** | `MultiField` internals, `CollectionNested`, advanced `NestedValidate` helpers — treat as non-contract |
 | **Internal** | `ErasedValidator` trait, `AsValidatable` bridge, macro `@`-arms |
 

--- a/crates/validator/docs/architecture.md
+++ b/crates/validator/docs/architecture.md
@@ -184,7 +184,7 @@ nebula-validator/src/
 ├── engine.rs          validate_rules(), ExecutionMode (StaticOnly / Deferred / Full).
 ├── proof.rs           Validated<T> proof token.
 ├── error.rs           ValidatorError, ValidatorResult<T>.
-├── macros.rs          validator! (private; expanded at call site).
+├── macros.rs          validator! — `#[macro_export]`ed, module private; expands at the call site.
 └── prelude.rs         Single-import convenience re-export.
 ```
 

--- a/crates/validator/docs/architecture.md
+++ b/crates/validator/docs/architecture.md
@@ -184,7 +184,7 @@ nebula-validator/src/
 ├── engine.rs          validate_rules(), ExecutionMode (StaticOnly / Deferred / Full).
 ├── proof.rs           Validated<T> proof token.
 ├── error.rs           ValidatorError, ValidatorResult<T>.
-├── macros.rs          validator!, compose!, any_of! (private; expanded at call site).
+├── macros.rs          validator! (private; expanded at call site).
 └── prelude.rs         Single-import convenience re-export.
 ```
 

--- a/crates/validator/docs/combinators.md
+++ b/crates/validator/docs/combinators.md
@@ -298,18 +298,6 @@ fn password_rules() -> impl Validate<str> {
 }
 ```
 
-### The `compose!` and `any_of!` macros
-
-Shorthand for `And` and `Or` chains:
-
-```rust
-// AND-chain: equivalent to a.and(b).and(c)
-let v = compose![min_length(3), max_length(20), alphanumeric()];
-
-// OR-chain: equivalent to a.or(b).or(c)
-let v = any_of![exact_length(8), exact_length(16), exact_length(32)];
-```
-
 ### Type erasure for plugin/SDK consumers
 
 When validator types cross crate boundaries (e.g., a plugin registers validators against a

--- a/crates/validator/macros/Cargo.toml
+++ b/crates/validator/macros/Cargo.toml
@@ -17,9 +17,9 @@ doctest = false
 
 [dependencies]
 nebula-macro-support = { path = "../../sdk/macros-support" }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 # Used to validate `#[validate(regex = "...")]` patterns at macro-time so
 # compile errors surface before runtime.

--- a/crates/validator/src/macros.rs
+++ b/crates/validator/src/macros.rs
@@ -3,8 +3,9 @@
 //! # Available Macros
 //!
 //! - `validator!` — Create a complete validator (struct + Validate impl + factory fn)
-//! - `compose!` — AND-chain multiple validators
-//! - `any_of!` — OR-chain multiple validators
+//!
+//! Composition is method chaining, not a macro: `v1.and(v2)` / `v1.or(v2)`
+//! from [`ValidateExt`](crate::foundation::ValidateExt).
 //!
 //! # Examples
 //!
@@ -712,78 +713,6 @@ macro_rules! validator {
 }
 
 // ============================================================================
-// COMPOSE MACRO
-// ============================================================================
-
-/// Composes multiple validators using AND logic.
-///
-/// **Deprecated** — prefer `.and(...)` method chaining, which produces
-/// identical code with clearer semantics:
-///
-/// ```rust
-/// # #![allow(deprecated)]
-/// # use nebula_validator::prelude::*;
-/// # use nebula_validator::compose;
-/// // Old:
-/// let with_macro = compose![min_length(5), max_length(20), alphanumeric()];
-/// // New:
-/// let with_chain = min_length(5).and(max_length(20)).and(alphanumeric());
-/// # assert!(with_macro.validate("hello1").is_ok());
-/// # assert!(with_chain.validate("hello1").is_ok());
-/// ```
-#[macro_export]
-#[deprecated(
-    since = "0.1.0",
-    note = "use `.and(...)` method chaining instead: \
-            `v1.and(v2).and(v3)` replaces `compose![v1, v2, v3]`"
-)]
-macro_rules! compose {
-    () => {
-        compile_error!("compose! requires at least one validator expression");
-    };
-    ($first:expr) => { $first };
-    ($first:expr, $($rest:expr),+ $(,)?) => {
-        $first$(.and($rest))+
-    };
-}
-
-// ============================================================================
-// ANY_OF MACRO
-// ============================================================================
-
-/// Composes multiple validators using OR logic.
-///
-/// **Deprecated** — prefer `.or(...)` method chaining, which produces
-/// identical code with clearer semantics:
-///
-/// ```rust
-/// # #![allow(deprecated)]
-/// # use nebula_validator::prelude::*;
-/// # use nebula_validator::any_of;
-/// // Old:
-/// let with_macro = any_of![exact_length(5), exact_length(10)];
-/// // New:
-/// let with_chain = exact_length(5).or(exact_length(10));
-/// # assert!(with_macro.validate("hello").is_ok());
-/// # assert!(with_chain.validate("world12345").is_ok());
-/// ```
-#[macro_export]
-#[deprecated(
-    since = "0.1.0",
-    note = "use `.or(...)` method chaining instead: \
-            `v1.or(v2).or(v3)` replaces `any_of![v1, v2, v3]`"
-)]
-macro_rules! any_of {
-    () => {
-        compile_error!("any_of! requires at least one validator expression");
-    };
-    ($first:expr) => { $first };
-    ($first:expr, $($rest:expr),+ $(,)?) => {
-        $first$(.or($rest))+
-    };
-}
-
-// ============================================================================
 // TESTS
 // ============================================================================
 
@@ -921,29 +850,20 @@ mod tests {
         assert!(v.validate(&11).is_err());
     }
 
-    // Test 7: compose! and any_of! still work (deprecated, but kept for
-    // compatibility until removed)
-    #[expect(
-        deprecated,
-        reason = "verifying compose! still works while it lives; macro is deprecated but not yet removed"
-    )]
+    // Test 7: macro-generated validators compose through `ValidateExt`
     #[test]
-    fn test_compose_still_works() {
+    fn test_and_chaining_composes_generated_validators() {
         use crate::foundation::ValidateExt;
-        let v = compose![TestMinLen { min: 3 }, TestMinLen { min: 1 }];
-        assert!(v.validate("abc").is_ok());
-        assert!(v.validate("ab").is_err());
+        let chained = TestMinLen { min: 3 }.and(TestMinLen { min: 1 });
+        assert!(chained.validate("abc").is_ok());
+        assert!(chained.validate("ab").is_err());
     }
 
-    #[expect(
-        deprecated,
-        reason = "verifying any_of! still works while it lives; macro is deprecated but not yet removed"
-    )]
     #[test]
-    fn test_any_of_still_works() {
+    fn test_or_chaining_composes_generated_validators() {
         use crate::foundation::ValidateExt;
-        let v = any_of![TestMinLen { min: 100 }, TestMinLen { min: 1 }];
-        assert!(v.validate("x").is_ok());
+        let chained = TestMinLen { min: 100 }.or(TestMinLen { min: 1 });
+        assert!(chained.validate("x").is_ok());
     }
 
     // Test 8: Error messages are correct

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,3 +1,39 @@
+# Local dev stacks
+
+Two independent compose files live here:
+
+| File | Brings up | Taskfile entry |
+|------|-----------|----------------|
+| `docker-compose.yml` | Postgres (+ Redis under the `cache` profile) | `task db:up` / `db:down` |
+| `docker-compose.observability.yml` | OTEL collector + Jaeger | `task obs:up` / `obs:down` |
+
+## Database stack
+
+```bash
+task db:up                       # or: docker compose -f deploy/docker/docker-compose.yml up -d
+export DATABASE_URL=postgresql://nebula:nebula@localhost:5432/nebula
+task db:migrate                  # apply pending migrations
+task db:reset                    # drop + create + migrate (destroys local dev data)
+```
+
+Credentials, database name and port come from `POSTGRES_USER` / `POSTGRES_PASSWORD` /
+`POSTGRES_DB` / `POSTGRES_PORT`, defaulting to `nebula` / `nebula` / `nebula` / `5432`.
+The image tracks the PostgreSQL major that `test-matrix.yml` runs against, so a
+migration that passes locally is running on the same major as CI.
+
+### Podman instead of Docker
+
+The Taskfile invokes `docker compose`, which works unmodified on a podman host with
+two pieces in place:
+
+- a compose provider — `docker-compose-v2` (podman finds it via
+  `~/.docker/cli-plugins/docker-compose`, `/usr/libexec/docker/cli-plugins/`, or
+  `docker-compose` on `$PATH`; `podman compose version` lists every path it probes);
+- a `docker` → `podman` shim — the `podman-docker` package, or a two-line
+  `exec podman "$@"` script on `$PATH`.
+
+`sudo apt install -y podman-docker docker-compose-v2` covers both on Ubuntu.
+
 # Observability stack (local dev)
 
 `docker-compose.observability.yml` brings up the minimal collector + Jaeger

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,52 @@
+# Local infra stack (Postgres + optional Redis).
+# Run from repo root:
+#   docker compose -f deploy/docker/docker-compose.yml up -d
+# Enable redis profile:
+#   docker compose -f deploy/docker/docker-compose.yml --profile cache up -d
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: nebula-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-nebula}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nebula}
+      POSTGRES_DB: ${POSTGRES_DB:-nebula}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - nebula_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nebula} -d ${POSTGRES_DB:-nebula}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - nebula_net
+
+  redis:
+    image: redis:7-alpine
+    container_name: nebula-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    profiles: ["cache"]
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - nebula_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - nebula_net
+
+volumes:
+  nebula_pgdata:
+  nebula_redis_data:
+
+networks:
+  nebula_net:
+    driver: bridge

--- a/docs/ENGINEERING_2026.md
+++ b/docs/ENGINEERING_2026.md
@@ -26,7 +26,7 @@ project studied. Divergence from these needs a written reason.
 | C1 | `[workspace.lints]` in root Cargo.toml; every crate `[lints] workspace = true`; **every allow/deny decision listed with a comment, never silent** | all five | ✅ done |
 | C2 | Restriction lints promoted: `print_stdout`, `print_stderr`, `dbg_macro` warn/deny — all output flows through one sink (`tracing` / a `Printer`) | uv, rust-analyzer, iroh | ✅ done (2026-07-06) |
 | C3 | `#[expect(..., reason)]` over `#[allow]`; stale suppressions fail the gate | uv (AGENTS.md), Nebula | ✅ done (2026-07-06) |
-| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ✅ done (2026-07-07): workspace clippy on default + no-default in `check`, cargo-hack each-feature. Extended 2026-07-25: the cargo-hack and MSRV jobs run under `CARGO_BUILD_WARNINGS=deny` (Cargo 1.97 `build.warnings`), so the 108 per-feature configs are gated on rustc lints, not just type errors |
+| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ✅ done (2026-07-07): workspace clippy on default + no-default in `check`, cargo-hack each-feature. Extended 2026-07-25: the cargo-hack and MSRV jobs run under `CARGO_BUILD_WARNINGS=deny` (Cargo 1.97 `build.warnings`), so the 118 per-feature configs are gated on rustc lints, not just type errors |
 | C5 | Rustdoc is a hard gate: `RUSTDOCFLAGS="-D warnings"` on the workspace | reth, omicron, iroh | ✅ already in place (`doc` job runs `RUSTDOCFLAGS=-D warnings`) |
 | C6 | Unused-dependency control is mechanized: `unused_crate_dependencies` warn per crate + udeps/machete/shear in CI | reth (all three layers), uv (shear) | ✅ done (2026-07-07): per-crate `unused_crate_dependencies` + udeps weekly + machete; 15 dead deps purged on adoption |
 | C7 | Generated artifacts are committed and CI re-generates + `git diff --exit-code` | rust-analyzer (`codegen --check`), uv (`check-generated-files`), omicron (openapi), reth (CLI docs) | ❌ not yet needed at scale; adopt with schema export |
@@ -241,11 +241,11 @@ The blueprint for making durable execution deterministically testable:
 
 1. ✅ **Feature-matrix clippy** (C4): `check` job now runs workspace clippy on
    default and `--no-default-features` after the all-features pass;
-   `feature-hygiene` (cargo-hack `--each-feature`, 108 configs) was already
+   `feature-hygiene` (cargo-hack `--each-feature`, 118 configs) was already
    in place for type errors. Since the 1.97 toolchain bump it also carries
    `CARGO_BUILD_WARNINGS=deny`, which promotes a rustc lint warning in any
    single-feature config to a build error — previously only a type error in
-   one of those 108 configs could fail the job.
+   one of those 118 configs could fail the job.
 2. ✅ **Rustdoc gate** (C5): was already in place (`doc` job,
    `RUSTDOCFLAGS=-D warnings`, `--document-private-items`).
 3. ✅ **Dep hygiene** (C6): `#![cfg_attr(not(test), warn(unused_crate_dependencies))]`
@@ -255,7 +255,7 @@ The blueprint for making durable execution deterministically testable:
    (`loom`, `smallvec`, `uuid`) became properly optional or cfg-anchored.
    Plus reth's no-test-deps-in-release `cargo tree` gate (`test-dep-leak` job).
 4. ✅ **`cargo-check-external-types`** on `sdk` and `api` with per-crate
-   allowlists (`external-types` job, nightly-2026-03-20 ↔ tool 0.5.0).
+   allowlists (`external-types` job, nightly-2026-04-20 ↔ tool 0.5.0).
 5. ✅ **Aggregator + workflow security**: aggregator (`required` job) and
    SHA-pinned actions were already in place; **zizmor** gate added at
    high severity — its 4 pre-existing high findings (workflow-level

--- a/docs/ENGINEERING_2026.md
+++ b/docs/ENGINEERING_2026.md
@@ -26,7 +26,7 @@ project studied. Divergence from these needs a written reason.
 | C1 | `[workspace.lints]` in root Cargo.toml; every crate `[lints] workspace = true`; **every allow/deny decision listed with a comment, never silent** | all five | ✅ done |
 | C2 | Restriction lints promoted: `print_stdout`, `print_stderr`, `dbg_macro` warn/deny — all output flows through one sink (`tracing` / a `Printer`) | uv, rust-analyzer, iroh | ✅ done (2026-07-06) |
 | C3 | `#[expect(..., reason)]` over `#[allow]`; stale suppressions fail the gate | uv (AGENTS.md), Nebula | ✅ done (2026-07-06) |
-| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ✅ done (2026-07-07): workspace clippy on default + no-default in `check`, cargo-hack each-feature |
+| C4 | **Lint the feature matrix, not just `--all-features`**: clippy on default + `--no-default-features` + all-features, or `cargo hack` | iroh (3 configs), reth (hack, sharded), omicron (`xtask check-features`) | ✅ done (2026-07-07): workspace clippy on default + no-default in `check`, cargo-hack each-feature. Extended 2026-07-25: the cargo-hack and MSRV jobs run under `CARGO_BUILD_WARNINGS=deny` (Cargo 1.97 `build.warnings`), so the 108 per-feature configs are gated on rustc lints, not just type errors |
 | C5 | Rustdoc is a hard gate: `RUSTDOCFLAGS="-D warnings"` on the workspace | reth, omicron, iroh | ✅ already in place (`doc` job runs `RUSTDOCFLAGS=-D warnings`) |
 | C6 | Unused-dependency control is mechanized: `unused_crate_dependencies` warn per crate + udeps/machete/shear in CI | reth (all three layers), uv (shear) | ✅ done (2026-07-07): per-crate `unused_crate_dependencies` + udeps weekly + machete; 15 dead deps purged on adoption |
 | C7 | Generated artifacts are committed and CI re-generates + `git diff --exit-code` | rust-analyzer (`codegen --check`), uv (`check-generated-files`), omicron (openapi), reth (CLI docs) | ❌ not yet needed at scale; adopt with schema export |
@@ -242,7 +242,10 @@ The blueprint for making durable execution deterministically testable:
 1. ✅ **Feature-matrix clippy** (C4): `check` job now runs workspace clippy on
    default and `--no-default-features` after the all-features pass;
    `feature-hygiene` (cargo-hack `--each-feature`, 108 configs) was already
-   in place for type errors.
+   in place for type errors. Since the 1.97 toolchain bump it also carries
+   `CARGO_BUILD_WARNINGS=deny`, which promotes a rustc lint warning in any
+   single-feature config to a build error — previously only a type error in
+   one of those 108 configs could fail the job.
 2. ✅ **Rustdoc gate** (C5): was already in place (`doc` job,
    `RUSTDOCFLAGS=-D warnings`, `--document-private-items`).
 3. ✅ **Dep hygiene** (C6): `#![cfg_attr(not(test), warn(unused_crate_dependencies))]`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,6 +14,6 @@
 #   recommended format per the rustup book.
 
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 # Nebula rustfmt configuration.
 #
 # Stable-only: runs cleanly on the toolchain pinned in `rust-toolchain.toml`
-# (currently 1.96). Apply locally with:
+# (currently 1.97). Apply locally with:
 #
 #     cargo fmt --all
 #

--- a/tools/xtask/tests/ci_plan.rs
+++ b/tools/xtask/tests/ci_plan.rs
@@ -746,7 +746,7 @@ fn nightly_refresh_chaos_targets_the_existing_storage_harness() {
         "nightly refresh chaos target must exist in the package selected by the workflow"
     );
     for required in [
-        "toolchain: 1.96.1",
+        "toolchain: 1.97.1",
         "-p nebula-storage",
         "--test refresh_coordinator_chaos",
         "--features chaos-full",


### PR DESCRIPTION
Moves the workspace to Rust 1.97.1 and finishes the ripple that falls out of it: the deprecated shims that would otherwise ship into 0.1.0, the dependency refresh that syn 3 gated, and three defects the upgrade's verification runs exposed.

## Toolchain — 1.96 → 1.97.1

Pinned toolchain and declared MSRV both move. 1.97 enables **v0 symbol mangling by default**, so profiler and debugger symbol output changes shape; `-C symbol-mangling-version=legacy` restores the old form if any tooling depends on it.

Fallout was small: one new lint (`useless_borrows_in_formatting`) at three sites, fixed at the call site.

The upgrade also buys a real gate improvement. The clippy job only sees the workspace-level all / default / no-default configurations, so a rustc warning firing under a *single isolated feature* slipped straight through `cargo hack check --each-feature` — the exact blind spot that job exists to cover. Cargo 1.97's `build.warnings` closes it: feature-hygiene and MSRV now run under `CARGO_BUILD_WARNINGS=deny`, verified across all 118 per-feature configurations.

## Breaking — deprecated shims removed

Every one carried `since = "0.1.0"`, i.e. none was ever released in a non-deprecated form. Removing them now avoids shipping a fossil in the first release.

| Crate | Removed | Replacement |
|---|---|---|
| credential | `AuthStyle` re-exports on `credentials`, `credentials::oauth2`, `credentials::oauth2_config` | `nebula_credential::AuthStyle` / `scheme::oauth2::AuthStyle` |
| log | `field::NODE_ID`; dead private `emit_to_hooks` | `field::NODE_KEY`; `emit_to_hooks_inline` / `_bounded` |
| validator | `compose!`, `any_of!` | `ValidateExt` chaining — `v1.and(v2)` / `v1.or(v2)` |
| api | `EmailEnvelope` | `EmailMessage`; `emails()` returns `Vec<EmailMessage>` |

The validator removal closes one already planned in that crate's own `docs/DESIGN.md`. No coverage is lost — the macro tests now assert the same behaviour through the chaining API, and the `EmailEnvelope` redaction canary duplicated one that already covers `EmailMessage`.

## Fixes — two are real defects, not test noise

**Plugin load order was non-deterministic.** `dependency::resolve` sorted the graph's *nodes* by key but left each node's adjacency in manifest declaration order, so the DFS emitted dependencies in whatever order they were declared. Two registries describing the same graph could freeze to different `load_order`s — and therefore different `PluginSet` identities, which derive from that order. Edge lists are now sorted and deduplicated.

**A cargo feature changed the wire shape of a versioned config.** `Config::telemetry` is `#[cfg(feature = "telemetry")]`, so a `schema_version: 1` config serialized `{"telemetry": null, …}` from a telemetry build and omitted the key otherwise. A schema version must pin one shape. Now `skip_serializing_if`, which turns the snapshot tests into a genuine cross-feature contract.

**A stale source-text assertion** in the Postgres refresh-retry test pinned a verbatim `SELECT` prefix that a later `material_epoch` column broke; the production SQL was correct. It now asserts each required column is read in that one statement, which is the actual guarantee — the `clock_timestamp()` sample must come from the statement observing version / reauth / record state, or it is stale after a lock wait.

All three only run under `--all-features`, a configuration the per-package CI matrix never exercises.

## Dependencies

`syn` 2 → 3, plus `cargo update`. `syn`/`quote`/`proc-macro2` were declared independently in all eight derive crates and had already drifted between `"2.0"` and `"2"`; they move to `[workspace.dependencies]` so the parser cannot split across majors. Migration was two call sites: `TypePath` gained `attrs`, and `ItemImpl::trait_` dropped its `Option<Bang>` (negative-impl polarity moved to `ImplModifiers`, which this workspace never inspected). `cargo outdated` now reports every direct dependency current.

## Local dev stack

`Taskfile.yml` points `COMPOSE_LOCAL` at `deploy/docker/docker-compose.yml`, which `b1138dff` ("chore: remove stale docs") deleted as collateral — `task db:up` has been broken since. Restored on `postgres:17-alpine` to match the major `test-matrix.yml` runs against.

The SQLite migration README told the reader to regenerate `0027_port_adapter_schema.sql` from `schema.sql` with `cp`. The two have legitimately diverged (later port changes landed as 0032–0035), so following it would rewrite an already-applied migration and duplicate them. It now states the real invariant — replaying the chain must end in the schema `init_schema` builds in one shot — and documents the four deliberately PostgreSQL-only migrations instead of claiming total parity.

## Verification

- clippy `-D warnings` × all-features / default / no-default — clean
- `cargo fmt --check`, `taplo fmt --check`, `typos` — clean
- nextest **6662/6662** all-features (was 6658 with 4 failing), **6457/6457** default
- doctests **432 passed**
- `cargo hack --each-feature` under `CARGO_BUILD_WARNINGS=deny`, 118 configs — clean
- `cargo deny` — advisories / bans / licenses / sources ok
- migrations replayed onto an empty volume: **PostgreSQL 40/40** (56 tables), **SQLite 36/36** (54 tables), no pending; `port_*` schemas identical between the migration chain and `init_schema`

## Notes for review

- **This carries more than one concern**, against the `CONTRIBUTING.md` rule. They are causally chained — the toolchain bump surfaced the lints, the `--all-features` verification surfaced the three defects, syn 3 gated the dependency refresh — but the three `fix(...)` commits and `fix(deploy)` are independently revertable if you would rather they land separately. Say the word and I will split them out.
- `taplo fmt` normalizes the `tokio-rustls` entry in the root manifest. That entry was already non-conforming at HEAD and is unrelated to this change; it is unavoidable collateral once the manifest is touched, since the gate formats the whole file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cvd7WyyCfmR7kTYGoJPg5b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Minimum supported Rust version is now 1.97.
  - Telemetry configuration is omitted from serialized output when unset, preserving wire compatibility.
  - Plugin dependency processing is now deterministic.
  - Local PostgreSQL and optional Redis development stacks are available through Docker Compose.

- **Removed**
  - Deprecated validator composition macros and legacy authentication/logging compatibility aliases.

- **Documentation**
  - Clarified SQLite migration procedures, database setup, supported toolchains, and validator APIs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->