### PR TITLE
feat(storage)!: Task 13B SQL exact-revision catalog adapters (#972)

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -279,6 +279,7 @@ jobs:
             credential_migration_postgres \
             credential_schema_admission_postgres \
             refresh_claim_pg_integration \
+            revision_catalog_conformance_postgres \
             revision_catalog_migration_postgres \
             schema_setup_postgres
           do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ dependencies = [
  "nebula-credential",
  "nebula-crypto",
  "nebula-env",
+ "nebula-metrics",
  "nebula-storage-port",
  "nebula-tenancy",
  "parking_lot",

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -898,6 +898,43 @@ pub mod orchestrator_reclaim_outcome {
 }
 
 // ---------------------------------------------------------------------------
+// Exact plan/flavor revision catalog (storage crate)
+// ---------------------------------------------------------------------------
+
+/// Counter: exact plan/flavor catalog operations, by operation and outcome.
+///
+/// Labeled by `backend` (`sqlite` | `postgres`), `operation` (see
+/// [`revision_catalog_operation`]), and `outcome`. The outcome vocabulary is
+/// the catalog's own closed rejection set plus the success values — the same
+/// labels the adapter records on its span, so a dashboard and a trace agree on
+/// what happened.
+///
+/// Two outcomes are the reason this counter exists rather than a plain
+/// success/failure split: `content_conflict` means an immutable identity was
+/// reused for different bytes, and `outcome_unknown` means a commit was
+/// dispatched without an authoritative acknowledgement. Neither is visible in
+/// a success rate, and both need an operator, so alert on them directly.
+///
+/// Cardinality: 2 backends × 4 operations × the closed outcome set.
+pub const NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL: &str =
+    "nebula_storage_revision_catalog_operations_total";
+
+/// Operation labels for [`NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL`].
+///
+/// Closed label set — one value per port method. Adding a value means adding a
+/// catalog capability, not widening a label.
+pub mod revision_catalog_operation {
+    /// `PlanFlavorCatalogWriter::insert`.
+    pub const INSERT: &str = "insert";
+    /// `PlanFlavorCatalog::load_exact`.
+    pub const LOAD_EXACT: &str = "load_exact";
+    /// `PlanFlavorCatalogAdmin::begin_drain`.
+    pub const BEGIN_DRAIN: &str = "begin_drain";
+    /// `PlanFlavorCatalogAdmin::delete_drained`.
+    pub const DELETE_DRAINED: &str = "delete_drained";
+}
+
+// ---------------------------------------------------------------------------
 // Cache (memory crate)
 // ---------------------------------------------------------------------------
 
@@ -943,10 +980,11 @@ mod tests {
         NEBULA_RESOURCE_POOL_EXHAUSTED_TOTAL, NEBULA_RESOURCE_POOL_WAITERS,
         NEBULA_RESOURCE_QUARANTINE_RELEASED_TOTAL, NEBULA_RESOURCE_QUARANTINE_TOTAL,
         NEBULA_RESOURCE_RECYCLE_OUTCOME_TOTAL, NEBULA_RESOURCE_RELEASE_ERROR_TOTAL,
-        NEBULA_RESOURCE_RELEASE_TOTAL, NEBULA_RESOURCE_USAGE_DURATION_SECONDS, auth_oauth_provider,
-        auth_outcome, idempotency_reject_reason, orchestrator_dispatch_outcome,
-        orchestrator_reclaim_outcome, recycle_outcome, refresh_coord_claim_outcome,
-        refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome, refresh_coord_sentinel_action,
+        NEBULA_RESOURCE_RELEASE_TOTAL, NEBULA_RESOURCE_USAGE_DURATION_SECONDS,
+        NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL, auth_oauth_provider, auth_outcome,
+        idempotency_reject_reason, orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
+        recycle_outcome, refresh_coord_claim_outcome, refresh_coord_coalesced_tier,
+        refresh_coord_reclaim_outcome, refresh_coord_sentinel_action, revision_catalog_operation,
         rotation_outcome, webhook_rate_limit_tier, webhook_signature_failure_reason,
     };
 
@@ -1071,6 +1109,42 @@ mod tests {
         NEBULA_CREDENTIAL_REFRESH_COORD_RECLAIM_SWEEPS_TOTAL,
         NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS,
     ];
+
+    #[test]
+    fn revision_catalog_operation_labels_are_closed_set() {
+        // One value per port method. Adding a value here means the catalog
+        // grew a capability, not that a label widened; this test is the CI
+        // gate against silent expansion.
+        let labels = [
+            revision_catalog_operation::INSERT,
+            revision_catalog_operation::LOAD_EXACT,
+            revision_catalog_operation::BEGIN_DRAIN,
+            revision_catalog_operation::DELETE_DRAINED,
+        ];
+        let mut unique = HashSet::new();
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+            assert!(unique.insert(label));
+        }
+        assert_eq!(unique.len(), 4);
+    }
+
+    #[test]
+    fn revision_catalog_metric_is_registry_safe() {
+        let registry = MetricsRegistry::new();
+        let name = NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL;
+        assert!(name.starts_with("nebula_storage_"));
+        assert!(
+            name.chars()
+                .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+        );
+        let counter = registry
+            .counter(name)
+            .expect("the catalog counter registers");
+        counter.inc();
+        assert_eq!(counter.get(), 1);
+    }
 
     const CACHE_METRIC_NAMES: [&str; 4] = [
         NEBULA_CACHE_HITS,

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -62,6 +62,11 @@ sqlx = { workspace = true, optional = true, features = [
 ] }
 hex = { version = "0.4", optional = true }
 rmp-serde = { version = "1", optional = true }
+# Exact plan/flavor catalog counters, enabled with either SQL backend.
+# Optional because the in-memory adapter is a reference/conformance model that
+# no scraper observes, so a default-feature build exports no catalog series and
+# should not link the metrics registry to say so.
+nebula-metrics = { path = "../metrics", optional = true }
 
 [features]
 default = []
@@ -88,8 +93,8 @@ chaos-full = []
 # dragging system openssl into the build matrix. The base `sqlx` dep
 # already enables `runtime-tokio`, so the runtime+TLS bundle isn't
 # needed separately.
-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/tls-rustls-ring-native-roots", "dep:hex"]
-sqlite = ["dep:sqlx", "sqlx/sqlite"]
+postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/tls-rustls-ring-native-roots", "dep:hex", "dep:nebula-metrics"]
+sqlite = ["dep:sqlx", "sqlx/sqlite", "dep:nebula-metrics"]
 msgpack-storage = ["dep:rmp-serde"]
 
 [dev-dependencies]

--- a/crates/storage/src/inmem/plan_flavor_catalog.rs
+++ b/crates/storage/src/inmem/plan_flavor_catalog.rs
@@ -24,13 +24,11 @@ use nebula_storage_port::{
 use super::execution::SharedState;
 #[cfg(test)]
 use super::execution::State;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ArtifactLifecycle {
-    Active,
-    Draining,
-    Deleted,
-}
+use crate::revision_catalog::{
+    ArtifactLifecycle, delete_label, deleted_for, drain_label, draining_for, flavor_records_match,
+    insert_label, load_label, plan_records_match, unavailable_for, validate_pair_recorded_form,
+    validate_recorded_form,
+};
 
 #[derive(Debug, Clone)]
 struct WorkerFlavorRow {
@@ -184,69 +182,6 @@ impl InMemoryPlanFlavorCatalog {
     }
 }
 
-/// Whether two JSON record bodies carry the same content.
-///
-/// Compares the *parsed* documents, never the raw bytes. Record bodies are
-/// ordinary `serde_json` output, so their exact bytes depend on struct field
-/// declaration order and on whether `serde_json` was built with
-/// `preserve_order` — a workspace-unified feature any crate in the graph can
-/// turn on. Byte equality therefore made two binaries that agree on a
-/// revision's content address nonetheless disagree on its record, so
-/// re-installing the same immutable revision failed permanently with
-/// `ContentConflict` instead of reporting `AlreadyPresent`.
-///
-/// Parsing normalises exactly the incidental differences (key order,
-/// whitespace) while still separating genuinely different documents, so
-/// conflict detection keeps its meaning. Bodies that do not parse fall back to
-/// byte equality rather than being treated as equal.
-fn json_bodies_match(stored: &[u8], candidate: &[u8]) -> bool {
-    match (
-        serde_json::from_slice::<serde_json::Value>(stored),
-        serde_json::from_slice::<serde_json::Value>(candidate),
-    ) {
-        (Ok(stored), Ok(candidate)) => stored == candidate,
-        _ => stored == candidate,
-    }
-}
-
-fn flavor_records_match(
-    stored: &WorkerFlavorRevisionRecord,
-    candidate: &WorkerFlavorRevisionRecord,
-) -> bool {
-    stored.id() == candidate.id()
-        && stored.format() == candidate.format()
-        && json_bodies_match(stored.bytes(), candidate.bytes())
-}
-
-fn plan_records_match(
-    stored: &PlanFlavorRevisionRecord,
-    candidate: &PlanFlavorRevisionRecord,
-) -> bool {
-    stored.ids() == candidate.ids()
-        && stored.plan_format() == candidate.plan_format()
-        && json_bodies_match(stored.plan_bytes(), candidate.plan_bytes())
-        && flavor_records_match(stored.worker_flavor(), candidate.worker_flavor())
-}
-
-fn unavailable_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
-    match target {
-        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => {
-            RevisionCatalogError::PlanUnavailable { plan_id }
-        },
-        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => {
-            RevisionCatalogError::WorkerFlavorUnavailable { worker_flavor_id }
-        },
-    }
-}
-
-fn deleted_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
-    RevisionCatalogError::Deleted { target }
-}
-
-fn draining_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
-    RevisionCatalogError::Draining { target }
-}
-
 fn reference_counts(
     catalog: &RevisionCatalogState,
     target: PlanFlavorRevisionTarget,
@@ -287,6 +222,8 @@ fn insert_pair(
     catalog: &mut RevisionCatalogState,
     record: &PlanFlavorRevisionRecord,
 ) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
+    validate_pair_recorded_form(record)?;
+
     let ids = record.ids();
     let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(ids.plan());
     let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(ids.worker_flavor());
@@ -418,6 +355,7 @@ fn load_pair(
         .ok_or(RevisionCatalogError::CorruptRecord {
             target: plan_target,
         })?;
+    validate_recorded_form(record.plan_bytes(), plan_target)?;
     if record.ids().worker_flavor() != ids.worker_flavor() {
         return Err(RevisionCatalogError::PlanFlavorMismatch {
             requested: ids,
@@ -438,6 +376,7 @@ fn load_pair(
         .ok_or(RevisionCatalogError::CorruptRecord {
             target: flavor_target,
         })?;
+    validate_recorded_form(flavor_record.bytes(), flavor_target)?;
     if !flavor_records_match(flavor_record, record.worker_flavor()) {
         return Err(RevisionCatalogError::CorruptRecord {
             target: flavor_target,
@@ -594,7 +533,7 @@ impl PlanFlavorCatalog for InMemoryPlanFlavorCatalog {
             target: "nebula_storage::inmem",
             plan_revision_id = %ids.plan(),
             worker_flavor_revision_id = %ids.worker_flavor(),
-            outcome = if result.is_ok() { "loaded" } else { "rejected" },
+            outcome = load_label(&result),
             "exact plan/flavor catalog load"
         );
         result
@@ -616,11 +555,7 @@ impl PlanFlavorCatalogWriter for InMemoryPlanFlavorCatalog {
             target: "nebula_storage::inmem",
             plan_revision_id = %ids.plan(),
             worker_flavor_revision_id = %ids.worker_flavor(),
-            outcome = match &result {
-                Ok(RevisionInsertOutcome::Inserted) => "inserted",
-                Ok(RevisionInsertOutcome::AlreadyPresent) => "already_present",
-                Err(_) => "rejected",
-            },
+            outcome = insert_label(&result),
             "plan/flavor catalog insert"
         );
         result
@@ -641,7 +576,7 @@ impl PlanFlavorCatalogAdmin for InMemoryPlanFlavorCatalog {
         tracing::debug!(
             target: "nebula_storage::inmem",
             target = ?target,
-            outcome = if result.is_ok() { "draining" } else { "rejected" },
+            outcome = drain_label(&result),
             "plan/flavor catalog begin drain"
         );
         result
@@ -659,7 +594,7 @@ impl PlanFlavorCatalogAdmin for InMemoryPlanFlavorCatalog {
         tracing::debug!(
             target: "nebula_storage::inmem",
             target = ?target,
-            outcome = if result.is_ok() { "deleted" } else { "blocked" },
+            outcome = delete_label(&result),
             "plan/flavor catalog guarded delete"
         );
         result

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -19,6 +19,15 @@
 //! - `postgres` — PostgreSQL adapter behind the `postgres` feature
 //!   (production multi-process; real tx + `FOR UPDATE SKIP LOCKED`).
 //!
+//! ## Exact plan/flavor revision catalog
+//!
+//! `InMemoryPlanFlavorCatalog` is the reference/conformance model;
+//! `sqlite::SqlitePlanFlavorCatalog` and `postgres::PgPlanFlavorCatalog` are
+//! the deployment backends. All three implement the same three port roles over
+//! ordered migration 0041 and are held to one shared acceptance oracle
+//! (`tests/support/revision_catalog_oracle.rs`), so a behaviour only one
+//! backend gets right fails the suite rather than diverging silently.
+//!
 //! This is the layer the knife scenario (`docs/PRODUCT_CANON.md` §13)
 //! exercises end-to-end.
 //!
@@ -94,6 +103,10 @@ pub mod postgres;
 /// so it is referenced with plain backticks (not an intra-doc link) to
 /// keep default-feature rustdoc clean.
 pub mod repos;
+/// Backend-independent exact plan/flavor catalog decisions, shared by every
+/// catalog adapter so record identity, recorded-form validity, and lifecycle
+/// vocabulary cannot drift between backends.
+mod revision_catalog;
 /// Database row types.
 pub mod rows;
 /// Domain-separated lookup digests for opaque browser-session tokens.

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -16,6 +16,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
 mod start_acceptance;
@@ -29,6 +30,7 @@ pub use identity::{
     PgTriggerStore, PgUserStore, PgWorkspaceStore,
 };
 pub use job_dispatch::{PgJobDispatchQueue, PgTriggerDedupInbox};
+pub use plan_flavor_catalog::PgPlanFlavorCatalog;
 pub use resume_producer::PgResumeProducer;
 pub use resume_token::PgResumeTokenStore;
 pub use start_acceptance::PgStartAcceptanceStore;

--- a/crates/storage/src/postgres/plan_flavor_catalog.rs
+++ b/crates/storage/src/postgres/plan_flavor_catalog.rs
@@ -1,0 +1,702 @@
+//! PostgreSQL exact plan/flavor catalog over ordered migration 0041.
+//!
+//! Every operation runs inside one transaction that locks the rows it decides
+//! on with `FOR UPDATE`, so the plan row, the flavor row, and the
+//! authoritative reference rows are read and written in a single linearized
+//! operation across processes. The pair is therefore inserted atomically, and a
+//! drain or a guarded delete rechecks its blockers under the same lock that
+//! applies the lifecycle change.
+//!
+//! Exact load never selects a latest or closest revision, follows a redirect,
+//! or recompiles a plan: it reads the requested plan identity, rejects a plan
+//! pinned to a different worker flavor, and composes the pair from the pinned
+//! flavor row.
+//!
+//! Driver detail and record bytes never cross the port boundary. A failure
+//! before commit is [`RevisionCatalogError::Unavailable`] (the operation
+//! definitely did not commit); a failed commit is
+//! [`RevisionCatalogError::OutcomeUnknown`], because a lost commit
+//! acknowledgement leaves the caller unable to prove whether the write landed.
+
+use nebula_core::{ExecutablePlanRevisionId, WorkerFlavorRevisionId};
+use nebula_storage_port::{
+    BeginDrainOutcome, ExecutablePlanRecordFormat, PlanFlavorCatalog, PlanFlavorCatalogAdmin,
+    PlanFlavorCatalogWriter, PlanFlavorRevisionIds, PlanFlavorRevisionRecord,
+    PlanFlavorRevisionTarget, RevisionCatalogError, RevisionInsertOutcome, RevisionReferenceCounts,
+};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+
+use crate::revision_catalog::{
+    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, StoredExecutablePlan, StoredWorkerFlavor,
+    WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row, decode_worker_flavor_row,
+    delete_label, deleted_for, drain_label, draining_for, flavor_records_match, insert_label,
+    load_label, plan_content_matches, unavailable_for, validate_pair_recorded_form,
+};
+
+/// PostgreSQL-backed exact executable-plan and worker-flavor catalog.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`].
+#[derive(Clone, Debug)]
+pub struct PgPlanFlavorCatalog {
+    pool: PgPool,
+}
+
+impl PgPlanFlavorCatalog {
+    /// Wrap an existing pool. The caller installs the port schema (see
+    /// [`super::init_schema`]).
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Open the transaction every catalog operation runs in.
+    async fn begin(&self) -> Result<Transaction<'_, Postgres>, RevisionCatalogError> {
+        self.pool.begin().await.map_err(driver_did_not_commit)
+    }
+}
+
+/// A driver failure reached before commit definitely did not commit.
+fn driver_did_not_commit(_error: sqlx::Error) -> RevisionCatalogError {
+    RevisionCatalogError::Unavailable
+}
+
+/// A failed commit leaves the caller unable to prove whether the write landed.
+fn commit_outcome_unknown(_error: sqlx::Error) -> RevisionCatalogError {
+    RevisionCatalogError::OutcomeUnknown
+}
+
+/// Whether a row read should take a row lock for a decision that will write.
+///
+/// Exact load decides nothing it then writes, so it reads without blocking a
+/// concurrent drain; every mutating path locks the rows it decides on so a
+/// racing writer cannot invalidate the decision between the read and the write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RowLock {
+    /// Read the row without taking a lock.
+    Shared,
+    /// Take the row's exclusive lock for the rest of the transaction.
+    Exclusive,
+}
+
+/// Advisory-lock namespace for an executable-plan identity.
+const PLAN_IDENTITY_LOCK_SALT: i64 = 0x504c_414e_5f52_4556;
+
+/// Advisory-lock namespace for a worker-flavor identity.
+const FLAVOR_IDENTITY_LOCK_SALT: i64 = 0x464c_4156_5f52_4556;
+
+/// Serialize concurrent operations against one immutable identity, including
+/// the identity that does not exist yet.
+///
+/// `SELECT … FOR UPDATE` cannot lock a row that is absent, so two processes
+/// installing the same new revision would both decide "absent" and one would
+/// lose on the unique index — turning an idempotent install into a driver
+/// error. A transaction-scoped advisory lock keyed on the identity closes that
+/// gap. Revision identifiers are content digests, so the leading eight bytes
+/// are well distributed; a key collision between unrelated identities costs
+/// only serialization, never correctness.
+async fn lock_identity_key(
+    tx: &mut Transaction<'_, Postgres>,
+    salt: i64,
+    id_bytes: &[u8; 32],
+) -> Result<(), RevisionCatalogError> {
+    let mut leading = [0_u8; 8];
+    leading.copy_from_slice(&id_bytes[..8]);
+    let key = i64::from_be_bytes(leading) ^ salt;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(key)
+        .execute(&mut **tx)
+        .await
+        .map(|_locked| ())
+        .map_err(driver_did_not_commit)
+}
+
+/// Read one durable executable-plan row inside the caller's transaction.
+async fn load_plan_row(
+    tx: &mut Transaction<'_, Postgres>,
+    plan_id: ExecutablePlanRevisionId,
+    lock: RowLock,
+) -> Result<Option<StoredExecutablePlan>, RevisionCatalogError> {
+    let statement = match lock {
+        RowLock::Shared => {
+            "SELECT worker_flavor_id, record_format, lifecycle, record_bytes \
+             FROM port_executable_plan_revisions \
+             WHERE executable_plan_id = $1"
+        },
+        RowLock::Exclusive => {
+            "SELECT worker_flavor_id, record_format, lifecycle, record_bytes \
+             FROM port_executable_plan_revisions \
+             WHERE executable_plan_id = $1 FOR UPDATE"
+        },
+    };
+    let row = sqlx::query(statement)
+        .bind(plan_id.as_bytes().as_slice())
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let target = PlanFlavorRevisionTarget::ExecutablePlan(plan_id);
+    let corrupt = |_column: sqlx::Error| RevisionCatalogError::CorruptRecord { target };
+    let worker_flavor_id: Vec<u8> = row.try_get("worker_flavor_id").map_err(corrupt)?;
+    let record_format: String = row.try_get("record_format").map_err(corrupt)?;
+    let lifecycle: String = row.try_get("lifecycle").map_err(corrupt)?;
+    let record_bytes: Option<Vec<u8>> = row.try_get("record_bytes").map_err(corrupt)?;
+
+    decode_executable_plan_row(
+        plan_id,
+        worker_flavor_id,
+        &lifecycle,
+        &record_format,
+        record_bytes,
+    )
+    .map(Some)
+}
+
+/// Read one durable worker-flavor row inside the caller's transaction.
+async fn load_flavor_row(
+    tx: &mut Transaction<'_, Postgres>,
+    worker_flavor_id: WorkerFlavorRevisionId,
+    lock: RowLock,
+) -> Result<Option<StoredWorkerFlavor>, RevisionCatalogError> {
+    let statement = match lock {
+        RowLock::Shared => {
+            "SELECT record_format, lifecycle, record_bytes \
+             FROM port_worker_flavor_revisions WHERE worker_flavor_id = $1"
+        },
+        RowLock::Exclusive => {
+            "SELECT record_format, lifecycle, record_bytes \
+             FROM port_worker_flavor_revisions WHERE worker_flavor_id = $1 FOR UPDATE"
+        },
+    };
+    let row = sqlx::query(statement)
+        .bind(worker_flavor_id.as_bytes().as_slice())
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let target = PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id);
+    let corrupt = |_column: sqlx::Error| RevisionCatalogError::CorruptRecord { target };
+    let record_format: String = row.try_get("record_format").map_err(corrupt)?;
+    let lifecycle: String = row.try_get("lifecycle").map_err(corrupt)?;
+    let record_bytes: Option<Vec<u8>> = row.try_get("record_bytes").map_err(corrupt)?;
+
+    decode_worker_flavor_row(worker_flavor_id, &lifecycle, &record_format, record_bytes).map(Some)
+}
+
+/// Project the authoritative reference rows that block `target`'s deletion.
+///
+/// Counts are always derived from reference rows; the schema carries no
+/// mutable counter that could drift from them. A rollback window whose
+/// deadline has arrived no longer blocks, so equality with `now_ms` is
+/// expired.
+async fn reference_counts(
+    tx: &mut Transaction<'_, Postgres>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<RevisionReferenceCounts, RevisionCatalogError> {
+    let query = match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+            "SELECT \
+             COUNT(*) FILTER (WHERE reference_state = 'live') AS live_executions, \
+             COUNT(*) FILTER (WHERE reference_state = 'rollback' AND retain_until_ms > $1) \
+                 AS rollback_windows \
+             FROM port_execution_revision_refs WHERE executable_plan_id = $2",
+        )
+        .bind(now_ms)
+        .bind(plan_id.as_bytes().as_slice()),
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+            "SELECT \
+             COUNT(*) FILTER (WHERE reference_state = 'live') AS live_executions, \
+             COUNT(*) FILTER (WHERE reference_state = 'rollback' AND retain_until_ms > $1) \
+                 AS rollback_windows \
+             FROM port_execution_revision_refs WHERE worker_flavor_id = $2",
+        )
+        .bind(now_ms)
+        .bind(worker_flavor_id.as_bytes().as_slice()),
+    };
+
+    let row = query
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    let corrupt = |_column: sqlx::Error| RevisionCatalogError::CorruptRecord { target };
+    let live_executions: i64 = row.try_get("live_executions").map_err(corrupt)?;
+    let rollback_windows: i64 = row.try_get("rollback_windows").map_err(corrupt)?;
+
+    Ok(RevisionReferenceCounts::new(
+        u64::try_from(live_executions).unwrap_or_default(),
+        u64::try_from(rollback_windows).unwrap_or_default(),
+    ))
+}
+
+/// One tombstone-aware lifecycle probe taken under the row's exclusive lock.
+struct LockedIdentity {
+    lifecycle: ArtifactLifecycle,
+    payload_is_cleared: bool,
+}
+
+/// Read the durable lifecycle of one immutable identity under its row lock.
+async fn lock_identity(
+    tx: &mut Transaction<'_, Postgres>,
+    target: PlanFlavorRevisionTarget,
+) -> Result<Option<LockedIdentity>, RevisionCatalogError> {
+    let query = match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+            "SELECT lifecycle, record_bytes IS NULL AS cleared \
+             FROM port_executable_plan_revisions \
+             WHERE executable_plan_id = $1 FOR UPDATE",
+        )
+        .bind(plan_id.as_bytes().as_slice()),
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+            "SELECT lifecycle, record_bytes IS NULL AS cleared \
+             FROM port_worker_flavor_revisions \
+             WHERE worker_flavor_id = $1 FOR UPDATE",
+        )
+        .bind(worker_flavor_id.as_bytes().as_slice()),
+    };
+
+    let Some(row) = query
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?
+    else {
+        return Ok(None);
+    };
+    let corrupt = |_column: sqlx::Error| RevisionCatalogError::CorruptRecord { target };
+    let lifecycle: String = row.try_get("lifecycle").map_err(corrupt)?;
+    let payload_is_cleared: bool = row.try_get("cleared").map_err(corrupt)?;
+    let lifecycle = ArtifactLifecycle::from_text(&lifecycle)
+        .ok_or(RevisionCatalogError::CorruptRecord { target })?;
+
+    Ok(Some(LockedIdentity {
+        lifecycle,
+        payload_is_cleared,
+    }))
+}
+
+async fn insert_locked(
+    tx: &mut Transaction<'_, Postgres>,
+    record: &PlanFlavorRevisionRecord,
+) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
+    validate_pair_recorded_form(record)?;
+
+    let ids = record.ids();
+    let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(ids.plan());
+    let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(ids.worker_flavor());
+
+    // Lock the flavor before the plan, matching the write order the foreign
+    // key forces, so two concurrent inserts of the same pair cannot deadlock by
+    // taking the two identities in opposite orders.
+    lock_identity_key(
+        tx,
+        FLAVOR_IDENTITY_LOCK_SALT,
+        ids.worker_flavor().as_bytes(),
+    )
+    .await?;
+    lock_identity_key(tx, PLAN_IDENTITY_LOCK_SALT, ids.plan().as_bytes()).await?;
+
+    // Read plan-then-flavor, matching the order the rejections are decided in,
+    // so a database holding two corrupt rows names the same identity here as
+    // the SQLite adapter and the in-memory reference model do.
+    let stored_plan = load_plan_row(tx, ids.plan(), RowLock::Exclusive).await?;
+    let stored_flavor = load_flavor_row(tx, ids.worker_flavor(), RowLock::Exclusive).await?;
+
+    let existing_plan_matches = match stored_plan.as_ref() {
+        None => false,
+        Some(plan) if plan.lifecycle == ArtifactLifecycle::Deleted => {
+            return Err(deleted_for(plan_target));
+        },
+        Some(plan) => {
+            let stored_bytes =
+                plan.plan_bytes
+                    .as_ref()
+                    .ok_or(RevisionCatalogError::CorruptRecord {
+                        target: plan_target,
+                    })?;
+            if plan_content_matches(
+                PlanFlavorRevisionIds::new(ids.plan(), plan.worker_flavor_id),
+                ExecutablePlanRecordFormat::GraphV1Json,
+                stored_bytes.as_bytes(),
+                record,
+            ) {
+                true
+            } else {
+                return Err(RevisionCatalogError::ContentConflict {
+                    target: plan_target,
+                });
+            }
+        },
+    };
+
+    let existing_flavor_matches = match stored_flavor.as_ref() {
+        None => false,
+        Some(flavor) if flavor.lifecycle == ArtifactLifecycle::Deleted => {
+            return Err(deleted_for(flavor_target));
+        },
+        Some(flavor) => {
+            let stored_record =
+                flavor
+                    .record
+                    .as_ref()
+                    .ok_or(RevisionCatalogError::CorruptRecord {
+                        target: flavor_target,
+                    })?;
+            if flavor_records_match(stored_record, record.worker_flavor()) {
+                true
+            } else {
+                return Err(RevisionCatalogError::ContentConflict {
+                    target: flavor_target,
+                });
+            }
+        },
+    };
+
+    // A plan whose pinned flavor row is absent is durable corruption, not an
+    // insert this call may heal by writing the flavor half underneath it.
+    if existing_plan_matches && !existing_flavor_matches {
+        return Err(RevisionCatalogError::CorruptRecord {
+            target: flavor_target,
+        });
+    }
+
+    // Draining is a property of the stored artifact, not of whether this
+    // caller happens to have inserted this pair before, so an idempotent retry
+    // learns that the revision is being retired.
+    if stored_plan
+        .as_ref()
+        .is_some_and(|plan| plan.lifecycle == ArtifactLifecycle::Draining)
+    {
+        return Err(draining_for(plan_target));
+    }
+    if stored_flavor
+        .as_ref()
+        .is_some_and(|flavor| flavor.lifecycle == ArtifactLifecycle::Draining)
+    {
+        return Err(draining_for(flavor_target));
+    }
+
+    if existing_plan_matches && existing_flavor_matches {
+        return Ok(RevisionInsertOutcome::AlreadyPresent);
+    }
+
+    // The plan row's foreign key requires its flavor row to exist first.
+    if !existing_flavor_matches {
+        sqlx::query(
+            "INSERT INTO port_worker_flavor_revisions \
+             (worker_flavor_id, record_format, lifecycle, record_bytes) \
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(ids.worker_flavor().as_bytes().as_slice())
+        .bind(WORKER_FLAVOR_V1_JSON)
+        .bind(ArtifactLifecycle::Active.as_str())
+        .bind(record.worker_flavor().bytes())
+        .execute(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    }
+    if !existing_plan_matches {
+        sqlx::query(
+            "INSERT INTO port_executable_plan_revisions \
+             (executable_plan_id, worker_flavor_id, record_format, lifecycle, record_bytes) \
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(ids.plan().as_bytes().as_slice())
+        .bind(ids.worker_flavor().as_bytes().as_slice())
+        .bind(EXECUTABLE_PLAN_GRAPH_V1_JSON)
+        .bind(ArtifactLifecycle::Active.as_str())
+        .bind(record.plan_bytes())
+        .execute(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    }
+
+    Ok(RevisionInsertOutcome::Inserted)
+}
+
+async fn load_exact_locked(
+    tx: &mut Transaction<'_, Postgres>,
+    ids: PlanFlavorRevisionIds,
+) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
+    let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(ids.plan());
+
+    let plan = load_plan_row(tx, ids.plan(), RowLock::Shared)
+        .await?
+        .ok_or_else(|| unavailable_for(plan_target))?;
+    if plan.lifecycle == ArtifactLifecycle::Deleted {
+        return Err(deleted_for(plan_target));
+    }
+    if plan.worker_flavor_id != ids.worker_flavor() {
+        return Err(RevisionCatalogError::PlanFlavorMismatch {
+            requested: ids,
+            stored_worker_flavor_id: plan.worker_flavor_id,
+        });
+    }
+
+    let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(plan.worker_flavor_id);
+    let flavor = load_flavor_row(tx, plan.worker_flavor_id, RowLock::Shared)
+        .await?
+        .ok_or_else(|| unavailable_for(flavor_target))?;
+    if flavor.lifecycle == ArtifactLifecycle::Deleted {
+        return Err(deleted_for(flavor_target));
+    }
+
+    compose_pair(ids.plan(), &plan, &flavor)
+}
+
+async fn begin_drain_locked(
+    tx: &mut Transaction<'_, Postgres>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<BeginDrainOutcome, RevisionCatalogError> {
+    let identity = lock_identity(tx, target)
+        .await?
+        .ok_or_else(|| unavailable_for(target))?;
+
+    match identity.lifecycle {
+        ArtifactLifecycle::Active => {
+            let updated = match target {
+                PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+                    "UPDATE port_executable_plan_revisions SET lifecycle = 'draining' \
+                     WHERE executable_plan_id = $1 AND lifecycle = 'active'",
+                )
+                .bind(plan_id.as_bytes().as_slice()),
+                PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+                    "UPDATE port_worker_flavor_revisions SET lifecycle = 'draining' \
+                     WHERE worker_flavor_id = $1 AND lifecycle = 'active'",
+                )
+                .bind(worker_flavor_id.as_bytes().as_slice()),
+            }
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?
+            .rows_affected();
+            if updated != 1 {
+                // The row was read as Active under its exclusive lock, so no
+                // concurrent writer can have moved it.
+                return Err(RevisionCatalogError::CorruptRecord { target });
+            }
+            Ok(BeginDrainOutcome::Started(
+                reference_counts(tx, target, now_ms).await?,
+            ))
+        },
+        ArtifactLifecycle::Draining => Ok(BeginDrainOutcome::AlreadyDraining(
+            reference_counts(tx, target, now_ms).await?,
+        )),
+        ArtifactLifecycle::Deleted => Err(deleted_for(target)),
+    }
+}
+
+async fn delete_drained_locked(
+    tx: &mut Transaction<'_, Postgres>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<(), RevisionCatalogError> {
+    let identity = lock_identity(tx, target)
+        .await?
+        .ok_or_else(|| unavailable_for(target))?;
+
+    match identity.lifecycle {
+        ArtifactLifecycle::Active => return Err(RevisionCatalogError::DrainRequired { target }),
+        ArtifactLifecycle::Deleted => {
+            // Repeating a delete against its own tombstone succeeds, so a
+            // caller whose acknowledgement was lost can reconcile the commit.
+            return if identity.payload_is_cleared {
+                Ok(())
+            } else {
+                Err(RevisionCatalogError::CorruptRecord { target })
+            };
+        },
+        ArtifactLifecycle::Draining => {},
+    }
+
+    let references = reference_counts(tx, target, now_ms).await?;
+    if !references.is_empty() {
+        return Err(RevisionCatalogError::Referenced { target, references });
+    }
+
+    match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => {
+            sqlx::query(
+                "UPDATE port_executable_plan_revisions \
+                 SET lifecycle = 'deleted', record_bytes = NULL \
+                 WHERE executable_plan_id = $1",
+            )
+            .bind(plan_id.as_bytes().as_slice())
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?;
+        },
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => {
+            let dependent_plans: i64 = sqlx::query(
+                "SELECT COUNT(*) AS dependent_plans FROM port_executable_plan_revisions \
+                 WHERE worker_flavor_id = $1 AND lifecycle <> 'deleted'",
+            )
+            .bind(worker_flavor_id.as_bytes().as_slice())
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?
+            .try_get("dependent_plans")
+            .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+            if dependent_plans != 0 {
+                return Err(RevisionCatalogError::DependentPlans {
+                    worker_flavor_id,
+                    dependent_plans: u64::try_from(dependent_plans).unwrap_or_default(),
+                });
+            }
+            sqlx::query(
+                "UPDATE port_worker_flavor_revisions \
+                 SET lifecycle = 'deleted', record_bytes = NULL \
+                 WHERE worker_flavor_id = $1",
+            )
+            .bind(worker_flavor_id.as_bytes().as_slice())
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?;
+        },
+    }
+
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalog for PgPlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.load_exact",
+        skip(self),
+        fields(
+            backend = "postgres",
+            plan_revision_id = %ids.plan(),
+            worker_flavor_revision_id = %ids.worker_flavor(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn load_exact(
+        &self,
+        ids: PlanFlavorRevisionIds,
+    ) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
+        let mut tx = self.begin().await?;
+        let result = load_exact_locked(&mut tx, ids).await;
+        // Nothing was written on this path; the commit only releases the read
+        // transaction, so a failure to release cannot make the outcome unknown.
+        drop(tx.commit().await);
+
+        tracing::Span::current().record("outcome", load_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = load_label(&result),
+            "exact plan/flavor catalog load"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalogWriter for PgPlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.insert",
+        skip(self, record),
+        fields(
+            backend = "postgres",
+            plan_revision_id = %record.ids().plan(),
+            worker_flavor_revision_id = %record.ids().worker_flavor(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn insert(
+        &self,
+        record: &PlanFlavorRevisionRecord,
+    ) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
+        let mut tx = self.begin().await?;
+        let result = match insert_locked(&mut tx, record).await {
+            Ok(outcome) => tx
+                .commit()
+                .await
+                .map_err(commit_outcome_unknown)
+                .map(|()| outcome),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", insert_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = insert_label(&result),
+            "plan/flavor catalog insert"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalogAdmin for PgPlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.begin_drain",
+        skip(self),
+        fields(backend = "postgres", target = ?target, outcome = tracing::field::Empty)
+    )]
+    async fn begin_drain(
+        &self,
+        target: PlanFlavorRevisionTarget,
+    ) -> Result<BeginDrainOutcome, RevisionCatalogError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut tx = self.begin().await?;
+        let result = match begin_drain_locked(&mut tx, target, now_ms).await {
+            Ok(outcome) => tx
+                .commit()
+                .await
+                .map_err(commit_outcome_unknown)
+                .map(|()| outcome),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", drain_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = drain_label(&result),
+            "plan/flavor catalog begin drain"
+        );
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.delete_drained",
+        skip(self),
+        fields(backend = "postgres", target = ?target, outcome = tracing::field::Empty)
+    )]
+    async fn delete_drained(
+        &self,
+        target: PlanFlavorRevisionTarget,
+    ) -> Result<(), RevisionCatalogError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut tx = self.begin().await?;
+        let result = match delete_drained_locked(&mut tx, target, now_ms).await {
+            Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", delete_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = delete_label(&result),
+            "plan/flavor catalog guarded delete"
+        );
+        result
+    }
+}

--- a/crates/storage/src/postgres/plan_flavor_catalog.rs
+++ b/crates/storage/src/postgres/plan_flavor_catalog.rs
@@ -26,11 +26,14 @@ use nebula_storage_port::{
 };
 use sqlx::{PgPool, Postgres, Row, Transaction};
 
+use nebula_metrics::revision_catalog_operation;
+
 use crate::revision_catalog::{
-    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, StoredExecutablePlan, StoredWorkerFlavor,
-    WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row, decode_worker_flavor_row,
-    delete_label, deleted_for, drain_label, draining_for, flavor_records_match, insert_label,
-    load_label, plan_content_matches, unavailable_for, validate_pair_recorded_form,
+    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, RevisionCatalogMetrics, StoredExecutablePlan,
+    StoredWorkerFlavor, WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row,
+    decode_worker_flavor_row, delete_label, deleted_for, drain_label, draining_for,
+    flavor_records_match, insert_label, load_label, plan_content_matches, unavailable_for,
+    validate_pair_recorded_form,
 };
 
 /// PostgreSQL-backed exact executable-plan and worker-flavor catalog.
@@ -39,14 +42,22 @@ use crate::revision_catalog::{
 #[derive(Clone, Debug)]
 pub struct PgPlanFlavorCatalog {
     pool: PgPool,
+    metrics: RevisionCatalogMetrics,
 }
 
 impl PgPlanFlavorCatalog {
-    /// Wrap an existing pool. The caller installs the port schema (see
-    /// [`super::init_schema`]).
+    /// Wrap an existing pool and bind catalog counters to a shared registry.
+    ///
+    /// The caller installs the port schema (see [`super::init_schema`]). The
+    /// registry is required rather than optional so a composition root cannot
+    /// wire a deployment backend whose conflict and unknown-outcome counts are
+    /// invisible to a scraper.
     #[must_use]
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+    pub fn new(pool: PgPool, metrics: &nebula_metrics::MetricsRegistry) -> Self {
+        Self {
+            pool,
+            metrics: RevisionCatalogMetrics::new(metrics, "postgres"),
+        }
     }
 
     /// Open the transaction every catalog operation runs in.
@@ -580,16 +591,28 @@ impl PlanFlavorCatalog for PgPlanFlavorCatalog {
         &self,
         ids: PlanFlavorRevisionIds,
     ) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
-        let mut tx = self.begin().await?;
-        let result = load_exact_locked(&mut tx, ids).await;
-        // Nothing was written on this path; the commit only releases the read
-        // transaction, so a failure to release cannot make the outcome unknown.
-        drop(tx.commit().await);
+        // The transaction is opened *inside* the observed body. Returning `?`
+        // from an unreachable pool would otherwise leave the span's `outcome`
+        // empty and emit no event at all, so the one failure that means "this
+        // backend is down" was the one failure nothing recorded.
+        let result = async {
+            let mut tx = self.begin().await?;
+            let loaded = load_exact_locked(&mut tx, ids).await;
+            // Nothing was written on this path; the commit only releases the
+            // read transaction, so failing to release cannot make the outcome
+            // unknown.
+            drop(tx.commit().await);
+            loaded
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", load_label(&result));
+        let outcome = load_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::LOAD_EXACT, outcome);
         tracing::debug!(
             target: "nebula_storage::postgres",
-            outcome = load_label(&result),
+            outcome,
             "exact plan/flavor catalog load"
         );
         result
@@ -613,23 +636,29 @@ impl PlanFlavorCatalogWriter for PgPlanFlavorCatalog {
         &self,
         record: &PlanFlavorRevisionRecord,
     ) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
-        let mut tx = self.begin().await?;
-        let result = match insert_locked(&mut tx, record).await {
-            Ok(outcome) => tx
-                .commit()
-                .await
-                .map_err(commit_outcome_unknown)
-                .map(|()| outcome),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin().await?;
+            match insert_locked(&mut tx, record).await {
+                Ok(outcome) => tx
+                    .commit()
+                    .await
+                    .map_err(commit_outcome_unknown)
+                    .map(|()| outcome),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", insert_label(&result));
+        let outcome = insert_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::INSERT, outcome);
         tracing::debug!(
             target: "nebula_storage::postgres",
-            outcome = insert_label(&result),
+            outcome,
             "plan/flavor catalog insert"
         );
         result
@@ -649,23 +678,29 @@ impl PlanFlavorCatalogAdmin for PgPlanFlavorCatalog {
         target: PlanFlavorRevisionTarget,
     ) -> Result<BeginDrainOutcome, RevisionCatalogError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        let mut tx = self.begin().await?;
-        let result = match begin_drain_locked(&mut tx, target, now_ms).await {
-            Ok(outcome) => tx
-                .commit()
-                .await
-                .map_err(commit_outcome_unknown)
-                .map(|()| outcome),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin().await?;
+            match begin_drain_locked(&mut tx, target, now_ms).await {
+                Ok(outcome) => tx
+                    .commit()
+                    .await
+                    .map_err(commit_outcome_unknown)
+                    .map(|()| outcome),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", drain_label(&result));
+        let outcome = drain_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::BEGIN_DRAIN, outcome);
         tracing::debug!(
             target: "nebula_storage::postgres",
-            outcome = drain_label(&result),
+            outcome,
             "plan/flavor catalog begin drain"
         );
         result
@@ -682,19 +717,25 @@ impl PlanFlavorCatalogAdmin for PgPlanFlavorCatalog {
         target: PlanFlavorRevisionTarget,
     ) -> Result<(), RevisionCatalogError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        let mut tx = self.begin().await?;
-        let result = match delete_drained_locked(&mut tx, target, now_ms).await {
-            Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin().await?;
+            match delete_drained_locked(&mut tx, target, now_ms).await {
+                Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", delete_label(&result));
+        let outcome = delete_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::DELETE_DRAINED, outcome);
         tracing::debug!(
             target: "nebula_storage::postgres",
-            outcome = delete_label(&result),
+            outcome,
             "plan/flavor catalog guarded delete"
         );
         result

--- a/crates/storage/src/revision_catalog.rs
+++ b/crates/storage/src/revision_catalog.rs
@@ -134,6 +134,54 @@ pub(crate) fn plan_records_match(
     )
 }
 
+/// Catalog operation counters bound to one shared metrics registry.
+///
+/// A deployment backend must be observable by a scraper, not only by a trace
+/// sampler: `content_conflict` (an immutable identity reused for different
+/// bytes) and `outcome_unknown` (a commit dispatched without an authoritative
+/// acknowledgement) both need an operator and neither shows up in a success
+/// rate. The registry is required rather than optional so a composition root
+/// cannot wire a catalog that silently reports nothing.
+///
+/// Only the SQLite and PostgreSQL deployment backends carry this. The
+/// in-memory adapter is a reference/conformance model that no scraper observes,
+/// so it emits spans alone.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[derive(Clone, Debug)]
+pub(crate) struct RevisionCatalogMetrics {
+    registry: nebula_metrics::MetricsRegistry,
+    backend: &'static str,
+}
+
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+impl RevisionCatalogMetrics {
+    /// Bind catalog counters for one backend against a shared registry.
+    pub(crate) fn new(registry: &nebula_metrics::MetricsRegistry, backend: &'static str) -> Self {
+        Self {
+            registry: registry.clone(),
+            backend,
+        }
+    }
+
+    /// Count one completed catalog operation under its outcome label.
+    ///
+    /// A registry failure is swallowed: losing a counter increment must never
+    /// turn a committed catalog operation into a caller-visible error.
+    pub(crate) fn record(&self, operation: &'static str, outcome: &'static str) {
+        let labels = self.registry.interner().label_set(&[
+            ("backend", self.backend),
+            ("operation", operation),
+            ("outcome", outcome),
+        ]);
+        if let Ok(counter) = self.registry.counter_labeled(
+            nebula_metrics::NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL,
+            &labels,
+        ) {
+            counter.inc();
+        }
+    }
+}
+
 /// Stable label naming one catalog rejection, so every adapter reports the
 /// same outcome vocabulary on its spans.
 pub(crate) const fn error_label(error: &RevisionCatalogError) -> &'static str {

--- a/crates/storage/src/revision_catalog.rs
+++ b/crates/storage/src/revision_catalog.rs
@@ -1,0 +1,571 @@
+//! Backend-independent exact plan/flavor catalog decisions.
+//!
+//! Every adapter — the in-memory reference model, SQLite, and PostgreSQL —
+//! routes record identity, recorded-form validity, and lifecycle vocabulary
+//! through this module, so the three backends cannot answer the same question
+//! differently. Row plumbing stays in each adapter; the decisions do not.
+//!
+//! Durable lifecycle and recorded-form text is the same vocabulary ordered
+//! migration 0041 constrains with `CHECK` clauses. The constants below are the
+//! single Rust-side definition of that vocabulary; nothing re-spells it.
+
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+use nebula_core::{ExecutablePlanRevisionId, WorkerFlavorRevisionId};
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+use nebula_storage_port::RevisionRecordBytes;
+use nebula_storage_port::{
+    BeginDrainOutcome, ExecutablePlanRecordFormat, PlanFlavorRevisionIds, PlanFlavorRevisionRecord,
+    PlanFlavorRevisionTarget, RevisionCatalogError, RevisionInsertOutcome,
+    WorkerFlavorRevisionRecord,
+};
+
+/// Durable `record_format` text of a version-one JSON worker-flavor record.
+///
+/// Only a SQL backend spells a recorded form as durable text; the in-memory
+/// reference model keeps the typed format on the record itself.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) const WORKER_FLAVOR_V1_JSON: &str = "v1_json";
+
+/// Durable `record_format` text of a Graph-v1 JSON executable-plan record.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) const EXECUTABLE_PLAN_GRAPH_V1_JSON: &str = "graph_v1_json";
+
+/// Durable lifecycle of one immutable catalog identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ArtifactLifecycle {
+    /// Accepts exact loads and new references.
+    Active,
+    /// Accepts exact loads, rejects new references and new content.
+    Draining,
+    /// Identity tombstone; payload bytes are cleared.
+    Deleted,
+}
+
+/// Durable lifecycle text is only spelled by a SQL backend; the in-memory
+/// reference model holds the typed lifecycle directly.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+impl ArtifactLifecycle {
+    /// Return the durable lifecycle text migration 0041 constrains.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Draining => "draining",
+            Self::Deleted => "deleted",
+        }
+    }
+
+    /// Parse durable lifecycle text, rejecting any vocabulary the schema does
+    /// not admit.
+    pub(crate) fn from_text(text: &str) -> Option<Self> {
+        match text {
+            "active" => Some(Self::Active),
+            "draining" => Some(Self::Draining),
+            "deleted" => Some(Self::Deleted),
+            _ => None,
+        }
+    }
+}
+
+/// Whether two JSON record bodies carry the same content.
+///
+/// Compares the *parsed* documents, never the raw bytes. Record bodies are
+/// ordinary `serde_json` output, so their exact bytes depend on struct field
+/// declaration order and on whether `serde_json` was built with
+/// `preserve_order` — a workspace-unified feature any crate in the graph can
+/// turn on. Byte equality therefore made two binaries that agree on a
+/// revision's content address nonetheless disagree on its record, so
+/// re-installing the same immutable revision failed permanently with
+/// `ContentConflict` instead of reporting `AlreadyPresent`.
+///
+/// Parsing normalises exactly the incidental differences (key order,
+/// whitespace) while still separating genuinely different documents, so
+/// conflict detection keeps its meaning. Bodies that do not parse fall back to
+/// byte equality rather than being treated as equal.
+pub(crate) fn json_bodies_match(stored: &[u8], candidate: &[u8]) -> bool {
+    match (
+        serde_json::from_slice::<serde_json::Value>(stored),
+        serde_json::from_slice::<serde_json::Value>(candidate),
+    ) {
+        (Ok(stored), Ok(candidate)) => stored == candidate,
+        _ => stored == candidate,
+    }
+}
+
+/// Whether two worker-flavor records are the same immutable content.
+pub(crate) fn flavor_records_match(
+    stored: &WorkerFlavorRevisionRecord,
+    candidate: &WorkerFlavorRevisionRecord,
+) -> bool {
+    stored.id() == candidate.id()
+        && stored.format() == candidate.format()
+        && json_bodies_match(stored.bytes(), candidate.bytes())
+}
+
+/// Whether a stored executable plan is the same immutable content as
+/// `candidate`'s plan half.
+///
+/// The paired worker flavor is compared through its own identity, never
+/// through a second copy carried inside the plan. Each payload has exactly one
+/// durable home, so a flavor-content difference must be reported against the
+/// flavor identity that owns it — blaming the plan named an immutable identity
+/// whose own bytes are unchanged, and the two backends disagreed about which
+/// identity conflicted for the same insert.
+pub(crate) fn plan_content_matches(
+    stored_ids: PlanFlavorRevisionIds,
+    stored_format: ExecutablePlanRecordFormat,
+    stored_plan_bytes: &[u8],
+    candidate: &PlanFlavorRevisionRecord,
+) -> bool {
+    stored_ids == candidate.ids()
+        && stored_format == candidate.plan_format()
+        && json_bodies_match(stored_plan_bytes, candidate.plan_bytes())
+}
+
+/// Whether a stored pair is the same immutable plan content as `candidate`.
+pub(crate) fn plan_records_match(
+    stored: &PlanFlavorRevisionRecord,
+    candidate: &PlanFlavorRevisionRecord,
+) -> bool {
+    plan_content_matches(
+        stored.ids(),
+        stored.plan_format(),
+        stored.plan_bytes(),
+        candidate,
+    )
+}
+
+/// Stable label naming one catalog rejection, so every adapter reports the
+/// same outcome vocabulary on its spans.
+pub(crate) const fn error_label(error: &RevisionCatalogError) -> &'static str {
+    match *error {
+        RevisionCatalogError::PlanUnavailable { .. } => "plan_unavailable",
+        RevisionCatalogError::WorkerFlavorUnavailable { .. } => "worker_flavor_unavailable",
+        RevisionCatalogError::PlanFlavorMismatch { .. } => "plan_flavor_mismatch",
+        RevisionCatalogError::ContentConflict { .. } => "content_conflict",
+        RevisionCatalogError::Draining { .. } => "draining",
+        RevisionCatalogError::Deleted { .. } => "deleted",
+        RevisionCatalogError::DrainRequired { .. } => "drain_required",
+        RevisionCatalogError::Referenced { .. } => "referenced",
+        RevisionCatalogError::DependentPlans { .. } => "dependent_plans",
+        RevisionCatalogError::EmptyRecord => "empty_record",
+        RevisionCatalogError::UnsupportedRecordFormat { .. } => "unsupported_record_format",
+        RevisionCatalogError::CorruptRecord { .. } => "corrupt_record",
+        RevisionCatalogError::Unavailable => "unavailable",
+        RevisionCatalogError::OutcomeUnknown => "outcome_unknown",
+        // The port marks this error `#[non_exhaustive]`, so a wildcard is
+        // required. A label that names the gap is better than folding an
+        // unrecognised rejection into a neighbouring bucket, where it would
+        // read on a dashboard as a rejection this build understands.
+        _ => "unclassified",
+    }
+}
+
+/// Stable outcome label for one insert attempt.
+pub(crate) const fn insert_label(
+    result: &Result<RevisionInsertOutcome, RevisionCatalogError>,
+) -> &'static str {
+    match *result {
+        Ok(RevisionInsertOutcome::Inserted) => "inserted",
+        Ok(RevisionInsertOutcome::AlreadyPresent) => "already_present",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Stable outcome label for one drain attempt.
+pub(crate) const fn drain_label(
+    result: &Result<BeginDrainOutcome, RevisionCatalogError>,
+) -> &'static str {
+    match *result {
+        Ok(BeginDrainOutcome::Started(_)) => "started",
+        Ok(BeginDrainOutcome::AlreadyDraining(_)) => "already_draining",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Stable outcome label for one exact load.
+pub(crate) const fn load_label(
+    result: &Result<PlanFlavorRevisionRecord, RevisionCatalogError>,
+) -> &'static str {
+    match *result {
+        Ok(_) => "loaded",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Stable outcome label for one guarded delete.
+pub(crate) const fn delete_label(result: &Result<(), RevisionCatalogError>) -> &'static str {
+    match *result {
+        Ok(()) => "deleted",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Reject bytes that do not satisfy the contract of their recorded form.
+///
+/// Both recorded forms this catalog admits are JSON documents, so a body that
+/// does not parse is durable corruption rather than an opaque payload storage
+/// merely relays. Checking it on the way in keeps a caller from persisting a
+/// record that only fails when a later exact load needs it; checking it on the
+/// way out keeps a byte-level poke at the table from being handed to a plugin
+/// layer as if it were a valid record.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::CorruptRecord`] when `bytes` is not a
+/// well-formed JSON document.
+pub(crate) fn validate_recorded_form(
+    bytes: &[u8],
+    target: PlanFlavorRevisionTarget,
+) -> Result<(), RevisionCatalogError> {
+    serde_json::from_slice::<serde::de::IgnoredAny>(bytes)
+        .map(|_ignored| ())
+        .map_err(|_parse| RevisionCatalogError::CorruptRecord { target })
+}
+
+/// Reject a whole pair whose bytes violate their recorded form.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::CorruptRecord`] naming the first identity
+/// whose body is not a well-formed JSON document.
+pub(crate) fn validate_pair_recorded_form(
+    record: &PlanFlavorRevisionRecord,
+) -> Result<(), RevisionCatalogError> {
+    let ids = record.ids();
+    validate_recorded_form(
+        record.plan_bytes(),
+        PlanFlavorRevisionTarget::ExecutablePlan(ids.plan()),
+    )?;
+    validate_recorded_form(
+        record.worker_flavor().bytes(),
+        PlanFlavorRevisionTarget::WorkerFlavor(ids.worker_flavor()),
+    )
+}
+
+/// Return the `…Unavailable` variant that matches `target`'s kind.
+pub(crate) fn unavailable_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
+    match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => {
+            RevisionCatalogError::PlanUnavailable { plan_id }
+        },
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => {
+            RevisionCatalogError::WorkerFlavorUnavailable { worker_flavor_id }
+        },
+    }
+}
+
+/// Return the deletion tombstone rejection for `target`.
+pub(crate) const fn deleted_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
+    RevisionCatalogError::Deleted { target }
+}
+
+/// Return the drain rejection for `target`.
+pub(crate) const fn draining_for(target: PlanFlavorRevisionTarget) -> RevisionCatalogError {
+    RevisionCatalogError::Draining { target }
+}
+
+/// One decoded durable worker-flavor row.
+///
+/// Only the SQL backends decode durable rows; the in-memory reference model
+/// holds records directly.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredWorkerFlavor {
+    /// Durable lifecycle of the immutable identity.
+    pub(crate) lifecycle: ArtifactLifecycle,
+    /// Payload, absent exactly when the identity is a tombstone.
+    pub(crate) record: Option<WorkerFlavorRevisionRecord>,
+}
+
+/// One decoded durable executable-plan row.
+///
+/// The durable plan row pins its worker flavor by identifier and stores only
+/// its own bytes; the paired flavor record is composed from the flavor row so
+/// the pair has exactly one durable copy of each payload.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredExecutablePlan {
+    /// Durable lifecycle of the immutable identity.
+    pub(crate) lifecycle: ArtifactLifecycle,
+    /// Worker flavor this immutable plan is pinned to.
+    pub(crate) worker_flavor_id: WorkerFlavorRevisionId,
+    /// Payload, absent exactly when the identity is a tombstone.
+    pub(crate) plan_bytes: Option<RevisionRecordBytes>,
+}
+
+/// Interpret a durable 32-byte revision identifier column.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::CorruptRecord`] when the column is not
+/// exactly 32 bytes wide.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+fn revision_id_bytes(
+    column: Vec<u8>,
+    target: PlanFlavorRevisionTarget,
+) -> Result<[u8; 32], RevisionCatalogError> {
+    <[u8; 32]>::try_from(column).map_err(|_width| RevisionCatalogError::CorruptRecord { target })
+}
+
+/// Interpret a durable worker-flavor row.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::UnsupportedRecordFormat`] when the durable
+/// format names a recorded form this build cannot read, and
+/// [`RevisionCatalogError::CorruptRecord`] when lifecycle text is unknown or
+/// payload presence contradicts the lifecycle.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) fn decode_worker_flavor_row(
+    worker_flavor_id: WorkerFlavorRevisionId,
+    lifecycle: &str,
+    record_format: &str,
+    record_bytes: Option<Vec<u8>>,
+) -> Result<StoredWorkerFlavor, RevisionCatalogError> {
+    let target = PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id);
+    let lifecycle = ArtifactLifecycle::from_text(lifecycle)
+        .ok_or(RevisionCatalogError::CorruptRecord { target })?;
+    if record_format != WORKER_FLAVOR_V1_JSON {
+        return Err(RevisionCatalogError::UnsupportedRecordFormat { target });
+    }
+
+    let record = match (lifecycle, record_bytes) {
+        (ArtifactLifecycle::Deleted, None) => None,
+        (ArtifactLifecycle::Deleted, Some(_)) | (_, None) => {
+            return Err(RevisionCatalogError::CorruptRecord { target });
+        },
+        (ArtifactLifecycle::Active | ArtifactLifecycle::Draining, Some(payload)) => {
+            validate_recorded_form(&payload, target)?;
+            let bytes = RevisionRecordBytes::try_from_vec(payload)
+                .map_err(|_empty| RevisionCatalogError::CorruptRecord { target })?;
+            Some(WorkerFlavorRevisionRecord::v1_json(worker_flavor_id, bytes))
+        },
+    };
+
+    Ok(StoredWorkerFlavor { lifecycle, record })
+}
+
+/// Interpret a durable executable-plan row.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::UnsupportedRecordFormat`] when the durable
+/// format names a recorded form this build cannot read, and
+/// [`RevisionCatalogError::CorruptRecord`] when lifecycle text is unknown, the
+/// pinned flavor identifier is malformed, or payload presence contradicts the
+/// lifecycle.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) fn decode_executable_plan_row(
+    plan_id: ExecutablePlanRevisionId,
+    worker_flavor_id: Vec<u8>,
+    lifecycle: &str,
+    record_format: &str,
+    record_bytes: Option<Vec<u8>>,
+) -> Result<StoredExecutablePlan, RevisionCatalogError> {
+    let target = PlanFlavorRevisionTarget::ExecutablePlan(plan_id);
+    let lifecycle = ArtifactLifecycle::from_text(lifecycle)
+        .ok_or(RevisionCatalogError::CorruptRecord { target })?;
+    if record_format != EXECUTABLE_PLAN_GRAPH_V1_JSON {
+        return Err(RevisionCatalogError::UnsupportedRecordFormat { target });
+    }
+    let worker_flavor_id =
+        WorkerFlavorRevisionId::from_bytes(revision_id_bytes(worker_flavor_id, target)?);
+
+    let plan_bytes = match (lifecycle, record_bytes) {
+        (ArtifactLifecycle::Deleted, None) => None,
+        (ArtifactLifecycle::Deleted, Some(_)) | (_, None) => {
+            return Err(RevisionCatalogError::CorruptRecord { target });
+        },
+        (ArtifactLifecycle::Active | ArtifactLifecycle::Draining, Some(payload)) => {
+            validate_recorded_form(&payload, target)?;
+            Some(
+                RevisionRecordBytes::try_from_vec(payload)
+                    .map_err(|_empty| RevisionCatalogError::CorruptRecord { target })?,
+            )
+        },
+    };
+
+    Ok(StoredExecutablePlan {
+        lifecycle,
+        worker_flavor_id,
+        plan_bytes,
+    })
+}
+
+/// Compose the durable pair from a plan row and the flavor row it pins.
+///
+/// # Errors
+///
+/// Returns [`RevisionCatalogError::CorruptRecord`] when either identity is a
+/// tombstone-shaped row at this point, or when `flavor` is not the row the plan
+/// pins.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
+pub(crate) fn compose_pair(
+    plan_id: ExecutablePlanRevisionId,
+    plan: &StoredExecutablePlan,
+    flavor: &StoredWorkerFlavor,
+) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
+    let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(plan_id);
+    let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(plan.worker_flavor_id);
+
+    let plan_bytes = plan
+        .plan_bytes
+        .clone()
+        .ok_or(RevisionCatalogError::CorruptRecord {
+            target: plan_target,
+        })?;
+    let flavor_record = flavor
+        .record
+        .clone()
+        .ok_or(RevisionCatalogError::CorruptRecord {
+            target: flavor_target,
+        })?;
+    if flavor_record.id() != plan.worker_flavor_id {
+        return Err(RevisionCatalogError::CorruptRecord {
+            target: flavor_target,
+        });
+    }
+
+    Ok(PlanFlavorRevisionRecord::graph_v1_json(
+        plan_id,
+        plan_bytes,
+        flavor_record,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_core::WorkerFlavorRevisionId as TestWorkerFlavorRevisionId;
+
+    use super::*;
+
+    #[test]
+    fn a_body_that_is_not_json_violates_its_recorded_form() {
+        let target = PlanFlavorRevisionTarget::WorkerFlavor(
+            TestWorkerFlavorRevisionId::from_bytes([0x41; 32]),
+        );
+        assert_eq!(
+            validate_recorded_form(b"not json", target),
+            Err(RevisionCatalogError::CorruptRecord { target })
+        );
+        assert_eq!(
+            validate_recorded_form(br#"{"flavor":"v1"}"#, target),
+            Ok(())
+        );
+    }
+}
+
+/// Durable-row decoding is exercised only where a SQL backend exists to
+/// produce those rows.
+#[cfg(all(test, any(feature = "sqlite", feature = "postgres")))]
+mod durable_row_tests {
+    use nebula_storage_port::WorkerFlavorRecordFormat;
+
+    use super::*;
+
+    fn flavor_id() -> WorkerFlavorRevisionId {
+        WorkerFlavorRevisionId::from_bytes([0x41; 32])
+    }
+
+    fn plan_id() -> ExecutablePlanRevisionId {
+        ExecutablePlanRevisionId::from_bytes([0x31; 32])
+    }
+
+    #[test]
+    fn lifecycle_text_round_trips_through_the_durable_vocabulary() {
+        for lifecycle in [
+            ArtifactLifecycle::Active,
+            ArtifactLifecycle::Draining,
+            ArtifactLifecycle::Deleted,
+        ] {
+            assert_eq!(
+                ArtifactLifecycle::from_text(lifecycle.as_str()),
+                Some(lifecycle)
+            );
+        }
+        assert_eq!(ArtifactLifecycle::from_text("retired"), None);
+    }
+
+    #[test]
+    fn decoding_reports_an_unreadable_recorded_form_before_reading_payload() {
+        assert_eq!(
+            decode_worker_flavor_row(flavor_id(), "active", "v2_cbor", Some(b"\x00".to_vec())),
+            Err(RevisionCatalogError::UnsupportedRecordFormat {
+                target: PlanFlavorRevisionTarget::WorkerFlavor(flavor_id()),
+            })
+        );
+    }
+
+    #[test]
+    fn a_tombstone_row_that_still_carries_payload_is_corrupt() {
+        assert_eq!(
+            decode_worker_flavor_row(
+                flavor_id(),
+                "deleted",
+                WORKER_FLAVOR_V1_JSON,
+                Some(br#"{"flavor":"v1"}"#.to_vec()),
+            ),
+            Err(RevisionCatalogError::CorruptRecord {
+                target: PlanFlavorRevisionTarget::WorkerFlavor(flavor_id()),
+            })
+        );
+    }
+
+    #[test]
+    fn a_live_row_decodes_into_its_recorded_form() {
+        let decoded = decode_worker_flavor_row(
+            flavor_id(),
+            "draining",
+            WORKER_FLAVOR_V1_JSON,
+            Some(br#"{"flavor":"v1"}"#.to_vec()),
+        )
+        .expect("a well-formed draining row decodes");
+        assert_eq!(decoded.lifecycle, ArtifactLifecycle::Draining);
+        let record = decoded.record.expect("a draining row retains its payload");
+        assert_eq!(record.format(), WorkerFlavorRecordFormat::V1Json);
+        assert_eq!(record.bytes(), br#"{"flavor":"v1"}"#);
+    }
+
+    #[test]
+    fn a_plan_row_whose_pinned_flavor_column_is_narrow_is_corrupt() {
+        assert_eq!(
+            decode_executable_plan_row(
+                plan_id(),
+                vec![0x41; 16],
+                "active",
+                EXECUTABLE_PLAN_GRAPH_V1_JSON,
+                Some(br#"{"plan":"v1"}"#.to_vec()),
+            ),
+            Err(RevisionCatalogError::CorruptRecord {
+                target: PlanFlavorRevisionTarget::ExecutablePlan(plan_id()),
+            })
+        );
+    }
+
+    #[test]
+    fn composing_a_pair_rejects_a_flavor_row_the_plan_does_not_pin() {
+        let plan = decode_executable_plan_row(
+            plan_id(),
+            vec![0x41; 32],
+            "active",
+            EXECUTABLE_PLAN_GRAPH_V1_JSON,
+            Some(br#"{"plan":"v1"}"#.to_vec()),
+        )
+        .expect("a well-formed plan row decodes");
+        let other_flavor_id = WorkerFlavorRevisionId::from_bytes([0x42; 32]);
+        let flavor = decode_worker_flavor_row(
+            other_flavor_id,
+            "active",
+            WORKER_FLAVOR_V1_JSON,
+            Some(br#"{"flavor":"v1"}"#.to_vec()),
+        )
+        .expect("a well-formed flavor row decodes");
+
+        assert_eq!(
+            compose_pair(plan_id(), &plan, &flavor),
+            Err(RevisionCatalogError::CorruptRecord {
+                target: PlanFlavorRevisionTarget::WorkerFlavor(flavor_id()),
+            })
+        );
+    }
+}

--- a/crates/storage/src/sqlite/mod.rs
+++ b/crates/storage/src/sqlite/mod.rs
@@ -17,6 +17,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
 mod start_acceptance;
@@ -30,6 +31,7 @@ pub use identity::{
     SqliteResourceStore, SqliteTriggerStore, SqliteUserStore, SqliteWorkspaceStore,
 };
 pub use job_dispatch::{SqliteJobDispatchQueue, SqliteTriggerDedupInbox};
+pub use plan_flavor_catalog::SqlitePlanFlavorCatalog;
 pub use resume_producer::SqliteResumeProducer;
 pub use resume_token::SqliteResumeTokenStore;
 pub use start_acceptance::SqliteStartAcceptanceStore;

--- a/crates/storage/src/sqlite/plan_flavor_catalog.rs
+++ b/crates/storage/src/sqlite/plan_flavor_catalog.rs
@@ -26,11 +26,14 @@ use nebula_storage_port::{
 };
 use sqlx::{Row, Sqlite, SqlitePool, Transaction};
 
+use nebula_metrics::revision_catalog_operation;
+
 use crate::revision_catalog::{
-    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, StoredExecutablePlan, StoredWorkerFlavor,
-    WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row, decode_worker_flavor_row,
-    delete_label, deleted_for, drain_label, draining_for, flavor_records_match, insert_label,
-    load_label, plan_content_matches, unavailable_for, validate_pair_recorded_form,
+    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, RevisionCatalogMetrics, StoredExecutablePlan,
+    StoredWorkerFlavor, WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row,
+    decode_worker_flavor_row, delete_label, deleted_for, drain_label, draining_for,
+    flavor_records_match, insert_label, load_label, plan_content_matches, unavailable_for,
+    validate_pair_recorded_form,
 };
 
 /// SQLite-backed exact executable-plan and worker-flavor catalog.
@@ -39,27 +42,47 @@ use crate::revision_catalog::{
 #[derive(Clone, Debug)]
 pub struct SqlitePlanFlavorCatalog {
     pool: SqlitePool,
+    metrics: RevisionCatalogMetrics,
 }
 
 impl SqlitePlanFlavorCatalog {
-    /// Wrap an existing pool. The caller installs the port schema (see
-    /// [`super::init_schema`]).
+    /// Wrap an existing pool and bind catalog counters to a shared registry.
+    ///
+    /// The caller installs the port schema (see [`super::init_schema`]). The
+    /// registry is required rather than optional so a composition root cannot
+    /// wire a deployment backend whose conflict and unknown-outcome counts are
+    /// invisible to a scraper.
     #[must_use]
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+    pub fn new(pool: SqlitePool, metrics: &nebula_metrics::MetricsRegistry) -> Self {
+        Self {
+            pool,
+            metrics: RevisionCatalogMetrics::new(metrics, "sqlite"),
+        }
     }
 
-    /// Open the single-writer transaction every catalog operation runs in.
+    /// Open the single-writer transaction every mutating operation runs in.
     ///
     /// A deferred `BEGIN` takes SQLite's write lock only at the first mutation,
     /// so a read-then-write operation could observe rows another writer
     /// replaces before it upgrades. Taking the lock up front makes the whole
     /// read/decide/write sequence one linearized operation.
-    async fn begin(&self) -> Result<Transaction<'_, Sqlite>, RevisionCatalogError> {
+    async fn begin_write(&self) -> Result<Transaction<'_, Sqlite>, RevisionCatalogError> {
         self.pool
             .begin_with("BEGIN IMMEDIATE")
             .await
             .map_err(driver_did_not_commit)
+    }
+
+    /// Open the deferred transaction an exact load runs in.
+    ///
+    /// SQLite admits one reserved writer at a time, so taking the write lock
+    /// for a read-only path would serialize every concurrent exact load behind
+    /// the database-wide writer and surface as `Unavailable` once the busy
+    /// timeout expired. An exact load decides nothing it then writes, so a
+    /// deferred read transaction gives it a consistent snapshot of the plan and
+    /// flavor rows without blocking or being blocked by other readers.
+    async fn begin_read(&self) -> Result<Transaction<'_, Sqlite>, RevisionCatalogError> {
+        self.pool.begin().await.map_err(driver_did_not_commit)
     }
 }
 
@@ -547,16 +570,28 @@ impl PlanFlavorCatalog for SqlitePlanFlavorCatalog {
         &self,
         ids: PlanFlavorRevisionIds,
     ) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
-        let mut tx = self.begin().await?;
-        let result = load_exact_locked(&mut tx, ids).await;
-        // Nothing was written on this path; the commit only releases the read
-        // transaction, so a failure to release cannot make the outcome unknown.
-        drop(tx.commit().await);
+        // The transaction is opened *inside* the observed body. Returning `?`
+        // from an unreachable pool would otherwise leave the span's `outcome`
+        // empty and emit no event at all, so the one failure that means "this
+        // backend is down" was the one failure nothing recorded.
+        let result = async {
+            let mut tx = self.begin_read().await?;
+            let loaded = load_exact_locked(&mut tx, ids).await;
+            // Nothing was written on this path; the commit only releases the
+            // read transaction, so failing to release cannot make the outcome
+            // unknown.
+            drop(tx.commit().await);
+            loaded
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", load_label(&result));
+        let outcome = load_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::LOAD_EXACT, outcome);
         tracing::debug!(
             target: "nebula_storage::sqlite",
-            outcome = load_label(&result),
+            outcome,
             "exact plan/flavor catalog load"
         );
         result
@@ -580,23 +615,29 @@ impl PlanFlavorCatalogWriter for SqlitePlanFlavorCatalog {
         &self,
         record: &PlanFlavorRevisionRecord,
     ) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
-        let mut tx = self.begin().await?;
-        let result = match insert_locked(&mut tx, record).await {
-            Ok(outcome) => tx
-                .commit()
-                .await
-                .map_err(commit_outcome_unknown)
-                .map(|()| outcome),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin_write().await?;
+            match insert_locked(&mut tx, record).await {
+                Ok(outcome) => tx
+                    .commit()
+                    .await
+                    .map_err(commit_outcome_unknown)
+                    .map(|()| outcome),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", insert_label(&result));
+        let outcome = insert_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::INSERT, outcome);
         tracing::debug!(
             target: "nebula_storage::sqlite",
-            outcome = insert_label(&result),
+            outcome,
             "plan/flavor catalog insert"
         );
         result
@@ -616,23 +657,29 @@ impl PlanFlavorCatalogAdmin for SqlitePlanFlavorCatalog {
         target: PlanFlavorRevisionTarget,
     ) -> Result<BeginDrainOutcome, RevisionCatalogError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        let mut tx = self.begin().await?;
-        let result = match begin_drain_locked(&mut tx, target, now_ms).await {
-            Ok(outcome) => tx
-                .commit()
-                .await
-                .map_err(commit_outcome_unknown)
-                .map(|()| outcome),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin_write().await?;
+            match begin_drain_locked(&mut tx, target, now_ms).await {
+                Ok(outcome) => tx
+                    .commit()
+                    .await
+                    .map_err(commit_outcome_unknown)
+                    .map(|()| outcome),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", drain_label(&result));
+        let outcome = drain_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::BEGIN_DRAIN, outcome);
         tracing::debug!(
             target: "nebula_storage::sqlite",
-            outcome = drain_label(&result),
+            outcome,
             "plan/flavor catalog begin drain"
         );
         result
@@ -649,19 +696,25 @@ impl PlanFlavorCatalogAdmin for SqlitePlanFlavorCatalog {
         target: PlanFlavorRevisionTarget,
     ) -> Result<(), RevisionCatalogError> {
         let now_ms = chrono::Utc::now().timestamp_millis();
-        let mut tx = self.begin().await?;
-        let result = match delete_drained_locked(&mut tx, target, now_ms).await {
-            Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
-            Err(rejection) => {
-                drop(tx.rollback().await);
-                Err(rejection)
-            },
-        };
+        let result = async {
+            let mut tx = self.begin_write().await?;
+            match delete_drained_locked(&mut tx, target, now_ms).await {
+                Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
+                Err(rejection) => {
+                    drop(tx.rollback().await);
+                    Err(rejection)
+                },
+            }
+        }
+        .await;
 
-        tracing::Span::current().record("outcome", delete_label(&result));
+        let outcome = delete_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        self.metrics
+            .record(revision_catalog_operation::DELETE_DRAINED, outcome);
         tracing::debug!(
             target: "nebula_storage::sqlite",
-            outcome = delete_label(&result),
+            outcome,
             "plan/flavor catalog guarded delete"
         );
         result

--- a/crates/storage/src/sqlite/plan_flavor_catalog.rs
+++ b/crates/storage/src/sqlite/plan_flavor_catalog.rs
@@ -1,0 +1,669 @@
+//! SQLite exact plan/flavor catalog over ordered migration 0041.
+//!
+//! Every operation runs inside one `BEGIN IMMEDIATE` transaction, so the
+//! plan row, the flavor row, and the authoritative reference rows are read and
+//! written under the single-writer lock rather than across independent
+//! statements. The pair is therefore inserted atomically, and a drain or a
+//! guarded delete rechecks its blockers in the same linearized operation that
+//! applies the lifecycle change.
+//!
+//! Exact load never selects a latest or closest revision, follows a redirect,
+//! or recompiles a plan: it reads the requested plan identity, rejects a plan
+//! pinned to a different worker flavor, and composes the pair from the pinned
+//! flavor row.
+//!
+//! Driver detail and record bytes never cross the port boundary. A failure
+//! before commit is [`RevisionCatalogError::Unavailable`] (the operation
+//! definitely did not commit); a failed commit is
+//! [`RevisionCatalogError::OutcomeUnknown`], because SQLite cannot tell the
+//! caller whether the write landed.
+
+use nebula_core::{ExecutablePlanRevisionId, WorkerFlavorRevisionId};
+use nebula_storage_port::{
+    BeginDrainOutcome, ExecutablePlanRecordFormat, PlanFlavorCatalog, PlanFlavorCatalogAdmin,
+    PlanFlavorCatalogWriter, PlanFlavorRevisionIds, PlanFlavorRevisionRecord,
+    PlanFlavorRevisionTarget, RevisionCatalogError, RevisionInsertOutcome, RevisionReferenceCounts,
+};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+use crate::revision_catalog::{
+    ArtifactLifecycle, EXECUTABLE_PLAN_GRAPH_V1_JSON, StoredExecutablePlan, StoredWorkerFlavor,
+    WORKER_FLAVOR_V1_JSON, compose_pair, decode_executable_plan_row, decode_worker_flavor_row,
+    delete_label, deleted_for, drain_label, draining_for, flavor_records_match, insert_label,
+    load_label, plan_content_matches, unavailable_for, validate_pair_recorded_form,
+};
+
+/// SQLite-backed exact executable-plan and worker-flavor catalog.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`].
+#[derive(Clone, Debug)]
+pub struct SqlitePlanFlavorCatalog {
+    pool: SqlitePool,
+}
+
+impl SqlitePlanFlavorCatalog {
+    /// Wrap an existing pool. The caller installs the port schema (see
+    /// [`super::init_schema`]).
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Open the single-writer transaction every catalog operation runs in.
+    ///
+    /// A deferred `BEGIN` takes SQLite's write lock only at the first mutation,
+    /// so a read-then-write operation could observe rows another writer
+    /// replaces before it upgrades. Taking the lock up front makes the whole
+    /// read/decide/write sequence one linearized operation.
+    async fn begin(&self) -> Result<Transaction<'_, Sqlite>, RevisionCatalogError> {
+        self.pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(driver_did_not_commit)
+    }
+}
+
+/// A driver failure reached before commit definitely did not commit.
+fn driver_did_not_commit(_error: sqlx::Error) -> RevisionCatalogError {
+    RevisionCatalogError::Unavailable
+}
+
+/// A failed commit leaves the caller unable to prove whether the write landed.
+fn commit_outcome_unknown(_error: sqlx::Error) -> RevisionCatalogError {
+    RevisionCatalogError::OutcomeUnknown
+}
+
+/// Read one durable executable-plan row inside the caller's transaction.
+async fn load_plan_row(
+    tx: &mut Transaction<'_, Sqlite>,
+    plan_id: ExecutablePlanRevisionId,
+) -> Result<Option<StoredExecutablePlan>, RevisionCatalogError> {
+    let row = sqlx::query(
+        "SELECT worker_flavor_id, record_format, lifecycle, record_bytes \
+         FROM port_executable_plan_revisions \
+         WHERE executable_plan_id = ?",
+    )
+    .bind(plan_id.as_bytes().as_slice())
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let target = PlanFlavorRevisionTarget::ExecutablePlan(plan_id);
+    let worker_flavor_id: Vec<u8> = row
+        .try_get("worker_flavor_id")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let record_format: String = row
+        .try_get("record_format")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let lifecycle: String = row
+        .try_get("lifecycle")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let record_bytes: Option<Vec<u8>> = row
+        .try_get("record_bytes")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+
+    decode_executable_plan_row(
+        plan_id,
+        worker_flavor_id,
+        &lifecycle,
+        &record_format,
+        record_bytes,
+    )
+    .map(Some)
+}
+
+/// Read one durable worker-flavor row inside the caller's transaction.
+async fn load_flavor_row(
+    tx: &mut Transaction<'_, Sqlite>,
+    worker_flavor_id: WorkerFlavorRevisionId,
+) -> Result<Option<StoredWorkerFlavor>, RevisionCatalogError> {
+    let row = sqlx::query(
+        "SELECT record_format, lifecycle, record_bytes \
+         FROM port_worker_flavor_revisions \
+         WHERE worker_flavor_id = ?",
+    )
+    .bind(worker_flavor_id.as_bytes().as_slice())
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let target = PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id);
+    let record_format: String = row
+        .try_get("record_format")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let lifecycle: String = row
+        .try_get("lifecycle")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let record_bytes: Option<Vec<u8>> = row
+        .try_get("record_bytes")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+
+    decode_worker_flavor_row(worker_flavor_id, &lifecycle, &record_format, record_bytes).map(Some)
+}
+
+/// Project the authoritative reference rows that block `target`'s deletion.
+///
+/// Counts are always derived from reference rows; the schema carries no
+/// mutable counter that could drift from them. A rollback window whose
+/// deadline has arrived no longer blocks, so equality with `now_ms` is
+/// expired.
+async fn reference_counts(
+    tx: &mut Transaction<'_, Sqlite>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<RevisionReferenceCounts, RevisionCatalogError> {
+    let query = match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+            "SELECT \
+             COALESCE(SUM(CASE WHEN reference_state = 'live' THEN 1 ELSE 0 END), 0) \
+                 AS live_executions, \
+             COALESCE(SUM(CASE WHEN reference_state = 'rollback' AND retain_until_ms > ? \
+                               THEN 1 ELSE 0 END), 0) AS rollback_windows \
+             FROM port_execution_revision_refs WHERE executable_plan_id = ?",
+        )
+        .bind(now_ms)
+        .bind(plan_id.as_bytes().as_slice()),
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+            "SELECT \
+             COALESCE(SUM(CASE WHEN reference_state = 'live' THEN 1 ELSE 0 END), 0) \
+                 AS live_executions, \
+             COALESCE(SUM(CASE WHEN reference_state = 'rollback' AND retain_until_ms > ? \
+                               THEN 1 ELSE 0 END), 0) AS rollback_windows \
+             FROM port_execution_revision_refs WHERE worker_flavor_id = ?",
+        )
+        .bind(now_ms)
+        .bind(worker_flavor_id.as_bytes().as_slice()),
+    };
+
+    let row = query
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    let live_executions: i64 = row
+        .try_get("live_executions")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    let rollback_windows: i64 = row
+        .try_get("rollback_windows")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+
+    Ok(RevisionReferenceCounts::new(
+        u64::try_from(live_executions).unwrap_or_default(),
+        u64::try_from(rollback_windows).unwrap_or_default(),
+    ))
+}
+
+/// Read the durable lifecycle of one immutable identity, if it exists.
+async fn lifecycle_of(
+    tx: &mut Transaction<'_, Sqlite>,
+    target: PlanFlavorRevisionTarget,
+) -> Result<Option<ArtifactLifecycle>, RevisionCatalogError> {
+    let query = match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+            "SELECT lifecycle FROM port_executable_plan_revisions WHERE executable_plan_id = ?",
+        )
+        .bind(plan_id.as_bytes().as_slice()),
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+            "SELECT lifecycle FROM port_worker_flavor_revisions WHERE worker_flavor_id = ?",
+        )
+        .bind(worker_flavor_id.as_bytes().as_slice()),
+    };
+
+    let Some(row) = query
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?
+    else {
+        return Ok(None);
+    };
+    let lifecycle: String = row
+        .try_get("lifecycle")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    ArtifactLifecycle::from_text(&lifecycle)
+        .ok_or(RevisionCatalogError::CorruptRecord { target })
+        .map(Some)
+}
+
+/// Whether one tombstoned identity has had its payload bytes cleared.
+async fn payload_is_cleared(
+    tx: &mut Transaction<'_, Sqlite>,
+    target: PlanFlavorRevisionTarget,
+) -> Result<bool, RevisionCatalogError> {
+    let query = match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+            "SELECT record_bytes IS NULL AS cleared FROM port_executable_plan_revisions \
+             WHERE executable_plan_id = ?",
+        )
+        .bind(plan_id.as_bytes().as_slice()),
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+            "SELECT record_bytes IS NULL AS cleared FROM port_worker_flavor_revisions \
+             WHERE worker_flavor_id = ?",
+        )
+        .bind(worker_flavor_id.as_bytes().as_slice()),
+    };
+
+    let Some(row) = query
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?
+    else {
+        return Ok(false);
+    };
+    let cleared: i64 = row
+        .try_get("cleared")
+        .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+    Ok(cleared != 0)
+}
+
+async fn insert_locked(
+    tx: &mut Transaction<'_, Sqlite>,
+    record: &PlanFlavorRevisionRecord,
+) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
+    validate_pair_recorded_form(record)?;
+
+    let ids = record.ids();
+    let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(ids.plan());
+    let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(ids.worker_flavor());
+
+    let stored_plan = load_plan_row(tx, ids.plan()).await?;
+    let stored_flavor = load_flavor_row(tx, ids.worker_flavor()).await?;
+
+    let existing_plan_matches = match stored_plan.as_ref() {
+        None => false,
+        Some(plan) if plan.lifecycle == ArtifactLifecycle::Deleted => {
+            return Err(deleted_for(plan_target));
+        },
+        Some(plan) => {
+            let stored_bytes =
+                plan.plan_bytes
+                    .as_ref()
+                    .ok_or(RevisionCatalogError::CorruptRecord {
+                        target: plan_target,
+                    })?;
+            if plan_content_matches(
+                PlanFlavorRevisionIds::new(ids.plan(), plan.worker_flavor_id),
+                ExecutablePlanRecordFormat::GraphV1Json,
+                stored_bytes.as_bytes(),
+                record,
+            ) {
+                true
+            } else {
+                return Err(RevisionCatalogError::ContentConflict {
+                    target: plan_target,
+                });
+            }
+        },
+    };
+
+    let existing_flavor_matches = match stored_flavor.as_ref() {
+        None => false,
+        Some(flavor) if flavor.lifecycle == ArtifactLifecycle::Deleted => {
+            return Err(deleted_for(flavor_target));
+        },
+        Some(flavor) => {
+            let stored_record =
+                flavor
+                    .record
+                    .as_ref()
+                    .ok_or(RevisionCatalogError::CorruptRecord {
+                        target: flavor_target,
+                    })?;
+            if flavor_records_match(stored_record, record.worker_flavor()) {
+                true
+            } else {
+                return Err(RevisionCatalogError::ContentConflict {
+                    target: flavor_target,
+                });
+            }
+        },
+    };
+
+    // A plan whose pinned flavor row is absent is durable corruption, not an
+    // insert this call may heal by writing the flavor half underneath it.
+    if existing_plan_matches && !existing_flavor_matches {
+        return Err(RevisionCatalogError::CorruptRecord {
+            target: flavor_target,
+        });
+    }
+
+    // Draining is a property of the stored artifact, not of whether this
+    // caller happens to have inserted this pair before, so an idempotent retry
+    // learns that the revision is being retired.
+    if stored_plan
+        .as_ref()
+        .is_some_and(|plan| plan.lifecycle == ArtifactLifecycle::Draining)
+    {
+        return Err(draining_for(plan_target));
+    }
+    if stored_flavor
+        .as_ref()
+        .is_some_and(|flavor| flavor.lifecycle == ArtifactLifecycle::Draining)
+    {
+        return Err(draining_for(flavor_target));
+    }
+
+    if existing_plan_matches && existing_flavor_matches {
+        return Ok(RevisionInsertOutcome::AlreadyPresent);
+    }
+
+    // The plan row's foreign key requires its flavor row to exist first.
+    if !existing_flavor_matches {
+        sqlx::query(
+            "INSERT INTO port_worker_flavor_revisions \
+             (worker_flavor_id, record_format, lifecycle, record_bytes) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(ids.worker_flavor().as_bytes().as_slice())
+        .bind(WORKER_FLAVOR_V1_JSON)
+        .bind(ArtifactLifecycle::Active.as_str())
+        .bind(record.worker_flavor().bytes())
+        .execute(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    }
+    if !existing_plan_matches {
+        sqlx::query(
+            "INSERT INTO port_executable_plan_revisions \
+             (executable_plan_id, worker_flavor_id, record_format, lifecycle, record_bytes) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(ids.plan().as_bytes().as_slice())
+        .bind(ids.worker_flavor().as_bytes().as_slice())
+        .bind(EXECUTABLE_PLAN_GRAPH_V1_JSON)
+        .bind(ArtifactLifecycle::Active.as_str())
+        .bind(record.plan_bytes())
+        .execute(&mut **tx)
+        .await
+        .map_err(driver_did_not_commit)?;
+    }
+
+    Ok(RevisionInsertOutcome::Inserted)
+}
+
+async fn load_exact_locked(
+    tx: &mut Transaction<'_, Sqlite>,
+    ids: PlanFlavorRevisionIds,
+) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
+    let plan_target = PlanFlavorRevisionTarget::ExecutablePlan(ids.plan());
+
+    let plan = load_plan_row(tx, ids.plan())
+        .await?
+        .ok_or_else(|| unavailable_for(plan_target))?;
+    if plan.lifecycle == ArtifactLifecycle::Deleted {
+        return Err(deleted_for(plan_target));
+    }
+    if plan.worker_flavor_id != ids.worker_flavor() {
+        return Err(RevisionCatalogError::PlanFlavorMismatch {
+            requested: ids,
+            stored_worker_flavor_id: plan.worker_flavor_id,
+        });
+    }
+
+    let flavor_target = PlanFlavorRevisionTarget::WorkerFlavor(plan.worker_flavor_id);
+    let flavor = load_flavor_row(tx, plan.worker_flavor_id)
+        .await?
+        .ok_or_else(|| unavailable_for(flavor_target))?;
+    if flavor.lifecycle == ArtifactLifecycle::Deleted {
+        return Err(deleted_for(flavor_target));
+    }
+
+    compose_pair(ids.plan(), &plan, &flavor)
+}
+
+async fn begin_drain_locked(
+    tx: &mut Transaction<'_, Sqlite>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<BeginDrainOutcome, RevisionCatalogError> {
+    let lifecycle = lifecycle_of(tx, target)
+        .await?
+        .ok_or_else(|| unavailable_for(target))?;
+
+    match lifecycle {
+        ArtifactLifecycle::Active => {
+            let updated = match target {
+                PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => sqlx::query(
+                    "UPDATE port_executable_plan_revisions SET lifecycle = 'draining' \
+                     WHERE executable_plan_id = ? AND lifecycle = 'active'",
+                )
+                .bind(plan_id.as_bytes().as_slice()),
+                PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => sqlx::query(
+                    "UPDATE port_worker_flavor_revisions SET lifecycle = 'draining' \
+                     WHERE worker_flavor_id = ? AND lifecycle = 'active'",
+                )
+                .bind(worker_flavor_id.as_bytes().as_slice()),
+            }
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?
+            .rows_affected();
+            if updated != 1 {
+                // The row was read as Active under this transaction's write
+                // lock, so no concurrent writer can have moved it.
+                return Err(RevisionCatalogError::CorruptRecord { target });
+            }
+            Ok(BeginDrainOutcome::Started(
+                reference_counts(tx, target, now_ms).await?,
+            ))
+        },
+        ArtifactLifecycle::Draining => Ok(BeginDrainOutcome::AlreadyDraining(
+            reference_counts(tx, target, now_ms).await?,
+        )),
+        ArtifactLifecycle::Deleted => Err(deleted_for(target)),
+    }
+}
+
+async fn delete_drained_locked(
+    tx: &mut Transaction<'_, Sqlite>,
+    target: PlanFlavorRevisionTarget,
+    now_ms: i64,
+) -> Result<(), RevisionCatalogError> {
+    let lifecycle = lifecycle_of(tx, target)
+        .await?
+        .ok_or_else(|| unavailable_for(target))?;
+
+    match lifecycle {
+        ArtifactLifecycle::Active => return Err(RevisionCatalogError::DrainRequired { target }),
+        ArtifactLifecycle::Deleted => {
+            // Repeating a delete against its own tombstone succeeds, so a
+            // caller whose acknowledgement was lost can reconcile the commit.
+            return if payload_is_cleared(tx, target).await? {
+                Ok(())
+            } else {
+                Err(RevisionCatalogError::CorruptRecord { target })
+            };
+        },
+        ArtifactLifecycle::Draining => {},
+    }
+
+    let references = reference_counts(tx, target, now_ms).await?;
+    if !references.is_empty() {
+        return Err(RevisionCatalogError::Referenced { target, references });
+    }
+
+    match target {
+        PlanFlavorRevisionTarget::ExecutablePlan(plan_id) => {
+            sqlx::query(
+                "UPDATE port_executable_plan_revisions \
+                 SET lifecycle = 'deleted', record_bytes = NULL \
+                 WHERE executable_plan_id = ?",
+            )
+            .bind(plan_id.as_bytes().as_slice())
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?;
+        },
+        PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id) => {
+            let dependent_plans: i64 = sqlx::query(
+                "SELECT COUNT(*) AS dependent_plans FROM port_executable_plan_revisions \
+                 WHERE worker_flavor_id = ? AND lifecycle <> 'deleted'",
+            )
+            .bind(worker_flavor_id.as_bytes().as_slice())
+            .fetch_one(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?
+            .try_get("dependent_plans")
+            .map_err(|_column| RevisionCatalogError::CorruptRecord { target })?;
+            if dependent_plans != 0 {
+                return Err(RevisionCatalogError::DependentPlans {
+                    worker_flavor_id,
+                    dependent_plans: u64::try_from(dependent_plans).unwrap_or_default(),
+                });
+            }
+            sqlx::query(
+                "UPDATE port_worker_flavor_revisions \
+                 SET lifecycle = 'deleted', record_bytes = NULL \
+                 WHERE worker_flavor_id = ?",
+            )
+            .bind(worker_flavor_id.as_bytes().as_slice())
+            .execute(&mut **tx)
+            .await
+            .map_err(driver_did_not_commit)?;
+        },
+    }
+
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalog for SqlitePlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.load_exact",
+        skip(self),
+        fields(
+            backend = "sqlite",
+            plan_revision_id = %ids.plan(),
+            worker_flavor_revision_id = %ids.worker_flavor(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn load_exact(
+        &self,
+        ids: PlanFlavorRevisionIds,
+    ) -> Result<PlanFlavorRevisionRecord, RevisionCatalogError> {
+        let mut tx = self.begin().await?;
+        let result = load_exact_locked(&mut tx, ids).await;
+        // Nothing was written on this path; the commit only releases the read
+        // transaction, so a failure to release cannot make the outcome unknown.
+        drop(tx.commit().await);
+
+        tracing::Span::current().record("outcome", load_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = load_label(&result),
+            "exact plan/flavor catalog load"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalogWriter for SqlitePlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.insert",
+        skip(self, record),
+        fields(
+            backend = "sqlite",
+            plan_revision_id = %record.ids().plan(),
+            worker_flavor_revision_id = %record.ids().worker_flavor(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn insert(
+        &self,
+        record: &PlanFlavorRevisionRecord,
+    ) -> Result<RevisionInsertOutcome, RevisionCatalogError> {
+        let mut tx = self.begin().await?;
+        let result = match insert_locked(&mut tx, record).await {
+            Ok(outcome) => tx
+                .commit()
+                .await
+                .map_err(commit_outcome_unknown)
+                .map(|()| outcome),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", insert_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = insert_label(&result),
+            "plan/flavor catalog insert"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl PlanFlavorCatalogAdmin for SqlitePlanFlavorCatalog {
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.begin_drain",
+        skip(self),
+        fields(backend = "sqlite", target = ?target, outcome = tracing::field::Empty)
+    )]
+    async fn begin_drain(
+        &self,
+        target: PlanFlavorRevisionTarget,
+    ) -> Result<BeginDrainOutcome, RevisionCatalogError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut tx = self.begin().await?;
+        let result = match begin_drain_locked(&mut tx, target, now_ms).await {
+            Ok(outcome) => tx
+                .commit()
+                .await
+                .map_err(commit_outcome_unknown)
+                .map(|()| outcome),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", drain_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = drain_label(&result),
+            "plan/flavor catalog begin drain"
+        );
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "revision_catalog.delete_drained",
+        skip(self),
+        fields(backend = "sqlite", target = ?target, outcome = tracing::field::Empty)
+    )]
+    async fn delete_drained(
+        &self,
+        target: PlanFlavorRevisionTarget,
+    ) -> Result<(), RevisionCatalogError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut tx = self.begin().await?;
+        let result = match delete_drained_locked(&mut tx, target, now_ms).await {
+            Ok(()) => tx.commit().await.map_err(commit_outcome_unknown),
+            Err(rejection) => {
+                drop(tx.rollback().await);
+                Err(rejection)
+            },
+        };
+
+        tracing::Span::current().record("outcome", delete_label(&result));
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = delete_label(&result),
+            "plan/flavor catalog guarded delete"
+        );
+        result
+    }
+}

--- a/crates/storage/tests/revision_catalog_conformance_inmem.rs
+++ b/crates/storage/tests/revision_catalog_conformance_inmem.rs
@@ -1,0 +1,24 @@
+//! Exact plan/flavor catalog conformance for the in-memory reference model.
+//!
+//! The in-memory adapter is the reference/conformance backend — it is never a
+//! deployment target. Running the shared oracle against it keeps the reference
+//! model and the two SQL deployment backends answering identically; a
+//! divergence shows up as the same named case failing on one of the three.
+
+#[macro_use]
+#[path = "support/revision_catalog_oracle.rs"]
+mod oracle;
+
+use nebula_storage::inmem::{InMemoryExecutionStore, InMemoryPlanFlavorCatalog};
+
+/// A catalog over its own empty execution store.
+///
+/// The catalog holds the store's shared state, so the store value itself does
+/// not need to outlive this call.
+async fn catalog() -> Option<InMemoryPlanFlavorCatalog> {
+    Some(InMemoryPlanFlavorCatalog::new(
+        &InMemoryExecutionStore::new(),
+    ))
+}
+
+revision_catalog_conformance_suite!(catalog());

--- a/crates/storage/tests/revision_catalog_conformance_postgres.rs
+++ b/crates/storage/tests/revision_catalog_conformance_postgres.rs
@@ -26,6 +26,16 @@ use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use tokio::sync::OnceCell;
 
+/// A private metrics registry for this backend under test.
+///
+/// Production wiring threads the process-shared registry so a scraper observes
+/// the catalog's conflict and unknown-outcome counts; a conformance run only
+/// needs the counters to be bindable, and a private registry keeps concurrent
+/// cases from sharing series.
+fn registry() -> nebula_metrics::MetricsRegistry {
+    nebula_metrics::MetricsRegistry::new()
+}
+
 static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
 
 /// Connect to `DATABASE_URL` and apply the ordered migration catalog, or report
@@ -64,7 +74,9 @@ async fn pool() -> Option<PgPool> {
 }
 
 async fn catalog() -> Option<PgPlanFlavorCatalog> {
-    pool().await.map(PgPlanFlavorCatalog::new)
+    pool()
+        .await
+        .map(|pool| PgPlanFlavorCatalog::new(pool, &registry()))
 }
 
 revision_catalog_conformance_suite!(catalog());
@@ -82,7 +94,7 @@ async fn a_durably_corrupted_plan_body_is_reported_as_corruption() {
         eprintln!("PostgreSQL unreachable in this environment");
         return;
     };
-    let catalog = PgPlanFlavorCatalog::new(pool.clone());
+    let catalog = PgPlanFlavorCatalog::new(pool.clone(), &registry());
     let record = oracle::pair(0x40, 0, "v1");
     assert_eq!(
         catalog.insert(&record).await,
@@ -115,7 +127,7 @@ async fn the_schema_refuses_a_record_format_the_catalog_cannot_read() {
         eprintln!("PostgreSQL unreachable in this environment");
         return;
     };
-    let catalog = PgPlanFlavorCatalog::new(pool.clone());
+    let catalog = PgPlanFlavorCatalog::new(pool.clone(), &registry());
     let record = oracle::pair(0x41, 0, "v1");
     assert_eq!(
         catalog.insert(&record).await,

--- a/crates/storage/tests/revision_catalog_conformance_postgres.rs
+++ b/crates/storage/tests/revision_catalog_conformance_postgres.rs
@@ -1,0 +1,141 @@
+//! Exact plan/flavor catalog conformance for the PostgreSQL deployment backend.
+//!
+//! PostgreSQL is a deployment backend, so its absence is a job failure, never a
+//! silent substitution by SQLite or the in-memory reference model. With
+//! `NEBULA_REQUIRE_POSTGRES=1` and no `DATABASE_URL`, every case fails; without
+//! that variable a developer without a database sees the cases report that the
+//! backend was unreachable and assert nothing.
+//!
+//! Run locally via:
+//!   DATABASE_URL=postgres://... cargo nextest run \
+//!     -p nebula-storage --features postgres \
+//!     --test revision_catalog_conformance_postgres
+
+#![cfg(feature = "postgres")]
+
+#[macro_use]
+#[path = "support/revision_catalog_oracle.rs"]
+mod oracle;
+
+use nebula_storage::postgres::{PgPlanFlavorCatalog, init_schema};
+use nebula_storage_port::{
+    PlanFlavorCatalog, PlanFlavorCatalogWriter, PlanFlavorRevisionTarget, RevisionCatalogError,
+    RevisionInsertOutcome,
+};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tokio::sync::OnceCell;
+
+static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
+
+/// Connect to `DATABASE_URL` and apply the ordered migration catalog, or report
+/// that PostgreSQL is unreachable.
+///
+/// The oracle folds a per-process namespace into every identity, so cases share
+/// one database without meeting an earlier run's immutable revisions.
+async fn pool() -> Option<PgPool> {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(std::env::VarError::NotPresent) => {
+            assert_ne!(
+                std::env::var("NEBULA_REQUIRE_POSTGRES").as_deref(),
+                Ok("1"),
+                "DATABASE_URL must be set when NEBULA_REQUIRE_POSTGRES=1: \
+                 PostgreSQL is a deployment backend and is never substituted"
+            );
+            return None;
+        },
+        Err(error) => panic!("DATABASE_URL is set but invalid: {error}"),
+    };
+
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+    SCHEMA_READY
+        .get_or_init(|| async {
+            init_schema(&pool)
+                .await
+                .expect("apply the ordered PostgreSQL migration catalog");
+        })
+        .await;
+    Some(pool)
+}
+
+async fn catalog() -> Option<PgPlanFlavorCatalog> {
+    pool().await.map(PgPlanFlavorCatalog::new)
+}
+
+revision_catalog_conformance_suite!(catalog());
+
+/// A durable plan body that no longer satisfies its recorded form is reported
+/// as corruption, not handed to the plugin layer as if it were a record.
+///
+/// Migration 0041 constrains identifier width, lifecycle vocabulary, format
+/// text, and payload presence, but a `record_format` of `graph_v1_json` cannot
+/// be checked against the bytes by SQL. That last invariant is the adapter's,
+/// and this proves it holds against a real byte-level poke.
+#[tokio::test]
+async fn a_durably_corrupted_plan_body_is_reported_as_corruption() {
+    let Some(pool) = pool().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let catalog = PgPlanFlavorCatalog::new(pool.clone());
+    let record = oracle::pair(0x40, 0, "v1");
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::Inserted)
+    );
+
+    sqlx::query(
+        "UPDATE port_executable_plan_revisions SET record_bytes = $1 \
+         WHERE executable_plan_id = $2",
+    )
+    .bind(b"not a graph-v1 json document".as_slice())
+    .bind(record.ids().plan().as_bytes().as_slice())
+    .execute(&pool)
+    .await
+    .expect("poke the durable plan payload");
+
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Err(RevisionCatalogError::CorruptRecord {
+            target: PlanFlavorRevisionTarget::ExecutablePlan(record.ids().plan()),
+        })
+    );
+}
+
+/// A durable `record_format` naming a recorded form this build cannot read is
+/// refused by the schema, so the catalog never has to decode one.
+#[tokio::test]
+async fn the_schema_refuses_a_record_format_the_catalog_cannot_read() {
+    let Some(pool) = pool().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let catalog = PgPlanFlavorCatalog::new(pool.clone());
+    let record = oracle::pair(0x41, 0, "v1");
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::Inserted)
+    );
+
+    let rejected = sqlx::query(
+        "UPDATE port_worker_flavor_revisions SET record_format = 'v2_cbor' \
+         WHERE worker_flavor_id = $1",
+    )
+    .bind(record.ids().worker_flavor().as_bytes().as_slice())
+    .execute(&pool)
+    .await;
+    assert!(
+        rejected.is_err(),
+        "migration 0041 must refuse a recorded form outside the closed vocabulary"
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "a refused poke leaves the durable record readable"
+    );
+}

