### PR TITLE
build(deps): tower-http 0.7 and the OpenTelemetry family 0.32/0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,22 @@ changes are expected between minor releases — call them out here.
 
 ### Changed
 
+- **tower-http 0.7 and the OpenTelemetry family 0.32 / 0.33.** These are
+  semver-major bumps, so the previous `cargo update` pass could not take them
+  and — importantly — `cargo outdated` does not report them either: every
+  dependency here is declared through `[workspace.dependencies]` and inherited
+  with `workspace = true`, which that tool does not resolve, so it answers "all
+  dependencies are up to date" while majors are outstanding. Treat dependabot,
+  not `cargo outdated`, as the authority for this workspace.
+  The four OpenTelemetry crates (`opentelemetry` 0.32, `opentelemetry-otlp`
+  0.32, `opentelemetry_sdk` 0.32.1, `tracing-opentelemetry` 0.33) move together
+  on purpose: bumping only `tracing-opentelemetry`, as the standalone dependabot
+  PR proposed, would link two incompatible `opentelemetry` versions at once.
+  Moving the set also collapsed a `reqwest` duplicate — `opentelemetry-http`
+  0.31 pinned its own reqwest 0.12 alongside the workspace's 0.13. No source
+  changes were needed; the API → control-queue → engine → action trace chain,
+  W3C propagation and OTLP metric export are verified by the existing
+  `OTEL_E2E_TEST` suite on the new versions.
 - **(breaking) Rust 1.97.1 is the pinned toolchain and the MSRV.** `rust-version`
   moves `1.96` → `1.97` across the workspace, together with
   `rust-toolchain.toml`, `clippy.toml` `msrv`, every CI/nightly workflow pin, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.10.2",
  "rcgen",
- "reqwest 0.13.4",
+ "reqwest",
  "rstest",
  "secrecy",
  "semver",
@@ -2999,7 +2999,7 @@ dependencies = [
  "tokio-util",
  "totp-rs",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3576,7 +3576,7 @@ dependencies = [
  "nebula-storage-port",
  "nebula-tenancy",
  "rcgen",
- "reqwest 0.13.4",
+ "reqwest",
  "secrecy",
  "serde_json",
  "sqlx",
@@ -4111,9 +4111,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4125,22 +4125,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.2",
  "opentelemetry",
@@ -4148,18 +4148,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -4170,15 +4170,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
  "thiserror",
  "tokio",
@@ -4598,6 +4599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4886,40 +4896,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.2",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4952,7 +4928,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5353,7 +5329,7 @@ checksum = "d631477761f57c76148456e55e80e9a479ff3fa4c65b2b4a0c3acf1167fd4638"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "sentry-actix",
  "sentry-backtrace",
@@ -6315,6 +6291,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "totp-rs"
 version = "5.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,6 +6341,24 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
  "async-compression",
  "bitflags",
  "bytes",
@@ -6362,14 +6367,13 @@ dependencies = [
  "http 1.4.2",
  "http-body",
  "http-body-util",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -6443,9 +6447,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ clap = { version = "4", features = ["derive"] }
 http = "1.4"
 reqwest = { version = "0.13", features = ["json"], default-features = false }
 axum = { version = "0.8", features = ["json"] }
-tower-http = { version = "0.6", features = ["trace", "cors", "compression-gzip"] }
+tower-http = { version = "0.7", features = ["trace", "cors", "compression-gzip"] }
 
 # Database — optional storage backends. The version is pinned here so the
 # three consumers (the `nebula-storage` adapter, `nebula-api`'s
@@ -166,10 +166,10 @@ rand = "0.10"
 
 
 # Observability (optional)
-opentelemetry = "0.31.0"
-opentelemetry-otlp = { version = "0.31.1", features = ["grpc-tonic", "trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "metrics"] }
-tracing-opentelemetry = "0.32.1"
+opentelemetry = "0.32.0"
+opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32.1", features = ["rt-tokio", "metrics"] }
+tracing-opentelemetry = "0.33.0"
 tempfile = "3.27.0"
 proptest = "1.11"
 criterion = { package = "codspeed-criterion-compat", version = "4" }


### PR DESCRIPTION
Finishes the dependency upgrade started in #965. These four bumps are semver-major, so the `cargo update` pass there could not take them.

## `cargo outdated` is blind in this workspace

Worth flagging, because #965's description claimed every direct dependency was current on its authority:

```
$ cargo outdated --workspace
All dependencies are up to date, yay!

$ cargo info tower-http           → version: 0.6.11 (latest 0.7.0)
$ cargo info tracing-opentelemetry → version: 0.32.1 (latest 0.33.0)
$ cargo info opentelemetry         → version: 0.31.0 (latest 0.32.0)
```

Every dependency here is declared in `[workspace.dependencies]` and inherited with `workspace = true`, which that tool does not resolve. It only ever reported crates declared *directly* in member manifests — which is also why centralizing `syn`/`quote`/`proc-macro2` in #965 silently removed them from its view. **Dependabot is the authority for this workspace, not `cargo outdated`.**

## The OpenTelemetry crates move as a set

| Crate | From | To |
|---|---|---|
| `opentelemetry` | 0.31.0 | 0.32.0 |
| `opentelemetry-otlp` | 0.31.1 | 0.32.0 |
| `opentelemetry_sdk` | 0.31.0 | 0.32.1 |
| `tracing-opentelemetry` | 0.32.1 | 0.33.0 |

Deliberately together. #804 proposes bumping only `tracing-opentelemetry`, which would pull `opentelemetry` 0.32 alongside the 0.31 our direct dependencies use — two incompatible copies of the OTel API linked into one binary. That is very likely why it is sitting BLOCKED.

Moving the set also **collapsed a `reqwest` duplicate**: `opentelemetry-http` 0.31 pinned its own reqwest 0.12 next to the workspace's 0.13.

One duplicate remains and is upstream's to fix: `reqwest` 0.13.4 itself depends on tower-http 0.6, so 0.6.11 stays transitively while our direct use is 0.7.0.

## Verification

No source changes were required by either bump. Since compilation proves little for an observability major, the OTLP suite was run explicitly under `OTEL_E2E_TEST=1`:

- one-root-span across API → control queue → engine → action
- W3C `traceparent` round-trip and response propagation
- OAuth callback trace redaction
- OTLP metric export to the in-memory collector

4/4 pass. Plus the standard gate: clippy `-D warnings` across all three feature configurations, `cargo fmt`/`taplo`/`typos`, nextest **6662/6662** all-features and default, doctests 432, `cargo hack --each-feature` under `CARGO_BUILD_WARNINGS=deny` (118 configs), `cargo deny` clean.

## Supersedes

- #804 (`tracing-opentelemetry` alone — unsafe in isolation, see above)
- #888 (`tower-http` 0.7.0 — included here)
- #964 is already DIRTY; its 26 minor/patch updates landed in #965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cvd7WyyCfmR7kTYGoJPg5b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated networking and observability components to newer major versions.
  * Preserved existing tracing, metrics, compression, CORS, and runtime capabilities.
  * Verified trace propagation and export behavior through the end-to-end observability test suite.
  * Documented the dependency updates in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->