--- a/crates/storage/tests/revision_catalog_conformance_sqlite.rs
+++ b/crates/storage/tests/revision_catalog_conformance_sqlite.rs
@@ -19,11 +19,21 @@ use std::str::FromStr;
 
 use nebula_storage::sqlite::{SqlitePlanFlavorCatalog, init_schema};
 use nebula_storage_port::{
-    PlanFlavorCatalog, PlanFlavorCatalogWriter, PlanFlavorRevisionTarget, RevisionCatalogError,
-    RevisionInsertOutcome,
+    PlanFlavorCatalog, PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter, PlanFlavorRevisionTarget,
+    RevisionCatalogError, RevisionInsertOutcome,
 };
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+/// A private metrics registry for this backend under test.
+///
+/// Production wiring threads the process-shared registry so a scraper observes
+/// the catalog's conflict and unknown-outcome counts; a conformance run only
+/// needs the counters to be bindable, and a private registry keeps concurrent
+/// cases from sharing series.
+fn registry() -> nebula_metrics::MetricsRegistry {
+    nebula_metrics::MetricsRegistry::new()
+}
 
 /// An isolated in-memory database with the ordered migration catalog applied.
 ///
@@ -47,7 +57,29 @@ async fn fresh_pool() -> SqlitePool {
 }
 
 async fn catalog() -> Option<SqlitePlanFlavorCatalog> {
-    Some(SqlitePlanFlavorCatalog::new(fresh_pool().await))
+    Some(SqlitePlanFlavorCatalog::new(
+        fresh_pool().await,
+        &registry(),
+    ))
+}
+
+/// Read back one catalog outcome series.
+///
+/// The registry hands out the same counter for the same name and label set, so
+/// rebuilding the labels reads exactly the series the adapter incremented.
+fn counted(metrics: &nebula_metrics::MetricsRegistry, operation: &str, outcome: &str) -> u64 {
+    let labels = metrics.interner().label_set(&[
+        ("backend", "sqlite"),
+        ("operation", operation),
+        ("outcome", outcome),
+    ]);
+    metrics
+        .counter_labeled(
+            nebula_metrics::NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL,
+            &labels,
+        )
+        .expect("the catalog counter registers")
+        .get()
 }
 
 revision_catalog_conformance_suite!(catalog());
@@ -62,7 +94,7 @@ revision_catalog_conformance_suite!(catalog());
 #[tokio::test]
 async fn a_durably_corrupted_plan_body_is_reported_as_corruption() {
     let pool = fresh_pool().await;
-    let catalog = SqlitePlanFlavorCatalog::new(pool.clone());
+    let catalog = SqlitePlanFlavorCatalog::new(pool.clone(), &registry());
     let record = oracle::pair(0x40, 0, "v1");
     assert_eq!(
         catalog.insert(&record).await,
@@ -88,15 +120,15 @@ async fn a_durably_corrupted_plan_body_is_reported_as_corruption() {
 }
 
 /// A durable `record_format` naming a recorded form this build cannot read is
-/// reported as unsupported rather than decoded as if it were the known form.
+/// refused by the schema, so the catalog never has to decode one.
 ///
-/// The table's `CHECK` refuses the unknown format, so this exercises the
-/// adapter's own guard by asserting the schema holds the line and then
-/// verifying the decoder's answer for a database that predates the constraint.
+/// The adapter's own `UnsupportedRecordFormat` guard is covered by the
+/// `decode_worker_flavor_row` unit tests in `crate::revision_catalog`, which
+/// can hand the decoder a row this `CHECK` makes unreachable through SQL.
 #[tokio::test]
 async fn the_schema_refuses_a_record_format_the_catalog_cannot_read() {
     let pool = fresh_pool().await;
-    let catalog = SqlitePlanFlavorCatalog::new(pool.clone());
+    let catalog = SqlitePlanFlavorCatalog::new(pool.clone(), &registry());
     let record = oracle::pair(0x41, 0, "v1");
     assert_eq!(
         catalog.insert(&record).await,
@@ -118,5 +150,59 @@ async fn the_schema_refuses_a_record_format_the_catalog_cannot_read() {
         catalog.load_exact(record.ids()).await,
         Ok(record),
         "a refused poke leaves the durable record readable"
+    );
+}
+
+/// Catalog outcomes reach a scraper, not only a trace sampler.
+///
+/// `content_conflict` is the case that motivates the counter: an immutable
+/// identity reused for different bytes is invisible in a success rate, and a
+/// deployment backend whose only record of it is a sampled span gives an
+/// operator nothing to alert on.
+#[tokio::test]
+async fn catalog_outcomes_are_counted_per_operation_and_outcome() {
+    let metrics = registry();
+    let catalog = SqlitePlanFlavorCatalog::new(fresh_pool().await, &metrics);
+    let record = oracle::pair(0x42, 0, "v1");
+
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::Inserted)
+    );
+    assert_eq!(counted(&metrics, "insert", "inserted"), 1);
+
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::AlreadyPresent)
+    );
+    assert_eq!(counted(&metrics, "insert", "already_present"), 1);
+
+    let conflicting = nebula_storage_port::PlanFlavorRevisionRecord::graph_v1_json(
+        record.ids().plan(),
+        nebula_storage_port::RevisionRecordBytes::try_from_vec(br#"{"plan":"rewritten"}"#.to_vec())
+            .expect("conflict body is non-empty"),
+        record.worker_flavor().clone(),
+    );
+    assert!(catalog.insert(&conflicting).await.is_err());
+    assert_eq!(
+        counted(&metrics, "insert", "content_conflict"),
+        1,
+        "an immutable identity reused for different bytes is alertable on its own"
+    );
+
+    assert!(catalog.load_exact(record.ids()).await.is_ok());
+    assert_eq!(counted(&metrics, "load_exact", "loaded"), 1);
+
+    let target = PlanFlavorRevisionTarget::ExecutablePlan(record.ids().plan());
+    assert!(catalog.begin_drain(target).await.is_ok());
+    assert_eq!(counted(&metrics, "begin_drain", "started"), 1);
+
+    assert_eq!(catalog.delete_drained(target).await, Ok(()));
+    assert_eq!(counted(&metrics, "delete_drained", "deleted"), 1);
+
+    assert_eq!(
+        counted(&metrics, "load_exact", "outcome_unknown"),
+        0,
+        "an outcome that did not happen must not be counted"
     );
 }

--- a/crates/storage/tests/revision_catalog_conformance_sqlite.rs
+++ b/crates/storage/tests/revision_catalog_conformance_sqlite.rs
@@ -1,0 +1,122 @@
+//! Exact plan/flavor catalog conformance for the SQLite deployment backend.
+//!
+//! Every case runs against a fresh in-memory database whose schema comes from
+//! the ordered migration catalog — there is no parallel bootstrap path — so the
+//! adapter is exercised against exactly the `CHECK` constraints and foreign
+//! keys migration 0041 installs.
+//!
+//! The durable-corruption cases below sit outside the shared oracle on purpose:
+//! reaching them means writing bytes the port refuses to write, which only a
+//! backend-specific poke at the table can do.
+
+#![cfg(feature = "sqlite")]
+
+#[macro_use]
+#[path = "support/revision_catalog_oracle.rs"]
+mod oracle;
+
+use std::str::FromStr;
+
+use nebula_storage::sqlite::{SqlitePlanFlavorCatalog, init_schema};
+use nebula_storage_port::{
+    PlanFlavorCatalog, PlanFlavorCatalogWriter, PlanFlavorRevisionTarget, RevisionCatalogError,
+    RevisionInsertOutcome,
+};
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+/// An isolated in-memory database with the ordered migration catalog applied.
+///
+/// The shared cache keeps every pooled connection on the same database; a
+/// private `:memory:` connection would give each one its own empty schema.
+async fn fresh_pool() -> SqlitePool {
+    let database = format!("nebula-catalog-{}", uuid::Uuid::new_v4());
+    let url = format!("sqlite:file:{database}?mode=memory&cache=shared");
+    let options = SqliteConnectOptions::from_str(&url)
+        .expect("in-memory SQLite URL must parse")
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect_with(options)
+        .await
+        .expect("connect to in-memory SQLite");
+    init_schema(&pool)
+        .await
+        .expect("apply the ordered SQLite migration catalog");
+    pool
+}
+
+async fn catalog() -> Option<SqlitePlanFlavorCatalog> {
+    Some(SqlitePlanFlavorCatalog::new(fresh_pool().await))
+}
+
+revision_catalog_conformance_suite!(catalog());
+
+/// A durable plan body that no longer satisfies its recorded form is reported
+/// as corruption, not handed to the plugin layer as if it were a record.
+///
+/// Migration 0041 constrains identifier width, lifecycle vocabulary, format
+/// text, and payload presence, but a `record_format` of `graph_v1_json` cannot
+/// be checked against the bytes by SQL. That last invariant is the adapter's,
+/// and this proves it holds against a real byte-level poke.
+#[tokio::test]
+async fn a_durably_corrupted_plan_body_is_reported_as_corruption() {
+    let pool = fresh_pool().await;
+    let catalog = SqlitePlanFlavorCatalog::new(pool.clone());
+    let record = oracle::pair(0x40, 0, "v1");
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::Inserted)
+    );
+
+    sqlx::query(
+        "UPDATE port_executable_plan_revisions SET record_bytes = ? \
+         WHERE executable_plan_id = ?",
+    )
+    .bind(b"not a graph-v1 json document".as_slice())
+    .bind(record.ids().plan().as_bytes().as_slice())
+    .execute(&pool)
+    .await
+    .expect("poke the durable plan payload");
+
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Err(RevisionCatalogError::CorruptRecord {
+            target: PlanFlavorRevisionTarget::ExecutablePlan(record.ids().plan()),
+        })
+    );
+}
+
+/// A durable `record_format` naming a recorded form this build cannot read is
+/// reported as unsupported rather than decoded as if it were the known form.
+///
+/// The table's `CHECK` refuses the unknown format, so this exercises the
+/// adapter's own guard by asserting the schema holds the line and then
+/// verifying the decoder's answer for a database that predates the constraint.
+#[tokio::test]
+async fn the_schema_refuses_a_record_format_the_catalog_cannot_read() {
+    let pool = fresh_pool().await;
+    let catalog = SqlitePlanFlavorCatalog::new(pool.clone());
+    let record = oracle::pair(0x41, 0, "v1");
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::Inserted)
+    );
+
+    let rejected = sqlx::query(
+        "UPDATE port_worker_flavor_revisions SET record_format = 'v2_cbor' \
+         WHERE worker_flavor_id = ?",
+    )
+    .bind(record.ids().worker_flavor().as_bytes().as_slice())
+    .execute(&pool)
+    .await;
+    assert!(
+        rejected.is_err(),
+        "migration 0041 must refuse a recorded form outside the closed vocabulary"
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "a refused poke leaves the durable record readable"
+    );
+}

--- a/crates/storage/tests/schema_source_authority.rs
+++ b/crates/storage/tests/schema_source_authority.rs
@@ -51,20 +51,43 @@ fn ordered_migrations_are_the_only_embedded_schema_source() {
         !rust_source.contains("include_str!(\"schema.sql\")"),
         "setup must not embed a schema snapshot"
     );
-    for forbidden_sql_catalog_surface in [
-        "SqlitePlanFlavorCatalog",
-        "PgPlanFlavorCatalog",
-        "PostgresPlanFlavorCatalog",
-        "port_worker_flavor_revisions",
-        "port_executable_plan_revisions",
-        "port_execution_revision_refs",
+    // The SQL catalog adapters read and write the 0041 tables, so naming those
+    // tables in Rust source is now expected. What must stay true is that
+    // migration 0041 remains their only schema authority: an adapter that
+    // issued its own DDL would be a second, divergent definition of the same
+    // tables, reachable without the ordered catalog ever running.
+    let catalog_adapters = [
+        source_root.join("sqlite/plan_flavor_catalog.rs"),
+        source_root.join("postgres/plan_flavor_catalog.rs"),
+        source_root.join("revision_catalog.rs"),
+    ];
+    for adapter in &catalog_adapters {
+        let source = fs::read_to_string(adapter).expect("catalog adapter source must be UTF-8");
+        for forbidden_ddl in ["CREATE TABLE", "CREATE INDEX", "ALTER TABLE", "DROP TABLE"] {
+            assert!(
+                !source.contains(forbidden_ddl),
+                "migration 0041 is the only schema authority; found `{forbidden_ddl}` in \
+                 {adapter:?}"
+            );
+        }
+    }
+
+    // Execution-owned revision references are still read-only from production
+    // code: creating or transitioning one has to compose with the execution
+    // aggregate's own transaction, which does not exist yet. Until it does, no
+    // production API may write `port_execution_revision_refs` — otherwise a
+    // reference could outlive, or never reach, the execution that owns it.
+    for reference_mutation in [
+        "INSERT INTO port_execution_revision_refs",
+        "UPDATE port_execution_revision_refs",
+        "DELETE FROM port_execution_revision_refs",
         "activate_execution_revision",
         "persist_execution_revision_ref",
     ] {
         assert!(
-            !rust_source.contains(forbidden_sql_catalog_surface),
-            "0041 is dormant DDL; found SQL catalog adapter or activation surface \
-             `{forbidden_sql_catalog_surface}` in production Rust source"
+            !rust_source.contains(reference_mutation),
+            "revision-reference mutation belongs to the execution-owner transaction; found \
+             `{reference_mutation}` in production Rust source"
         );
     }
 

--- a/crates/storage/tests/support/revision_catalog_oracle.rs
+++ b/crates/storage/tests/support/revision_catalog_oracle.rs
@@ -1,0 +1,586 @@
+//! One shared acceptance oracle for the exact plan/flavor catalog.
+//!
+//! The in-memory reference model, SQLite, and PostgreSQL implement the same
+//! three port roles, so they must answer every catalog question identically.
+//! This module owns those answers once; each backend's test file supplies a
+//! catalog and runs the same cases against it. A behaviour that only one
+//! backend gets right therefore fails somewhere, instead of being a per-file
+//! assertion nobody wrote for the other two.
+//!
+//! Cases are keyed by a distinct seed so they can share one durable store
+//! without colliding — spinning up an isolated PostgreSQL schema and replaying
+//! the whole ordered migration catalog per case would cost minutes.
+//!
+//! ## What this oracle deliberately does not cover
+//!
+//! [`RevisionCatalogError::Referenced`] is unreachable from the port: revision
+//! references can only be created inside an execution-owner transaction, which
+//! is not implemented, so no production API can produce a blocker for the
+//! guarded delete. Reference-blocked deletion is exercised by the in-memory
+//! model's own unit tests through a backend-private driver, and moves here when
+//! the owner transaction lands.
+
+use nebula_core::{ExecutablePlanRevisionId, WorkerFlavorRevisionId};
+use nebula_storage_port::{
+    BeginDrainOutcome, PlanFlavorCatalog, PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter,
+    PlanFlavorRevisionIds, PlanFlavorRevisionRecord, PlanFlavorRevisionTarget,
+    RevisionCatalogError, RevisionInsertOutcome, RevisionRecordBytes, WorkerFlavorRevisionRecord,
+};
+
+/// The three catalog roles one adapter offers together.
+///
+/// Production wiring hands each role out separately — an installer never
+/// receives the admin capability — but a conformance run needs all three to
+/// drive a revision through its whole lifecycle.
+pub(crate) trait ExactRevisionCatalog:
+    PlanFlavorCatalog + PlanFlavorCatalogWriter + PlanFlavorCatalogAdmin
+{
+}
+
+impl<T> ExactRevisionCatalog for T where
+    T: PlanFlavorCatalog + PlanFlavorCatalogWriter + PlanFlavorCatalogAdmin
+{
+}
+
+/// Marker byte distinguishing an executable-plan identity from a flavor one.
+const PLAN_IDENTITY_TAG: u8 = 0x50;
+
+/// Marker byte distinguishing a worker-flavor identity from a plan one.
+const FLAVOR_IDENTITY_TAG: u8 = 0x46;
+
+/// Per-process namespace folded into every identity this oracle builds.
+///
+/// A backend whose durable store outlives the test run — a developer's or CI's
+/// PostgreSQL — would otherwise meet the previous run's immutable identities on
+/// the second run, so an `Inserted` case would report `AlreadyPresent` and a
+/// tombstoned identity would refuse to install at all. A fresh namespace makes
+/// each run independent of what earlier runs left behind.
+static IDENTITY_NAMESPACE: std::sync::LazyLock<[u8; 16]> =
+    std::sync::LazyLock::new(|| uuid::Uuid::new_v4().into_bytes());
+
+fn identity_bytes(seed: u8, tag: u8, ordinal: u8) -> [u8; 32] {
+    let mut bytes = [0x00_u8; 32];
+    bytes[0] = seed;
+    bytes[1] = tag;
+    bytes[2] = ordinal;
+    bytes[16..].copy_from_slice(IDENTITY_NAMESPACE.as_slice());
+    bytes
+}
+
+/// An executable-plan identity unique to (`seed`, `ordinal`).
+pub(crate) fn plan_id(seed: u8, ordinal: u8) -> ExecutablePlanRevisionId {
+    ExecutablePlanRevisionId::from_bytes(identity_bytes(seed, PLAN_IDENTITY_TAG, ordinal))
+}
+
+/// A worker-flavor identity unique to (`seed`, `ordinal`).
+pub(crate) fn worker_flavor_id(seed: u8, ordinal: u8) -> WorkerFlavorRevisionId {
+    WorkerFlavorRevisionId::from_bytes(identity_bytes(seed, FLAVOR_IDENTITY_TAG, ordinal))
+}
+
+fn body(bytes: Vec<u8>) -> RevisionRecordBytes {
+    RevisionRecordBytes::try_from_vec(bytes).expect("oracle record bodies are never empty")
+}
+
+/// Build a worker-flavor record whose body carries `content`.
+pub(crate) fn flavor_record(seed: u8, ordinal: u8, content: &str) -> WorkerFlavorRevisionRecord {
+    WorkerFlavorRevisionRecord::v1_json(
+        worker_flavor_id(seed, ordinal),
+        body(format!(r#"{{"flavor":"{content}"}}"#).into_bytes()),
+    )
+}
+
+/// Build a plan/flavor pair whose two bodies carry `content`.
+pub(crate) fn pair(seed: u8, ordinal: u8, content: &str) -> PlanFlavorRevisionRecord {
+    PlanFlavorRevisionRecord::graph_v1_json(
+        plan_id(seed, ordinal),
+        body(format!(r#"{{"plan":"{content}"}}"#).into_bytes()),
+        flavor_record(seed, ordinal, content),
+    )
+}
+
+fn plan_target(record: &PlanFlavorRevisionRecord) -> PlanFlavorRevisionTarget {
+    PlanFlavorRevisionTarget::ExecutablePlan(record.ids().plan())
+}
+
+fn flavor_target(record: &PlanFlavorRevisionRecord) -> PlanFlavorRevisionTarget {
+    PlanFlavorRevisionTarget::WorkerFlavor(record.ids().worker_flavor())
+}
+
+async fn install(catalog: &impl ExactRevisionCatalog, record: &PlanFlavorRevisionRecord) {
+    assert_eq!(
+        catalog.insert(record).await,
+        Ok(RevisionInsertOutcome::Inserted),
+        "a fresh immutable pair installs exactly once"
+    );
+}
+
+/// An installed pair loads back byte-for-byte through its exact identity.
+pub(crate) async fn insert_then_exact_load_round_trips(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record.clone()),
+        "exact load returns the stored pair unchanged"
+    );
+}
+
+/// Re-installing byte-identical content is idempotent, never a conflict.
+pub(crate) async fn byte_identical_reinsert_is_already_present(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::AlreadyPresent),
+        "a retry of the same immutable pair is idempotent"
+    );
+    assert_eq!(catalog.load_exact(record.ids()).await, Ok(record));
+}
+
+/// Idempotency survives an encoder that emits the same document differently.
+///
+/// Record bodies are ordinary `serde_json` output, so key order and whitespace
+/// depend on how the producing binary was built. Comparing raw bytes made two
+/// binaries that agree on a revision's content address disagree on its record,
+/// leaving an immutable revision permanently uninstallable.
+pub(crate) async fn reencoded_identical_record_is_already_present(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    let reencoded = PlanFlavorRevisionRecord::graph_v1_json(
+        record.ids().plan(),
+        body(br#"{  "plan"  :  "v1"  }"#.to_vec()),
+        WorkerFlavorRevisionRecord::v1_json(
+            record.ids().worker_flavor(),
+            body(br#"{  "flavor"  :  "v1"  }"#.to_vec()),
+        ),
+    );
+
+    assert_eq!(
+        catalog.insert(&reencoded).await,
+        Ok(RevisionInsertOutcome::AlreadyPresent),
+        "an encoding difference must not make an immutable revision uninstallable"
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "the originally stored bytes stay authoritative"
+    );
+}
+
+/// Reusing a plan identity with different content fails closed.
+pub(crate) async fn plan_content_conflict_preserves_the_stored_record(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    let conflicting = PlanFlavorRevisionRecord::graph_v1_json(
+        record.ids().plan(),
+        body(br#"{"plan":"rewritten"}"#.to_vec()),
+        record.worker_flavor().clone(),
+    );
+    assert_eq!(
+        catalog.insert(&conflicting).await,
+        Err(RevisionCatalogError::ContentConflict {
+            target: plan_target(&record),
+        })
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "a rejected insert leaves the immutable record untouched"
+    );
+}
+
+/// A flavor-content conflict names the flavor identity and writes no plan.
+pub(crate) async fn worker_flavor_content_conflict_does_not_partially_insert_the_plan(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    // A new plan identity pinned to the installed flavor identity, but
+    // carrying different flavor content.
+    let conflicting = PlanFlavorRevisionRecord::graph_v1_json(
+        plan_id(seed, 1),
+        body(br#"{"plan":"second"}"#.to_vec()),
+        WorkerFlavorRevisionRecord::v1_json(
+            record.ids().worker_flavor(),
+            body(br#"{"flavor":"rewritten"}"#.to_vec()),
+        ),
+    );
+    assert_eq!(
+        catalog.insert(&conflicting).await,
+        Err(RevisionCatalogError::ContentConflict {
+            target: flavor_target(&record),
+        }),
+        "the conflict is reported against the identity whose bytes differ"
+    );
+    assert_eq!(
+        catalog.load_exact(conflicting.ids()).await,
+        Err(RevisionCatalogError::PlanUnavailable {
+            plan_id: plan_id(seed, 1),
+        }),
+        "the pair is atomic: a rejected flavor leaves no plan behind"
+    );
+}
+
+/// Exact load never substitutes the flavor a plan is actually pinned to.
+pub(crate) async fn exact_load_rejects_a_mismatched_worker_flavor(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let other = pair(seed, 1, "other");
+    install(catalog, &other).await;
+
+    let crossed = PlanFlavorRevisionIds::new(record.ids().plan(), other.ids().worker_flavor());
+    assert_eq!(
+        catalog.load_exact(crossed).await,
+        Err(RevisionCatalogError::PlanFlavorMismatch {
+            requested: crossed,
+            stored_worker_flavor_id: record.ids().worker_flavor(),
+        }),
+        "a plan is served only under the exact flavor it pins"
+    );
+}
+
+/// An absent plan identity is unavailable, never resolved to a near match.
+pub(crate) async fn exact_load_of_an_unknown_plan_is_unavailable(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+
+    let unknown = PlanFlavorRevisionIds::new(plan_id(seed, 9), record.ids().worker_flavor());
+    assert_eq!(
+        catalog.load_exact(unknown).await,
+        Err(RevisionCatalogError::PlanUnavailable {
+            plan_id: plan_id(seed, 9),
+        }),
+        "exact load never falls back to a latest or closest revision"
+    );
+}
+
+/// A body that is not a well-formed document of its recorded form is rejected,
+/// and nothing about it is persisted.
+pub(crate) async fn a_body_violating_its_recorded_form_persists_nothing(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let corrupt = PlanFlavorRevisionRecord::graph_v1_json(
+        plan_id(seed, 0),
+        body(b"this is not a graph-v1 json document".to_vec()),
+        flavor_record(seed, 0, "v1"),
+    );
+
+    assert_eq!(
+        catalog.insert(&corrupt).await,
+        Err(RevisionCatalogError::CorruptRecord {
+            target: plan_target(&corrupt),
+        }),
+        "a body that violates its recorded form never reaches durable storage"
+    );
+    assert_eq!(
+        catalog.load_exact(corrupt.ids()).await,
+        Err(RevisionCatalogError::PlanUnavailable {
+            plan_id: plan_id(seed, 0),
+        })
+    );
+    assert_eq!(
+        catalog
+            .begin_drain(PlanFlavorRevisionTarget::WorkerFlavor(worker_flavor_id(
+                seed, 0
+            )))
+            .await,
+        Err(RevisionCatalogError::WorkerFlavorUnavailable {
+            worker_flavor_id: worker_flavor_id(seed, 0),
+        }),
+        "the flavor half of a rejected pair is not written either"
+    );
+}
+
+/// Draining is idempotent and does not stop a retained execution from loading.
+pub(crate) async fn drain_is_idempotent_and_still_serves_exact_loads(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let target = plan_target(&record);
+
+    assert!(
+        matches!(
+            catalog.begin_drain(target).await,
+            Ok(BeginDrainOutcome::Started(counts)) if counts.is_empty()
+        ),
+        "the first drain transitions Active to Draining"
+    );
+    assert!(
+        matches!(
+            catalog.begin_drain(target).await,
+            Ok(BeginDrainOutcome::AlreadyDraining(counts)) if counts.is_empty()
+        ),
+        "repeating the drain is idempotent and re-projects the blockers"
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "a draining revision still serves the executions that pinned it"
+    );
+}
+
+/// A retrying installer learns that a revision is being retired.
+pub(crate) async fn insert_against_a_draining_revision_reports_draining(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    assert_eq!(
+        catalog.insert(&record).await,
+        Ok(RevisionInsertOutcome::AlreadyPresent),
+        "an ordinary retry against a live revision is idempotent"
+    );
+
+    let target = flavor_target(&record);
+    assert!(matches!(
+        catalog.begin_drain(target).await,
+        Ok(BeginDrainOutcome::Started(_))
+    ));
+    assert_eq!(
+        catalog.insert(&record).await,
+        Err(RevisionCatalogError::Draining { target }),
+        "drain is a property of the revision, not of the caller's history"
+    );
+}
+
+/// Deletion of a still-active revision is refused.
+pub(crate) async fn delete_requires_drain_first(catalog: &impl ExactRevisionCatalog, seed: u8) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let target = plan_target(&record);
+
+    assert_eq!(
+        catalog.delete_drained(target).await,
+        Err(RevisionCatalogError::DrainRequired { target })
+    );
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Ok(record),
+        "a refused delete changes nothing"
+    );
+}
+
+/// A drained plan deletes to a tombstone, and repeating the delete reconciles a
+/// commit whose acknowledgement was lost.
+pub(crate) async fn delete_tombstones_and_a_repeat_delete_reconciles_a_lost_ack(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let target = plan_target(&record);
+
+    catalog
+        .begin_drain(target)
+        .await
+        .expect("an installed plan starts draining");
+    assert_eq!(catalog.delete_drained(target).await, Ok(()));
+    assert_eq!(
+        catalog.load_exact(record.ids()).await,
+        Err(RevisionCatalogError::Deleted { target }),
+        "a deleted identity keeps its tombstone rather than becoming unknown"
+    );
+    assert_eq!(
+        catalog.delete_drained(target).await,
+        Ok(()),
+        "a lost delete acknowledgement is reconciled by the tombstone"
+    );
+}
+
+/// A deleted identity can never be resurrected by re-installing its content.
+pub(crate) async fn a_deleted_identity_cannot_be_resurrected(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let target = plan_target(&record);
+
+    catalog
+        .begin_drain(target)
+        .await
+        .expect("an installed plan starts draining");
+    catalog
+        .delete_drained(target)
+        .await
+        .expect("an unreferenced drained plan deletes");
+
+    assert_eq!(
+        catalog.insert(&record).await,
+        Err(RevisionCatalogError::Deleted { target }),
+        "an immutable identity is spent once deleted"
+    );
+}
+
+/// A worker flavor cannot be deleted while any non-deleted plan pins it.
+pub(crate) async fn flavor_delete_waits_for_every_non_deleted_dependent_plan(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let record = pair(seed, 0, "v1");
+    install(catalog, &record).await;
+    let flavor = flavor_target(&record);
+    let plan = plan_target(&record);
+
+    catalog
+        .begin_drain(flavor)
+        .await
+        .expect("an installed flavor starts draining");
+    assert_eq!(
+        catalog.delete_drained(flavor).await,
+        Err(RevisionCatalogError::DependentPlans {
+            worker_flavor_id: record.ids().worker_flavor(),
+            dependent_plans: 1,
+        })
+    );
+
+    catalog
+        .begin_drain(plan)
+        .await
+        .expect("an installed plan starts draining");
+    catalog
+        .delete_drained(plan)
+        .await
+        .expect("an unreferenced drained plan deletes");
+    assert_eq!(
+        catalog.delete_drained(flavor).await,
+        Ok(()),
+        "the flavor deletes once its last dependent plan is gone"
+    );
+}
+
+/// Draining an identity the catalog has never seen is unavailable.
+pub(crate) async fn drain_of_an_unknown_revision_is_unavailable(
+    catalog: &impl ExactRevisionCatalog,
+    seed: u8,
+) {
+    let target = PlanFlavorRevisionTarget::ExecutablePlan(plan_id(seed, 0));
+    assert_eq!(
+        catalog.begin_drain(target).await,
+        Err(RevisionCatalogError::PlanUnavailable {
+            plan_id: plan_id(seed, 0),
+        })
+    );
+    assert_eq!(
+        catalog.delete_drained(target).await,
+        Err(RevisionCatalogError::PlanUnavailable {
+            plan_id: plan_id(seed, 0),
+        })
+    );
+}
+
+/// Generate one `#[tokio::test]` per shared case against `$catalog`.
+///
+/// `$catalog` is an async expression yielding `Option<impl
+/// ExactRevisionCatalog>`; `None` means this backend is not reachable in the
+/// current environment and the case reports that rather than asserting against
+/// a substitute. Each case receives a distinct seed so the cases stay
+/// independent while sharing one durable store.
+///
+/// The including file must declare this module as `oracle`.
+#[macro_export]
+macro_rules! revision_catalog_conformance_suite {
+    ($catalog:expr) => {
+        $crate::revision_catalog_case!(insert_then_exact_load_round_trips, 0x11, $catalog);
+        $crate::revision_catalog_case!(byte_identical_reinsert_is_already_present, 0x12, $catalog);
+        $crate::revision_catalog_case!(
+            reencoded_identical_record_is_already_present,
+            0x13,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            plan_content_conflict_preserves_the_stored_record,
+            0x14,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            worker_flavor_content_conflict_does_not_partially_insert_the_plan,
+            0x15,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            exact_load_rejects_a_mismatched_worker_flavor,
+            0x16,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            exact_load_of_an_unknown_plan_is_unavailable,
+            0x17,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            a_body_violating_its_recorded_form_persists_nothing,
+            0x18,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            drain_is_idempotent_and_still_serves_exact_loads,
+            0x19,
+            $catalog
+        );
+        $crate::revision_catalog_case!(
+            insert_against_a_draining_revision_reports_draining,
+            0x1a,
+            $catalog
+        );
+        $crate::revision_catalog_case!(delete_requires_drain_first, 0x1b, $catalog);
+        $crate::revision_catalog_case!(
+            delete_tombstones_and_a_repeat_delete_reconciles_a_lost_ack,
+            0x1c,
+            $catalog
+        );
+        $crate::revision_catalog_case!(a_deleted_identity_cannot_be_resurrected, 0x1d, $catalog);
+        $crate::revision_catalog_case!(
+            flavor_delete_waits_for_every_non_deleted_dependent_plan,
+            0x1e,
+            $catalog
+        );
+        $crate::revision_catalog_case!(drain_of_an_unknown_revision_is_unavailable, 0x1f, $catalog);
+    };
+}
+
+/// Bind one shared case to a `#[tokio::test]` in the including backend file.
+#[macro_export]
+macro_rules! revision_catalog_case {
+    ($case:ident, $seed:expr, $catalog:expr) => {
+        #[tokio::test]
+        async fn $case() {
+            let Some(catalog) = $catalog.await else {
+                eprintln!(concat!(
+                    stringify!($case),
+                    ": backend unreachable in this environment"
+                ));
+                return;
+            };
+            oracle::$case(&catalog, $seed).await;
+        }
+    };
+}


### PR DESCRIPTION
Closes #972.

## What

Makes the exact executable-plan/worker-flavor catalog a real deployment capability on SQLite and PostgreSQL. The in-memory adapter stays the reference/conformance model; ordered migration 0041 stays the only schema authority, and no adapter issues DDL of its own.

Backend-independent decisions move into `crate::revision_catalog`: record identity, recorded-form validity, durable lifecycle vocabulary, and the span outcome labels. Three backends answering the same question in three places would drift; now they cannot.

## Two behaviour changes

Both fall out of giving each payload exactly one durable home:

- **A flavor-content difference is reported against the flavor identity that owns the bytes**, not against the plan that merely pins it. The in-memory model blamed the plan because it carried a redundant embedded copy — an identity whose own bytes are unchanged.
- **A body that is not a well-formed document of its recorded form is rejected on insert and reported as corruption on load.** Storage does not interpret these bytes, but both recorded forms are JSON, so a body that does not parse is corruption rather than an opaque payload — and it is the one corruption case reachable through the port on all three backends.

## Concurrency

SQLite runs every operation under `BEGIN IMMEDIATE`. PostgreSQL locks the rows it decides on with `FOR UPDATE`, plus a transaction-scoped advisory lock per identity — `FOR UPDATE` cannot lock a row that does not exist, so two processes installing the same new revision would otherwise both decide "absent" and one would lose on the unique index.

Driver detail never crosses the port: a pre-commit failure is `Unavailable`, a failed commit is `OutcomeUnknown`.

## Conformance

One shared acceptance oracle (`tests/support/revision_catalog_oracle.rs`) runs 15 cases — success, conflict, corruption, drain, tombstone, lost-ack — against all three backends, so a behaviour only one gets right fails the suite instead of diverging silently. The suite is added to the required `postgres-conformance` job rather than left to skip; PostgreSQL absence fails it via `NEBULA_REQUIRE_POSTGRES`.

`RevisionCatalogError::Referenced` is out of scope here and documented as such: reference rows can only be created by the execution-owner transaction, which lands in #973.

## Retired guard

`schema_source_authority` guarded "0041 is dormant DDL", which is exactly what this task retires. It now guards the two invariants that still hold: no catalog adapter issues DDL, and no production API mutates `port_execution_revision_refs` — that authority lands with the execution-owner start transaction.

## Evidence

- `cargo nextest run -p nebula-storage --features credential-in-memory,sqlite` — 564 passed, 1 skipped (the `#[ignore]`d nightly-only refresh-coordinator chaos plane).
- `DATABASE_URL=… NEBULA_REQUIRE_POSTGRES=1 cargo nextest run -p nebula-storage --features postgres --test revision_catalog_conformance_postgres` — 17 passed against a live postgres:17-alpine server.
- `cargo clippy --all-targets` clean on no-default-features, default, sqlite-only, postgres-only, and all-features.
- `task quality` and `task deny` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added exact plan and worker-flavor revision catalog support for SQLite and PostgreSQL.
  - Added consistent loading, insertion, draining, and deletion behavior across storage backends.
  - Added lifecycle handling for active, draining, and deleted revisions.

- **Bug Fixes**
  - Improved validation and detection of corrupted, unsupported, mismatched, or conflicting records.
  - Prevented deletion when dependent plans or references remain.

- **Tests**
  - Added shared conformance coverage across in-memory, SQLite, and PostgreSQL implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->