### PR TITLE
feat(error,workflow,plugin,api)!: standardize activation diagnostics for NS14 (#979)

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -182,6 +182,18 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+      # The NS14 diagnostic-contract report names which rejections report which
+      # fields. A green exit code proves the suite ran; the report is what says
+      # what it found, so it is retained rather than re-derived.
+      - name: Upload NS14 diagnostic-contract report
+        if: always() && matrix.package == 'nebula-api'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ns14-diagnostic-contract
+          path: target/ns14/diagnostic-contract.json
+          if-no-files-found: error
+          retention-days: 14
+
   postgres-conformance:
     name: PostgreSQL storage conformance
     runs-on: ubuntu-latest

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -14,7 +14,7 @@ documentation.workspace = true
 
 [dependencies]
 nebula-env = { workspace = true }
-nebula-error = { workspace = true, features = ["derive"] }
+nebula-error = { workspace = true, features = ["derive", "serde"] }
 nebula-storage = { path = "../storage", features = ["credential-in-memory", "sqlite"] }
 nebula-storage-port = { path = "../storage-port" }
 # Composition-root dependency: `AppState`/`default_state` wrap the storage

--- a/crates/api/src/error/classify.rs
+++ b/crates/api/src/error/classify.rs
@@ -44,11 +44,11 @@ pub(super) fn flatten_validation_error(
         .or_else(|| inherited_pointer.map(str::to_owned))
         .unwrap_or_else(|| "/".to_owned());
 
-    out.push(ValidationFieldError {
-        code: err.code.to_string(),
-        detail: err.message.to_string(),
-        pointer: normalize_pointer(Some(&pointer)),
-    });
+    out.push(ValidationFieldError::field(
+        err.code.to_string(),
+        err.message.to_string(),
+        normalize_pointer(Some(&pointer)),
+    ));
 
     for nested in err.nested() {
         flatten_validation_error(nested, Some(&pointer), out);
@@ -56,67 +56,6 @@ pub(super) fn flatten_validation_error(
 }
 
 // ── Map a WorkflowError to a JSON Pointer ───────────────────────────────────
-
-/// Map a [`nebula_workflow::WorkflowError`] to a JSON Pointer (RFC 6901)
-/// that identifies the offending location in the workflow JSON document.
-///
-/// The workflow JSON schema is:
-/// ```json
-/// {
-///   "nodes":       [ { "id": "<key>", … }, … ],
-///   "connections": [ { "from_node": "<f>", "to_node": "<t>", … }, … ],
-///   "trigger":     { … },
-///   …
-/// }
-/// ```
-///
-/// Pointer conventions used here:
-/// - Node-specific errors: `/nodes/<node_key>`
-/// - Connection-specific: `/connections/<from>/<to>`
-/// - Trigger errors:      `/trigger`
-/// - Structural / whole-document errors: `""` (the root pointer, RFC 6901 §4)
-pub(super) fn workflow_error_pointer(err: &nebula_workflow::WorkflowError) -> String {
-    use nebula_workflow::WorkflowError;
-    match err {
-        // Node-keyed errors
-        WorkflowError::DuplicateNodeKey(key)
-        | WorkflowError::UnknownNode(key)
-        | WorkflowError::SelfLoop(key) => format!("/nodes/{key}"),
-
-        WorkflowError::InvalidParameterReference { node_key, .. } => {
-            format!("/nodes/{node_key}")
-        },
-
-        WorkflowError::InvalidActionKey { key, .. } => {
-            // The key string is the node's action_key; best we can do without
-            // the node key is to point at the nodes array.
-            let _ = key;
-            "/nodes".to_owned()
-        },
-
-        // Connection-keyed errors
-        WorkflowError::DuplicateConnection { from, to } => {
-            format!("/connections/{from}/{to}")
-        },
-
-        // Trigger errors
-        WorkflowError::InvalidTrigger { .. } => "/trigger".to_owned(),
-
-        // Schema-level / structural — point at root
-        WorkflowError::EmptyName
-        | WorkflowError::NoNodes
-        | WorkflowError::CycleDetected
-        | WorkflowError::NoEntryNodes
-        | WorkflowError::UnsupportedSchema { .. }
-        | WorkflowError::InvalidOwnerId
-        | WorkflowError::GraphError(_) => String::new(), // RFC 6901 root pointer
-
-        // `WorkflowError` is `#[non_exhaustive]`. Future variants without an
-        // API-side mapping fall back to the root pointer rather than failing
-        // to compile the API layer on every validator extension.
-        _ => String::new(),
-    }
-}
 
 // ── From<ValidationError> ────────────────────────────────────────────────────
 

--- a/crates/api/src/error/mod.rs
+++ b/crates/api/src/error/mod.rs
@@ -29,8 +29,6 @@ use axum::{
 };
 use thiserror::Error;
 
-use crate::error::classify::workflow_error_pointer;
-
 /// Main API Error Type
 #[non_exhaustive]
 #[derive(Debug, Error, nebula_error::Classify)]
@@ -567,16 +565,12 @@ impl ApiError {
                     StatusCode::UNPROCESSABLE_ENTITY,
                 )
                 .with_detail(detail)
-                .with_errors(
-                    errors
-                        .iter()
-                        .map(|err| ValidationFieldError {
-                            code: "workflow_definition_invalid".to_string(),
-                            detail: err.to_string(),
-                            pointer: workflow_error_pointer(err),
-                        })
-                        .collect(),
-                ),
+                // Every rejection contributes its own NS14 diagnostic rather
+                // than one shared `workflow_definition_invalid` code and a
+                // prose sentence. A client can now tell which rule fired, a UI
+                // can point at the element, and an author is told what to
+                // change — none of which survived being flattened into text.
+                .with_errors(activation_field_errors(errors)),
             ),
             ApiError::SessionExpired => (
                 StatusCode::UNAUTHORIZED,
@@ -677,6 +671,28 @@ impl ApiError {
             ),
         }
     }
+}
+
+/// Render typed workflow rejections as NS14 problem-details entries.
+///
+/// Ordering is canonical, so the same invalid workflow always produces the
+/// same response body: a client diffing two responses sees only real changes,
+/// and a snapshot test is meaningful.
+///
+/// The JSON Pointer comes from each diagnostic's own `path`, which is why the
+/// API no longer keeps a second `WorkflowError` → pointer table: two mappings
+/// for one fact drift, and the crate that raises the rejection is the one that
+/// knows which element it is about.
+fn activation_field_errors(errors: &[nebula_workflow::WorkflowError]) -> Vec<ValidationFieldError> {
+    use nebula_error::ActivationDiagnostics;
+
+    let diagnostics = nebula_error::canonical_diagnostics(
+        errors
+            .iter()
+            .flat_map(nebula_workflow::WorkflowError::activation_diagnostics)
+            .collect(),
+    );
+    diagnostics.iter().map(ValidationFieldError::from).collect()
 }
 
 impl IntoResponse for ApiError {
@@ -783,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_workflow_definition_structural_error_produces_root_pointer() {
+    fn invalid_workflow_definition_structural_error_points_at_the_offending_section() {
         use nebula_workflow::WorkflowError;
 
         let api_error = ApiError::InvalidWorkflowDefinition {
@@ -795,11 +811,29 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         let errors = problem.errors.expect("errors must be present");
         assert_eq!(errors.len(), 1);
-        // Structural errors (cycle, no entry nodes, etc.) point at root — RFC 6901 empty string.
+
+        // Structural rejections used to collapse to the RFC 6901 root pointer
+        // (the empty string). NS14 requires a non-empty path on every
+        // diagnostic, and a cycle is always a property of the connections, so
+        // pointing there is both required and strictly more useful than
+        // pointing at the whole document.
+        assert_eq!(errors[0].pointer, "/connections");
+        assert_eq!(errors[0].code, "WORKFLOW:CYCLE_DETECTED");
         assert_eq!(
-            errors[0].pointer, "",
-            "CycleDetected must produce the RFC 6901 root pointer (empty string), got: {:?}",
-            errors[0].pointer
+            errors[0].expected.as_deref(),
+            Some("an acyclic graph"),
+            "the contract that was required travels as its own field"
+        );
+        assert_eq!(
+            errors[0].actual.as_deref(),
+            Some("a graph containing a cycle")
+        );
+        assert!(
+            errors[0]
+                .remediation
+                .as_deref()
+                .is_some_and(|text| text.contains("cycle")),
+            "an author is told what to change, not just what is wrong"
         );
     }
 

--- a/crates/api/src/error/mod.rs
+++ b/crates/api/src/error/mod.rs
@@ -189,8 +189,11 @@ pub enum ApiError {
         /// Human-readable summary of all validation failures.
         detail: String,
         /// One entry per `WorkflowError` returned by `validate_workflow`.
-        /// Carrying the typed errors allows `to_problem_details` to produce
-        /// real RFC 6901 JSON Pointers rather than synthetic positional ones.
+        ///
+        /// The typed errors are carried rather than pre-rendered so
+        /// `to_problem_details` can emit each rejection's own NS14 diagnostic —
+        /// its code, the element it is about, the contract it required, what
+        /// was found, and how to fix it.
         errors: Vec<nebula_workflow::WorkflowError>,
     },
 
@@ -752,7 +755,7 @@ mod tests {
         let errors = problem.errors.expect("validation errors must be present");
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].code, "min_length");
-        assert_eq!(errors[0].pointer, "/profile/name");
+        assert_eq!(errors[0].pointer.as_deref(), Some("/profile/name"));
     }
 
     #[test]
@@ -771,7 +774,7 @@ mod tests {
         assert!(
             errors
                 .iter()
-                .any(|e| e.code == "required" && e.pointer == "/email")
+                .any(|e| e.code == "required" && e.pointer.as_deref() == Some("/email"))
         );
     }
 
@@ -791,11 +794,14 @@ mod tests {
         let errors = problem.errors.expect("errors must be present");
         assert_eq!(errors.len(), 1);
         assert!(
-            errors[0].pointer.starts_with("/nodes/"),
+            errors[0]
+                .path
+                .as_deref()
+                .is_some_and(|path| path.starts_with("/nodes/")),
             "DuplicateNodeKey must produce a /nodes/<key> pointer, got: {:?}",
             errors[0].pointer
         );
-        assert_eq!(errors[0].pointer, "/nodes/step_a");
+        assert_eq!(errors[0].path.as_deref(), Some("/nodes/step_a"));
     }
 
     #[test]
@@ -817,7 +823,7 @@ mod tests {
         // diagnostic, and a cycle is always a property of the connections, so
         // pointing there is both required and strictly more useful than
         // pointing at the whole document.
-        assert_eq!(errors[0].pointer, "/connections");
+        assert_eq!(errors[0].path.as_deref(), Some("/connections"));
         assert_eq!(errors[0].code, "WORKFLOW:CYCLE_DETECTED");
         assert_eq!(
             errors[0].expected.as_deref(),
@@ -854,9 +860,14 @@ mod tests {
         let errors = problem.errors.expect("errors must be present");
         assert_eq!(errors.len(), 1);
         assert_eq!(
-            errors[0].pointer, "/connections/a/b",
-            "DuplicateConnection must produce /connections/<from>/<to>, got: {:?}",
-            errors[0].pointer
+            errors[0].path.as_deref(),
+            Some("/connections/a/b"),
+            "a connection rejection names both endpoints it wires"
+        );
+        assert_eq!(
+            errors[0].pointer, None,
+            "an activation diagnostic reports a logical path, never a JSON Pointer it \
+             could not resolve against an array of connections"
         );
     }
 

--- a/crates/api/src/error/problem.rs
+++ b/crates/api/src/error/problem.rs
@@ -43,15 +43,81 @@ pub struct ProblemDetails {
     pub errors: Option<Vec<ValidationFieldError>>,
 }
 
-/// Validation field error
+/// One structured validation or activation rejection.
+///
+/// `code` and `pointer` are stable machine-readable contracts: a client
+/// matches on them rather than parsing `detail`. `expected`, `actual`, and
+/// `remediation` are the NS14 activation-diagnostic fields — present whenever
+/// the rejection came from an activation diagnostic, absent for the
+/// request-level validators that have no contract to compare against.
+///
+/// Flattening these into `detail` prose was the previous shape and it cost
+/// every one of them: a client could not tell which rule fired, a UI could not
+/// point at the offending element, and an author was told a count rather than
+/// what to change.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ValidationFieldError {
-    /// Validator error code
+    /// Stable machine-readable rejection code.
     pub code: String,
-    /// Error detail message
+    /// Human-readable message. Never the only place a field appears.
     pub detail: String,
-    /// JSON Pointer to the field (RFC 6901), e.g. "/age"
+    /// JSON Pointer to the offending element (RFC 6901), e.g. `/nodes/a`.
     pub pointer: String,
+    /// Secret-free description of the contract that was required.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+    /// Secret-free description of what was found, or a safe sentinel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual: Option<String>,
+    /// Stable, actionable guidance for resolving the rejection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remediation: Option<String>,
+}
+
+impl ValidationFieldError {
+    /// Build a request-level validation error with no contract comparison.
+    ///
+    /// Request-level validators reject a malformed field rather than a
+    /// mismatched contract, so they have no `expected`/`actual` pair to report
+    /// and deliberately omit the NS14 fields instead of inventing them.
+    #[must_use]
+    pub fn field(
+        code: impl Into<String>,
+        detail: impl Into<String>,
+        pointer: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            detail: detail.into(),
+            pointer: pointer.into(),
+            expected: None,
+            actual: None,
+            remediation: None,
+        }
+    }
+}
+
+impl From<&nebula_error::ActivationDiagnostic> for ValidationFieldError {
+    /// Carry all five NS14 fields onto the wire without flattening any of them.
+    ///
+    /// `detail` stays populated for a human reading the response, but every
+    /// field it summarises is also present on its own, so a client never has to
+    /// parse prose to recover a value.
+    fn from(diagnostic: &nebula_error::ActivationDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code().to_owned(),
+            detail: format!(
+                "{}: expected {}, found {}",
+                diagnostic.code(),
+                diagnostic.expected(),
+                diagnostic.actual()
+            ),
+            pointer: diagnostic.path().to_owned(),
+            expected: Some(diagnostic.expected().to_owned()),
+            actual: Some(diagnostic.actual().to_owned()),
+            remediation: Some(diagnostic.remediation().to_owned()),
+        }
+    }
 }
 
 impl ProblemDetails {

--- a/crates/api/src/error/problem.rs
+++ b/crates/api/src/error/problem.rs
@@ -45,8 +45,10 @@ pub struct ProblemDetails {
 
 /// One structured validation or activation rejection.
 ///
-/// `code` and `pointer` are stable machine-readable contracts: a client
-/// matches on them rather than parsing `detail`. `expected`, `actual`, and
+/// `code` and the location fields are stable machine-readable contracts: a
+/// client matches on them rather than parsing `detail`. Exactly one location
+/// field is populated — `pointer` when the target is addressable by RFC 6901,
+/// `path` when it is a logical workflow element. `expected`, `actual`, and
 /// `remediation` are the NS14 activation-diagnostic fields — present whenever
 /// the rejection came from an activation diagnostic, absent for the
 /// request-level validators that have no contract to compare against.
@@ -61,8 +63,30 @@ pub struct ValidationFieldError {
     pub code: String,
     /// Human-readable message. Never the only place a field appears.
     pub detail: String,
-    /// JSON Pointer to the offending element (RFC 6901), e.g. `/nodes/a`.
-    pub pointer: String,
+    /// RFC 6901 JSON Pointer into the request body, e.g. `/age`.
+    ///
+    /// Present for request-level validators, which reject a malformed field in
+    /// a document whose shape the pointer can actually address. Absent for
+    /// activation diagnostics — see [`Self::path`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pointer: Option<String>,
+
+    /// Stable logical path to the offending workflow element, e.g.
+    /// `/nodes/fetch_users`.
+    ///
+    /// Deliberately **not** an RFC 6901 pointer. `nodes` and `connections` are
+    /// JSON arrays, so RFC 6901 addresses their elements by index (`/nodes/3`),
+    /// and a key-shaped segment does not resolve against the document at all —
+    /// which is what the previous `pointer` value claimed to be and was not.
+    ///
+    /// A key-based path is the stronger contract for a diagnostic. An index
+    /// silently changes meaning the moment an author inserts a node above the
+    /// offending one, so a stored or diffed diagnostic would point somewhere
+    /// else; the author-defined key is the identity the author actually edits
+    /// in, and it survives reordering. Node keys are restricted to
+    /// `[0-9A-Za-z_.-]`, so a path needs no escaping.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     /// Secret-free description of the contract that was required.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected: Option<String>,
@@ -89,7 +113,8 @@ impl ValidationFieldError {
         Self {
             code: code.into(),
             detail: detail.into(),
-            pointer: pointer.into(),
+            pointer: Some(pointer.into()),
+            path: None,
             expected: None,
             actual: None,
             remediation: None,
@@ -112,7 +137,8 @@ impl From<&nebula_error::ActivationDiagnostic> for ValidationFieldError {
                 diagnostic.expected(),
                 diagnostic.actual()
             ),
-            pointer: diagnostic.path().to_owned(),
+            pointer: None,
+            path: Some(diagnostic.path().to_owned()),
             expected: Some(diagnostic.expected().to_owned()),
             actual: Some(diagnostic.actual().to_owned()),
             remediation: Some(diagnostic.remediation().to_owned()),

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -121,20 +121,22 @@ fn map_gateway_err(err: CredentialGatewayError, cred: &str) -> ApiError {
             detail: "credential properties were rejected".to_owned(),
             errors: report
                 .issues()
-                .map(|issue| crate::error::ValidationFieldError {
-                    detail: issue.message().to_owned(),
-                    pointer: issue.path().to_owned(),
-                    code: issue.code().to_owned(),
+                .map(|issue| {
+                    crate::error::ValidationFieldError::field(
+                        issue.code().to_owned(),
+                        issue.message().to_owned(),
+                        issue.path().to_owned(),
+                    )
                 })
                 .collect(),
         },
         CredentialGatewayError::TypeUnknown { key } => ApiError::Validation {
             detail: format!("unknown credential type: {key}"),
-            errors: vec![crate::error::ValidationFieldError {
-                detail: "no such credential type".to_owned(),
-                pointer: "/credential_key".to_owned(),
-                code: "unknown_credential_type".to_owned(),
-            }],
+            errors: vec![crate::error::ValidationFieldError::field(
+                "unknown_credential_type",
+                "no such credential type",
+                "/credential_key",
+            )],
         },
         CredentialGatewayError::CapabilityUnsupported { capability, key } => ApiError::Validation {
             detail: format!("credential type '{key}' does not support capability '{capability}'"),

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2239,15 +2239,47 @@ async fn activate_invalid_returns_422() {
     for err in errors {
         assert!(err["code"].is_string(), "each error must have a code");
         assert!(err["detail"].is_string(), "each error must have a detail");
-        // RFC 6901 JSON Pointer: either the root pointer ("") or a path starting with "/".
-        // Structural errors (CycleDetected, NoEntryNodes, …) produce "" (root);
-        // node/connection errors produce "/nodes/<key>" or "/connections/<from>/<to>".
+
+        // Exactly one location field. `pointer` is an RFC 6901 pointer into a
+        // request body; `path` is a stable logical path to a workflow element.
+        // Activation rejections use `path`, because `nodes` and `connections`
+        // are JSON arrays — RFC 6901 addresses their elements by index, so a
+        // key-shaped `pointer` never resolved against the document it claimed
+        // to point into.
+        let pointer = err["pointer"].as_str();
+        let path = err["path"].as_str();
         assert!(
-            err["pointer"]
-                .as_str()
-                .is_some_and(|p| p.is_empty() || p.starts_with('/')),
-            "pointer must be a valid RFC 6901 JSON Pointer (empty string or starts with /)"
+            pointer.is_some() != path.is_some(),
+            "each error carries exactly one location field, got pointer={pointer:?} \
+             path={path:?}"
         );
+        if let Some(pointer) = pointer {
+            assert!(
+                pointer.is_empty() || pointer.starts_with('/'),
+                "an RFC 6901 pointer is the root or starts with /"
+            );
+        }
+        if let Some(path) = path {
+            assert!(
+                path.starts_with('/'),
+                "a logical path names an element, never the whole document"
+            );
+            // An activation rejection is only actionable with all five NS14
+            // fields, so the wire must carry the other three too.
+            for field in ["expected", "actual", "remediation"] {
+                assert!(
+                    err[field]
+                        .as_str()
+                        .is_some_and(|value| !value.trim().is_empty()),
+                    "an activation diagnostic must carry a non-blank `{field}`"
+                );
+            }
+            assert_ne!(
+                err["code"].as_str(),
+                Some("workflow_definition_invalid"),
+                "every rejection reports its own rule, not one shared placeholder code"
+            );
+        }
     }
 }
 

--- a/crates/api/tests/ns14_diagnostic_contract.rs
+++ b/crates/api/tests/ns14_diagnostic_contract.rs
@@ -1,0 +1,279 @@
+//! NS14 diagnostic-contract evidence.
+//!
+//! Every activation rejection the workspace can raise must report all five
+//! fields. Each producing crate already asserts that for its own variants; this
+//! suite is the cross-crate half — it enumerates the rejections from the
+//! workflow validator, the plan compiler, and the registry-compatibility check
+//! together, and emits one versioned report covering all of them.
+//!
+//! The report is written to `target/ns14/diagnostic-contract.json` so CI can
+//! retain it as evidence rather than re-deriving the claim from a passing exit
+//! code. A test that only returned green would prove the suite ran, not what it
+//! found.
+//!
+//! This lives in `nebula-api` because it is the only crate that depends on all
+//! three producers *and* on the RFC 9457 boundary the diagnostics travel over,
+//! so a gap between what a producer reports and what a client receives fails
+//! here rather than in three places that each see one half.
+
+use std::{fs, path::PathBuf};
+
+use nebula_error::{
+    ActivationDiagnostics, DIAGNOSTIC_CONTRACT_REPORT_VERSION, DiagnosticContractEntry,
+    DiagnosticContractReport,
+};
+
+/// Collect every diagnostic one rejection reports into report entries.
+fn entries_for(
+    rejection_name: &str,
+    rejection: &dyn ActivationDiagnostics,
+) -> Vec<DiagnosticContractEntry> {
+    let diagnostics = rejection.activation_diagnostics();
+    assert!(
+        !diagnostics.is_empty(),
+        "{rejection_name} reported nothing, so a caller has nothing to act on"
+    );
+    diagnostics
+        .iter()
+        .map(|diagnostic| DiagnosticContractEntry::observed(rejection_name, diagnostic))
+        .collect()
+}
+
+/// One instance of every workflow-validation rejection.
+fn workflow_rejections() -> Vec<(&'static str, nebula_workflow::WorkflowError)> {
+    use nebula_core::node_key;
+    use nebula_workflow::WorkflowError;
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    vec![
+        ("WorkflowError::EmptyName", WorkflowError::EmptyName),
+        ("WorkflowError::NoNodes", WorkflowError::NoNodes),
+        (
+            "WorkflowError::DuplicateNodeKey",
+            WorkflowError::DuplicateNodeKey(a.clone()),
+        ),
+        (
+            "WorkflowError::UnknownNode",
+            WorkflowError::UnknownNode(a.clone()),
+        ),
+        (
+            "WorkflowError::SelfLoop",
+            WorkflowError::SelfLoop(a.clone()),
+        ),
+        ("WorkflowError::CycleDetected", WorkflowError::CycleDetected),
+        ("WorkflowError::NoEntryNodes", WorkflowError::NoEntryNodes),
+        (
+            "WorkflowError::InvalidParameterReference",
+            WorkflowError::InvalidParameterReference {
+                node_key: a.clone(),
+                source_node_key: b.clone(),
+            },
+        ),
+        (
+            "WorkflowError::ReferenceWithoutConnection",
+            WorkflowError::ReferenceWithoutConnection {
+                node_key: a.clone(),
+                source_node_key: b.clone(),
+            },
+        ),
+        (
+            "WorkflowError::InvalidActionKey",
+            WorkflowError::InvalidActionKey {
+                key: "bad key".to_owned(),
+                reason: "keys must be dotted".to_owned(),
+            },
+        ),
+        (
+            "WorkflowError::InvalidPluginKey",
+            WorkflowError::InvalidPluginKey {
+                key: "bad key".to_owned(),
+                reason: "keys must be lowercase".to_owned(),
+            },
+        ),
+        (
+            "WorkflowError::InvalidTrigger",
+            WorkflowError::InvalidTrigger {
+                reason: "cron expression is empty".to_owned(),
+            },
+        ),
+        (
+            "WorkflowError::UnsupportedSchema",
+            WorkflowError::UnsupportedSchema { version: 9, max: 1 },
+        ),
+        (
+            "WorkflowError::InvalidOwnerId",
+            WorkflowError::InvalidOwnerId,
+        ),
+        (
+            "WorkflowError::GraphError",
+            WorkflowError::GraphError("edge resolution failed".to_owned()),
+        ),
+        (
+            "WorkflowError::DuplicateConnection",
+            WorkflowError::DuplicateConnection { from: a, to: b },
+        ),
+    ]
+}
+
+/// One instance of every plan-integrity and registry-compatibility rejection.
+fn plugin_rejections() -> Vec<(&'static str, Box<dyn ActivationDiagnostics>)> {
+    use nebula_core::{ExecutablePlanRevisionId, PluginSetId, WorkerFlavorRevisionId};
+    use nebula_plugin::{
+        ExecutablePlanIntegrityError, PlanRegistryCompatibilityError, WorkerFlavorIntegrityError,
+    };
+
+    vec![
+        (
+            "ExecutablePlanIntegrityError::UnsupportedFormat",
+            Box::new(ExecutablePlanIntegrityError::UnsupportedFormat),
+        ),
+        (
+            "ExecutablePlanIntegrityError::NonCanonical",
+            Box::new(ExecutablePlanIntegrityError::NonCanonical {
+                section: "bindings",
+            }),
+        ),
+        (
+            "ExecutablePlanIntegrityError::ConvertersUnsupported",
+            Box::new(ExecutablePlanIntegrityError::ConvertersUnsupported),
+        ),
+        (
+            "ExecutablePlanIntegrityError::UnknownCredentialCapability",
+            Box::new(ExecutablePlanIntegrityError::UnknownCredentialCapability),
+        ),
+        (
+            "ExecutablePlanIntegrityError::CanonicalEncoding",
+            Box::new(ExecutablePlanIntegrityError::CanonicalEncoding),
+        ),
+        (
+            "ExecutablePlanIntegrityError::RevisionIdMismatch",
+            Box::new(ExecutablePlanIntegrityError::RevisionIdMismatch {
+                claimed: ExecutablePlanRevisionId::from_bytes([0x11; 32]),
+                computed: ExecutablePlanRevisionId::from_bytes([0x22; 32]),
+            }),
+        ),
+        (
+            "WorkerFlavorIntegrityError::UnsupportedRecordVersion",
+            Box::new(WorkerFlavorIntegrityError::UnsupportedRecordVersion { found: 99 }),
+        ),
+        (
+            "WorkerFlavorIntegrityError::UnsupportedCanonicalHashVersion",
+            Box::new(WorkerFlavorIntegrityError::UnsupportedCanonicalHashVersion { found: 99 }),
+        ),
+        (
+            "WorkerFlavorIntegrityError::RevisionIdMismatch",
+            Box::new(WorkerFlavorIntegrityError::RevisionIdMismatch {
+                claimed: WorkerFlavorRevisionId::from_bytes([0x11; 32]),
+                computed: WorkerFlavorRevisionId::from_bytes([0x22; 32]),
+            }),
+        ),
+        (
+            "PlanRegistryCompatibilityError::PluginSetMismatch",
+            Box::new(PlanRegistryCompatibilityError::PluginSetMismatch {
+                plan: PluginSetId::from_bytes([0x11; 32]),
+                registry: PluginSetId::from_bytes([0x22; 32]),
+            }),
+        ),
+        (
+            "PlanRegistryCompatibilityError::WorkerFlavorMismatch",
+            Box::new(PlanRegistryCompatibilityError::WorkerFlavorMismatch {
+                plan: WorkerFlavorRevisionId::from_bytes([0x33; 32]),
+                registry: WorkerFlavorRevisionId::from_bytes([0x44; 32]),
+            }),
+        ),
+        (
+            "PlanRegistryCompatibilityError::ContractMismatch",
+            Box::new(PlanRegistryCompatibilityError::ContractMismatch { section: "actions" }),
+        ),
+    ]
+}
+
+fn report_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/ns14")
+        .join("diagnostic-contract.json")
+}
+
+/// Emit the versioned report and fail if any rejection is missing a field.
+#[test]
+fn every_activation_rejection_satisfies_the_five_field_contract() {
+    let mut entries = Vec::new();
+    for (name, rejection) in workflow_rejections() {
+        entries.extend(entries_for(name, &rejection));
+    }
+    for (name, rejection) in plugin_rejections() {
+        entries.extend(entries_for(name, rejection.as_ref()));
+    }
+
+    let report = DiagnosticContractReport::new(entries);
+    assert_eq!(report.report_version, DIAGNOSTIC_CONTRACT_REPORT_VERSION);
+
+    // Write before asserting, so a failing run still leaves the evidence that
+    // shows *which* rejections fell short.
+    let path = report_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("the report directory is creatable");
+    }
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&report).expect("the report serializes"),
+    )
+    .expect("the report is writable");
+
+    let gaps = report.incomplete();
+    assert!(
+        gaps.is_empty(),
+        "these rejections do not satisfy the NS14 five-field contract: {:?}",
+        gaps.iter()
+            .map(|entry| &entry.rejection)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Two rejections answering to one code would make the machine-readable half
+/// of the contract useless — a client could not tell them apart.
+#[test]
+fn codes_are_distinct_across_every_producing_crate() {
+    let mut entries = Vec::new();
+    for (name, rejection) in workflow_rejections() {
+        entries.extend(entries_for(name, &rejection));
+    }
+    for (name, rejection) in plugin_rejections() {
+        entries.extend(entries_for(name, rejection.as_ref()));
+    }
+
+    let mut codes: Vec<&str> = entries.iter().map(|entry| entry.code.as_str()).collect();
+    let total = codes.len();
+    codes.sort_unstable();
+    codes.dedup();
+    assert_eq!(
+        codes.len(),
+        total,
+        "two rejections must not answer to the same diagnostic code"
+    );
+}
+
+/// Codes are namespaced by the layer that raises them, so a consumer can route
+/// on the prefix without a lookup table.
+#[test]
+fn codes_are_namespaced_by_their_producing_layer() {
+    for (name, rejection) in workflow_rejections() {
+        for entry in entries_for(name, &rejection) {
+            assert!(
+                entry.code.starts_with("WORKFLOW:"),
+                "{name} reported an unnamespaced code: {}",
+                entry.code
+            );
+        }
+    }
+    for (name, rejection) in plugin_rejections() {
+        for entry in entries_for(name, rejection.as_ref()) {
+            assert!(
+                entry.code.starts_with("PLUGIN_"),
+                "{name} reported an unnamespaced code: {}",
+                entry.code
+            );
+        }
+    }
+}

--- a/crates/error/src/activation.rs
+++ b/crates/error/src/activation.rs
@@ -1,0 +1,284 @@
+//! Structured activation diagnostics.
+//!
+//! An activation rejection has to say five things a caller can act on: which
+//! rule fired ([`ActivationDiagnostic::code`]), where
+//! ([`ActivationDiagnostic::path`]), what the contract required
+//! ([`ActivationDiagnostic::expected`]), what was found
+//! ([`ActivationDiagnostic::actual`]), and what to do about it
+//! ([`ActivationDiagnostic::remediation`]). Flattening those into one prose
+//! sentence loses every one of them: a caller cannot match on a sentence, and a
+//! UI cannot point at the offending node.
+//!
+//! The type lives here, in the cross-cutting error crate, because both the
+//! Core-tier workflow validator and the Business-tier plan compiler reject
+//! activations and must produce the same shape. Owning it in either of those
+//! would force the other into an upward dependency.
+
+use core::fmt;
+
+/// Longest a single diagnostic field may be, in bytes.
+///
+/// Diagnostics travel into logs and HTTP responses, and several fields embed
+/// author-supplied text: a `path` names a node key, an `actual` reports the
+/// contract that was observed. Neither is bounded by anything upstream, so a
+/// workflow carrying a megabyte-long key would push a megabyte per diagnostic
+/// into every log line and error body that mentions it. The bound is generous
+/// enough that no honest identifier reaches it.
+pub const MAX_DIAGNOSTIC_FIELD_BYTES: usize = 512;
+
+/// Marker appended to a field cut to fit [`MAX_DIAGNOSTIC_FIELD_BYTES`].
+///
+/// A truncated value must be visibly truncated: a consumer comparing `actual`
+/// against a known contract has to be able to tell "this differs" from "this is
+/// the first 512 bytes of something that differs".
+pub const TRUNCATION_MARKER: &str = "…";
+
+/// Cut `field` to the byte bound, splitting only on a `char` boundary.
+///
+/// Slicing a `String` mid-codepoint panics, and these fields carry
+/// author-supplied text, so the split point is walked back to the nearest
+/// boundary rather than assumed.
+fn bounded_field(field: String) -> String {
+    if field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES {
+        return field;
+    }
+    let mut end = MAX_DIAGNOSTIC_FIELD_BYTES;
+    while end > 0 && !field.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = String::with_capacity(end + TRUNCATION_MARKER.len());
+    truncated.push_str(&field[..end]);
+    truncated.push_str(TRUNCATION_MARKER);
+    truncated
+}
+
+/// One stable, secret-free activation diagnostic.
+///
+/// Construct through [`ActivationDiagnostic::new`], which bounds every field
+/// and refuses a diagnostic that would be missing one — a caller that receives
+/// this type can rely on all five being present and non-empty.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ActivationDiagnostic {
+    code: String,
+    path: String,
+    expected: String,
+    actual: String,
+    remediation: String,
+}
+
+impl ActivationDiagnostic {
+    /// Build one complete diagnostic, or `None` when the contract cannot hold.
+    ///
+    /// Returns `None` when any field is empty or blank, or when `code` exceeds
+    /// [`MAX_DIAGNOSTIC_FIELD_BYTES`]. `code` is checked against the bound
+    /// rather than cut to fit: it is a stable machine-readable contract, and a
+    /// truncated code would silently name a different diagnostic. The remaining
+    /// four fields are truncated with [`TRUNCATION_MARKER`].
+    #[must_use]
+    pub fn new(
+        code: impl Into<String>,
+        path: impl Into<String>,
+        expected: impl Into<String>,
+        actual: impl Into<String>,
+        remediation: impl Into<String>,
+    ) -> Option<Self> {
+        let code = code.into();
+        if code.len() > MAX_DIAGNOSTIC_FIELD_BYTES {
+            return None;
+        }
+
+        let value = Self {
+            code,
+            path: bounded_field(path.into()),
+            expected: bounded_field(expected.into()),
+            actual: bounded_field(actual.into()),
+            remediation: bounded_field(remediation.into()),
+        };
+
+        [
+            value.code.as_str(),
+            value.path.as_str(),
+            value.expected.as_str(),
+            value.actual.as_str(),
+            value.remediation.as_str(),
+        ]
+        .iter()
+        .all(|field| !field.trim().is_empty())
+        .then_some(value)
+    }
+
+    /// Stable machine-readable diagnostic code.
+    #[must_use]
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    /// Canonical path to the incompatible workflow or registry element.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Secret-free description of the required contract.
+    #[must_use]
+    pub fn expected(&self) -> &str {
+        &self.expected
+    }
+
+    /// Secret-free description of the observed contract, or a safe sentinel.
+    #[must_use]
+    pub fn actual(&self) -> &str {
+        &self.actual
+    }
+
+    /// Stable, actionable remediation guidance.
+    #[must_use]
+    pub fn remediation(&self) -> &str {
+        &self.remediation
+    }
+}
+
+impl fmt::Debug for ActivationDiagnostic {
+    /// Shows only `code` and `path`.
+    ///
+    /// `expected` and `actual` describe contract content, which is exactly
+    /// where a credential default or a parameter value could reach a log line.
+    /// A caller that wants them asks for them by name.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ActivationDiagnostic")
+            .field("code", &self.code)
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for ActivationDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} at {}", self.code, self.path)
+    }
+}
+
+/// Produce this rejection's diagnostics in a canonical order.
+///
+/// Every activation rejection implements this, so a caller that renders an
+/// error does not need to know which layer refused it. Implementations return
+/// at least one diagnostic: a rejection with nothing to say is not actionable,
+/// and the whole point of the contract is that a caller can act.
+pub trait ActivationDiagnostics {
+    /// Canonically sorted, duplicate-free diagnostics for this rejection.
+    fn activation_diagnostics(&self) -> Vec<ActivationDiagnostic>;
+}
+
+/// Sort and deduplicate diagnostics so equivalent input reports identically.
+///
+/// Ordering is by `(code, path, expected, actual, remediation)` through the
+/// derived `Ord`, which makes the report reproducible: two runs over the same
+/// workflow emit the same sequence, so a snapshot test is meaningful and a
+/// caller diffing two reports sees only real changes.
+#[must_use]
+pub fn canonical_diagnostics(
+    mut diagnostics: Vec<ActivationDiagnostic>,
+) -> Vec<ActivationDiagnostic> {
+    diagnostics.sort();
+    diagnostics.dedup();
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diagnostic(path: &str, actual: &str) -> ActivationDiagnostic {
+        ActivationDiagnostic::new("E001", path, "a contract", actual, "fix it")
+            .expect("the fixture uses non-empty diagnostic fields")
+    }
+
+    #[test]
+    fn a_diagnostic_missing_any_field_is_refused() {
+        assert!(ActivationDiagnostic::new("", "/workflow", "a", "b", "fix").is_none());
+        assert!(ActivationDiagnostic::new("E1", "/workflow", "a", "", "fix").is_none());
+        assert!(ActivationDiagnostic::new("E1", "   ", "a", "b", "fix").is_none());
+    }
+
+    /// Author-supplied text reaches `path` and `actual`, so an unbounded
+    /// workflow value would push its whole length into every log line and error
+    /// body that names the diagnostic.
+    #[test]
+    fn author_supplied_fields_are_bounded_and_visibly_truncated() {
+        let overlong = "n".repeat(MAX_DIAGNOSTIC_FIELD_BYTES * 4);
+        let bounded = diagnostic(&overlong, &overlong);
+
+        for field in [bounded.path(), bounded.actual()] {
+            assert!(
+                field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
+                "a diagnostic field must not carry an unbounded workflow value"
+            );
+            assert!(
+                field.ends_with(TRUNCATION_MARKER),
+                "a truncated value must be visibly truncated, so a consumer cannot \
+                 mistake a prefix for the whole contract"
+            );
+        }
+        assert_eq!(
+            bounded.expected(),
+            "a contract",
+            "a short field is left as-is"
+        );
+    }
+
+    /// The bound splits on a `char` boundary: these fields carry author-supplied
+    /// text, and slicing a `String` mid-codepoint panics.
+    #[test]
+    fn truncation_splits_on_a_char_boundary() {
+        let multibyte = "日".repeat(MAX_DIAGNOSTIC_FIELD_BYTES);
+        let bounded = diagnostic(&multibyte, &multibyte);
+
+        assert!(bounded.path().ends_with(TRUNCATION_MARKER));
+        assert!(
+            bounded.path().len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
+            "walking back to a boundary must not push the value over the bound"
+        );
+        assert!(
+            bounded
+                .path()
+                .trim_end_matches(TRUNCATION_MARKER)
+                .chars()
+                .all(|character| character == '日'),
+            "truncation must not produce a partial codepoint"
+        );
+    }
+
+    /// A code is a stable machine-readable contract, so it is rejected rather
+    /// than cut: a truncated code would silently name a different diagnostic.
+    #[test]
+    fn an_overlong_code_is_rejected_rather_than_truncated() {
+        let overlong_code = "E".repeat(MAX_DIAGNOSTIC_FIELD_BYTES + 1);
+        assert!(
+            ActivationDiagnostic::new(&overlong_code, "/workflow", "a", "b", "fix").is_none(),
+            "a code that does not fit its own contract is a construction bug"
+        );
+    }
+
+    #[test]
+    fn contract_content_stays_out_of_debug_and_display() {
+        let secret = "credential-value-that-must-not-leak";
+        let rendered = diagnostic("/nodes/a", secret);
+        assert!(!format!("{rendered}").contains(secret));
+        assert!(!format!("{rendered:?}").contains(secret));
+    }
+
+    #[test]
+    fn equivalent_input_produces_one_stable_order() {
+        let later = diagnostic("/nodes/b", "second");
+        let earlier = diagnostic("/nodes/a", "first");
+
+        let canonical =
+            canonical_diagnostics(vec![later.clone(), earlier.clone(), earlier.clone()]);
+        assert_eq!(
+            canonical,
+            vec![earlier, later],
+            "equivalent input must produce a stable, duplicate-free order"
+        );
+    }
+}

--- a/crates/error/src/activation.rs
+++ b/crates/error/src/activation.rs
@@ -282,3 +282,143 @@ mod tests {
         );
     }
 }
+
+/// Version of the NS14 diagnostic-contract report shape.
+///
+/// Bumped when the report gains or loses a field, so a consumer that stored an
+/// older bundle can tell it is reading a different shape rather than silently
+/// missing an entry.
+pub const DIAGNOSTIC_CONTRACT_REPORT_VERSION: u16 = 1;
+
+/// One rejection's compliance with the five-field contract.
+///
+/// Records the observed values rather than a bare boolean: a reviewer reading
+/// the bundle can see *what* each rejection reports, not merely that it
+/// reported something. That distinction is what makes the report evidence
+/// instead of a checkbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DiagnosticContractEntry {
+    /// Rust path of the rejection variant this entry covers.
+    pub rejection: String,
+    /// Stable machine-readable code the rejection reports.
+    pub code: String,
+    /// Logical path the rejection points at.
+    pub path: String,
+    /// Whether the contract the rejection required is reported.
+    pub reports_expected: bool,
+    /// Whether what was found is reported.
+    pub reports_actual: bool,
+    /// Whether actionable guidance is reported.
+    pub reports_remediation: bool,
+}
+
+impl DiagnosticContractEntry {
+    /// Record what `diagnostic` reports for the rejection named `rejection`.
+    #[must_use]
+    pub fn observed(rejection: impl Into<String>, diagnostic: &ActivationDiagnostic) -> Self {
+        Self {
+            rejection: rejection.into(),
+            code: diagnostic.code().to_owned(),
+            path: diagnostic.path().to_owned(),
+            reports_expected: !diagnostic.expected().trim().is_empty(),
+            reports_actual: !diagnostic.actual().trim().is_empty(),
+            reports_remediation: !diagnostic.remediation().trim().is_empty(),
+        }
+    }
+
+    /// Whether this rejection satisfies the whole five-field contract.
+    ///
+    /// `code` and `path` are non-empty by construction — [`ActivationDiagnostic::new`]
+    /// refuses a diagnostic without them — so completeness reduces to the three
+    /// fields a producer could still leave blank.
+    #[must_use]
+    pub const fn is_complete(&self) -> bool {
+        self.reports_expected && self.reports_actual && self.reports_remediation
+    }
+}
+
+/// The versioned NS14 diagnostic-contract report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DiagnosticContractReport {
+    /// Shape version of this report.
+    pub report_version: u16,
+    /// Contract this report is evidence for.
+    pub contract: String,
+    /// One entry per rejection variant, ordered by `(rejection, code)`.
+    pub entries: Vec<DiagnosticContractEntry>,
+}
+
+impl DiagnosticContractReport {
+    /// Build a report over `entries`, ordered so two runs produce one document.
+    #[must_use]
+    pub fn new(mut entries: Vec<DiagnosticContractEntry>) -> Self {
+        entries.sort_by(|left, right| {
+            (&left.rejection, &left.code).cmp(&(&right.rejection, &right.code))
+        });
+        Self {
+            report_version: DIAGNOSTIC_CONTRACT_REPORT_VERSION,
+            contract: "ns14".to_owned(),
+            entries,
+        }
+    }
+
+    /// Rejections that do not satisfy the five-field contract.
+    ///
+    /// An empty slice is the only passing state; a caller that wants a gate
+    /// asserts on this rather than on a count, so a failure names the
+    /// rejections rather than reporting an arithmetic mismatch.
+    #[must_use]
+    pub fn incomplete(&self) -> Vec<&DiagnosticContractEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| !entry.is_complete())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod report_tests {
+    use super::*;
+
+    fn diagnostic() -> ActivationDiagnostic {
+        ActivationDiagnostic::new("E001", "/nodes/a", "a contract", "something else", "fix it")
+            .expect("the fixture uses non-empty diagnostic fields")
+    }
+
+    #[test]
+    fn a_complete_rejection_leaves_the_report_empty_of_gaps() {
+        let report = DiagnosticContractReport::new(vec![DiagnosticContractEntry::observed(
+            "WorkflowError::EmptyName",
+            &diagnostic(),
+        )]);
+
+        assert_eq!(report.report_version, DIAGNOSTIC_CONTRACT_REPORT_VERSION);
+        assert_eq!(report.contract, "ns14");
+        assert!(report.incomplete().is_empty());
+    }
+
+    /// The gate has to be able to fail, so a blank field must surface as a gap
+    /// rather than be smoothed over by the constructor.
+    #[test]
+    fn a_blank_field_surfaces_as_an_incomplete_entry() {
+        let mut entry = DiagnosticContractEntry::observed("WorkflowError::NoNodes", &diagnostic());
+        entry.reports_remediation = false;
+
+        let report = DiagnosticContractReport::new(vec![entry]);
+        let gaps = report.incomplete();
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0].rejection, "WorkflowError::NoNodes");
+    }
+
+    #[test]
+    fn entries_are_ordered_so_two_runs_produce_one_document() {
+        let later = DiagnosticContractEntry::observed("B", &diagnostic());
+        let earlier = DiagnosticContractEntry::observed("A", &diagnostic());
+
+        let report = DiagnosticContractReport::new(vec![later, earlier]);
+        assert_eq!(report.entries[0].rejection, "A");
+        assert_eq!(report.entries[1].rejection, "B");
+    }
+}

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -51,8 +51,9 @@ mod severity;
 mod traits;
 
 pub use activation::{
-    ActivationDiagnostic, ActivationDiagnostics, MAX_DIAGNOSTIC_FIELD_BYTES, TRUNCATION_MARKER,
-    canonical_diagnostics,
+    ActivationDiagnostic, ActivationDiagnostics, DIAGNOSTIC_CONTRACT_REPORT_VERSION,
+    DiagnosticContractEntry, DiagnosticContractReport, MAX_DIAGNOSTIC_FIELD_BYTES,
+    TRUNCATION_MARKER, canonical_diagnostics,
 };
 pub use category::ErrorCategory;
 pub use code::{ErrorCode, codes};

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -31,11 +31,14 @@
 //! | [`ErrorCode`] | Machine-readable error code newtype |
 //! | [`ErrorCollection`] | Batch/validation error aggregation |
 //! | [`RetryHint`] | Structured retry guidance consumed by `nebula-resilience` |
+//! | [`ActivationDiagnostic`] | Five-field structured activation rejection |
+//! | [`ActivationDiagnostics`] | Trait producing a rejection's diagnostics |
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod activation;
 mod category;
 mod code;
 mod collection;
@@ -47,6 +50,10 @@ mod retry;
 mod severity;
 mod traits;
 
+pub use activation::{
+    ActivationDiagnostic, ActivationDiagnostics, MAX_DIAGNOSTIC_FIELD_BYTES, TRUNCATION_MARKER,
+    canonical_diagnostics,
+};
 pub use category::ErrorCategory;
 pub use code::{ErrorCode, codes};
 pub use collection::{BatchResult, ErrorCollection};

--- a/crates/plugin/src/compatibility.rs
+++ b/crates/plugin/src/compatibility.rs
@@ -1,6 +1,7 @@
 //! Exact frozen-registry compatibility for integrity-checked Graph-v1 plans.
 
 use nebula_core::{CredentialKey, Dependencies, PluginSetId, ResourceKey, WorkerFlavorRevisionId};
+use nebula_error::{ActivationDiagnostic, ActivationDiagnostics};
 
 use crate::{
     FrozenPluginRegistry,
@@ -334,4 +335,124 @@ fn find_credential<'a>(
         })
         .min_by_key(|(plugin_key, _, _)| *plugin_key)
         .map(|(_, plugin, snapshot)| (plugin, snapshot))
+}
+
+/// Build one diagnostic from constant parts, or fall back to a complete one.
+///
+/// Every field here is a compiler-authored constant or a typed identifier, so
+/// construction cannot legitimately fail. The fallback exists because a
+/// rejection that reports nothing is worse than one that reports a coarse
+/// code: a caller must never receive an empty diagnostic list.
+fn diagnostic(
+    code: &str,
+    path: &str,
+    expected: String,
+    actual: String,
+    remediation: &str,
+) -> ActivationDiagnostic {
+    ActivationDiagnostic::new(code, path, expected, actual, remediation).unwrap_or_else(|| {
+        ActivationDiagnostic::new(
+            code,
+            path,
+            "<contract>",
+            "<unavailable>",
+            "recompile the plan against the frozen registry this worker loads",
+        )
+        .unwrap_or_else(|| unreachable!("the fallback diagnostic uses non-empty constants"))
+    })
+}
+
+impl ActivationDiagnostics for PlanRegistryCompatibilityError {
+    fn activation_diagnostics(&self) -> Vec<ActivationDiagnostic> {
+        let single = match self {
+            Self::PluginSetMismatch { plan, registry } => diagnostic(
+                "PLUGIN_PLAN_COMPATIBILITY:PLUGIN_SET_MISMATCH",
+                "/plan/plugin_set_id",
+                plan.to_string(),
+                registry.to_string(),
+                "load the worker flavor whose plugin set this plan was compiled against, \
+                 or recompile the plan against this worker's frozen registry",
+            ),
+            Self::WorkerFlavorMismatch { plan, registry } => diagnostic(
+                "PLUGIN_PLAN_COMPATIBILITY:WORKER_FLAVOR_MISMATCH",
+                "/plan/worker_flavor_revision_id",
+                plan.to_string(),
+                registry.to_string(),
+                "dispatch this plan to a worker running its pinned flavor, \
+                 or recompile the plan against this worker's flavor",
+            ),
+            // The section is a stable, payload-free contract name; the differing
+            // contract body is deliberately not reported, because it can carry
+            // schema defaults and credential metadata.
+            Self::ContractMismatch { section } => diagnostic(
+                "PLUGIN_PLAN_COMPATIBILITY:CONTRACT_MISMATCH",
+                &format!("/plan/{section}"),
+                "the contract recorded when this plan was compiled".to_owned(),
+                "a different contract in the frozen registry".to_owned(),
+                "recompile the plan against this worker's frozen registry",
+            ),
+        };
+        vec![single]
+    }
+}
+
+#[cfg(test)]
+mod activation_diagnostic_tests {
+    use nebula_core::PluginSetId;
+
+    use super::*;
+
+    #[test]
+    fn every_compatibility_rejection_reports_all_five_fields() {
+        let plan_set = PluginSetId::from_bytes([0x11; 32]);
+        let registry_set = PluginSetId::from_bytes([0x22; 32]);
+        let flavor_plan = WorkerFlavorRevisionId::from_bytes([0x33; 32]);
+        let flavor_registry = WorkerFlavorRevisionId::from_bytes([0x44; 32]);
+
+        let rejections = [
+            PlanRegistryCompatibilityError::PluginSetMismatch {
+                plan: plan_set,
+                registry: registry_set,
+            },
+            PlanRegistryCompatibilityError::WorkerFlavorMismatch {
+                plan: flavor_plan,
+                registry: flavor_registry,
+            },
+            PlanRegistryCompatibilityError::ContractMismatch { section: "actions" },
+        ];
+
+        for rejection in &rejections {
+            let diagnostics = rejection.activation_diagnostics();
+            assert!(
+                !diagnostics.is_empty(),
+                "a rejection with nothing to report is not actionable"
+            );
+            for reported in diagnostics {
+                for field in [
+                    reported.code(),
+                    reported.path(),
+                    reported.expected(),
+                    reported.actual(),
+                    reported.remediation(),
+                ] {
+                    assert!(!field.trim().is_empty(), "NS14 requires all five fields");
+                }
+            }
+        }
+    }
+
+    /// A mismatch names both sides, so a caller can tell which artifact to move
+    /// without re-deriving either identity.
+    #[test]
+    fn an_identity_mismatch_reports_both_sides() {
+        let plan = WorkerFlavorRevisionId::from_bytes([0x33; 32]);
+        let registry = WorkerFlavorRevisionId::from_bytes([0x44; 32]);
+        let reported = PlanRegistryCompatibilityError::WorkerFlavorMismatch { plan, registry }
+            .activation_diagnostics();
+
+        let only = reported.first().expect("one diagnostic is reported");
+        assert_eq!(only.expected(), plan.to_string());
+        assert_eq!(only.actual(), registry.to_string());
+        assert_ne!(only.expected(), only.actual());
+    }
 }

--- a/crates/plugin/src/compiler.rs
+++ b/crates/plugin/src/compiler.rs
@@ -20,23 +20,25 @@ use nebula_workflow::{
 use semver::{BuildMetadata, Version};
 
 use crate::plan::{
-    ActivationDiagnostic, CANONICAL_HASH_VERSION_V1, COMPILER_VERSION_GRAPH_V1,
-    ExecutablePlanRevision, PlanCompilationError, RECORD_VERSION_V1, RecordedActionKindV1,
-    RecordedActionV1, RecordedAuthPatternV1, RecordedBindingContractV1, RecordedBindingSiteV1,
-    RecordedBindingV1, RecordedCheckpointPolicyV1, RecordedCheckpointingV1, RecordedConnectionV1,
-    RecordedConverterV1, RecordedCredentialV1, RecordedDependenciesV1, RecordedDependencyV1,
-    RecordedDurationV1, RecordedErrorStrategyV1, RecordedExecutablePlanRevisionV1,
-    RecordedFlowKindV1, RecordedGraphContentV1, RecordedInputPortV1, RecordedIsolationV1,
-    RecordedNodeV1, RecordedOutputPortV1, RecordedParameterV1, RecordedParameterValueV1,
-    RecordedPlanManifestV1, RecordedPlanProfileV1, RecordedPluginV1, RecordedRateLimitV1,
-    RecordedResourceV1, RecordedRetryV1, RecordedSchemaV1, RecordedSemverV1, RecordedSlotV1,
-    RecordedTriggerV1, RecordedVariableV1, RecordedWorkflowConfigV1, RecordedWorkflowVersionV1,
+    CANONICAL_HASH_VERSION_V1, COMPILER_VERSION_GRAPH_V1, ExecutablePlanRevision,
+    PlanCompilationError, RECORD_VERSION_V1, RecordedActionKindV1, RecordedActionV1,
+    RecordedAuthPatternV1, RecordedBindingContractV1, RecordedBindingSiteV1, RecordedBindingV1,
+    RecordedCheckpointPolicyV1, RecordedCheckpointingV1, RecordedConnectionV1, RecordedConverterV1,
+    RecordedCredentialV1, RecordedDependenciesV1, RecordedDependencyV1, RecordedDurationV1,
+    RecordedErrorStrategyV1, RecordedExecutablePlanRevisionV1, RecordedFlowKindV1,
+    RecordedGraphContentV1, RecordedInputPortV1, RecordedIsolationV1, RecordedNodeV1,
+    RecordedOutputPortV1, RecordedParameterV1, RecordedParameterValueV1, RecordedPlanManifestV1,
+    RecordedPlanProfileV1, RecordedPluginV1, RecordedRateLimitV1, RecordedResourceV1,
+    RecordedRetryV1, RecordedSchemaV1, RecordedSemverV1, RecordedSlotV1, RecordedTriggerV1,
+    RecordedVariableV1, RecordedWorkflowConfigV1, RecordedWorkflowVersionV1,
     SCHEMA_WIRE_VERSION_GRAPH_V1, validate_node_parameters, validate_parameter,
     validate_parameter_contract, validate_reference_contract, validate_trigger_configuration,
 };
 use crate::resolved_plugin::{
     ActionContractSnapshot, CredentialContractSnapshot, ResourceContractSnapshot,
 };
+use nebula_error::ActivationDiagnostic;
+
 use crate::{FrozenPluginRegistry, ResolvedPlugin};
 
 const DEFAULT_OUTPUT_PORT: &str = "out";

--- a/crates/plugin/src/flavor.rs
+++ b/crates/plugin/src/flavor.rs
@@ -567,3 +567,98 @@ impl CanonicalSha256 {
         self.0.finalize().into()
     }
 }
+
+impl nebula_error::ActivationDiagnostics for WorkerFlavorIntegrityError {
+    fn activation_diagnostics(&self) -> Vec<nebula_error::ActivationDiagnostic> {
+        use nebula_error::ActivationDiagnostic;
+
+        let (code, path, expected, actual, remediation) = match self {
+            Self::UnsupportedRecordVersion { found } => (
+                "PLUGIN_FLAVOR_INTEGRITY:UNSUPPORTED_RECORD_VERSION",
+                "/worker_flavor/record_version",
+                WORKER_FLAVOR_RECORD_VERSION_V1.to_string(),
+                found.to_string(),
+                "re-record the worker flavor with a runtime that writes this envelope version",
+            ),
+            Self::UnsupportedCanonicalHashVersion { found } => (
+                "PLUGIN_FLAVOR_INTEGRITY:UNSUPPORTED_CANONICAL_HASH_VERSION",
+                "/worker_flavor/canonical_hash_version",
+                WORKER_FLAVOR_CANONICAL_HASH_VERSION_V1.to_string(),
+                found.to_string(),
+                "re-record the worker flavor with a runtime that derives this identity version",
+            ),
+            // Both identities are content digests, so reporting them leaks
+            // nothing about the artifacts they address.
+            Self::RevisionIdMismatch { claimed, computed } => (
+                "PLUGIN_FLAVOR_INTEGRITY:REVISION_ID_MISMATCH",
+                "/worker_flavor/id",
+                computed.to_string(),
+                claimed.to_string(),
+                "discard the record: its claimed identity does not match its own content",
+            ),
+        };
+
+        vec![
+            ActivationDiagnostic::new(code, path, expected, actual, remediation).unwrap_or_else(
+                || {
+                    ActivationDiagnostic::new(
+                        code,
+                        path,
+                        "<contract>",
+                        "<unavailable>",
+                        "discard and re-record the worker flavor",
+                    )
+                    .unwrap_or_else(|| {
+                        unreachable!("the fallback diagnostic uses non-empty constants")
+                    })
+                },
+            ),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod activation_diagnostic_tests {
+    use nebula_error::ActivationDiagnostics;
+
+    use super::*;
+
+    #[test]
+    fn every_flavor_integrity_rejection_reports_all_five_fields() {
+        let rejections = [
+            WorkerFlavorIntegrityError::UnsupportedRecordVersion { found: 99 },
+            WorkerFlavorIntegrityError::UnsupportedCanonicalHashVersion { found: 99 },
+            WorkerFlavorIntegrityError::RevisionIdMismatch {
+                claimed: WorkerFlavorRevisionId::from_bytes([0x11; 32]),
+                computed: WorkerFlavorRevisionId::from_bytes([0x22; 32]),
+            },
+        ];
+
+        for rejection in &rejections {
+            let diagnostics = rejection.activation_diagnostics();
+            assert!(!diagnostics.is_empty());
+            for reported in diagnostics {
+                for field in [
+                    reported.code(),
+                    reported.path(),
+                    reported.expected(),
+                    reported.actual(),
+                    reported.remediation(),
+                ] {
+                    assert!(!field.trim().is_empty(), "NS14 requires all five fields");
+                }
+            }
+        }
+    }
+
+    /// The supported version is reported as `expected`, so a caller learns what
+    /// to re-record against rather than only that the found one was wrong.
+    #[test]
+    fn an_unsupported_version_names_the_one_this_runtime_reads() {
+        let reported = WorkerFlavorIntegrityError::UnsupportedRecordVersion { found: 99 }
+            .activation_diagnostics();
+        let only = reported.first().expect("one diagnostic is reported");
+        assert_eq!(only.expected(), WORKER_FLAVOR_RECORD_VERSION_V1.to_string());
+        assert_eq!(only.actual(), "99");
+    }
+}

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -76,8 +76,8 @@ pub use nebula_core::PluginKey;
 pub use nebula_metadata::PluginDependency;
 pub use nebula_plugin_macros::Plugin;
 pub use plan::{
-    ActivationDiagnostic, ExecutablePlanIntegrityError, ExecutablePlanRevision,
-    PlanBindingContract, PlanBindingRequirement, PlanBindingSite, PlanCompilationError,
+    ExecutablePlanIntegrityError, ExecutablePlanRevision, PlanBindingContract,
+    PlanBindingRequirement, PlanBindingSite, PlanCompilationError,
     RecordedExecutablePlanRevisionV1,
 };
 pub use plugin::Plugin;

--- a/crates/plugin/src/plan.rs
+++ b/crates/plugin/src/plan.rs
@@ -9,6 +9,7 @@ use nebula_core::{
     ResourceKey, WorkerFlavorRevisionId, WorkflowId, WorkflowVersionId,
 };
 use nebula_credential::Capabilities;
+use nebula_error::ActivationDiagnostic;
 use nebula_schema::{
     Assignability, Field, FieldKey, FieldValue, FieldValues, InputSchema, OutputSchema, PathWalk,
     RequiredMode, Schema, SchemaKind, ValidSchema, explain_assignable, explain_field_assignable,
@@ -27,140 +28,6 @@ pub(crate) const SCHEMA_WIRE_VERSION_GRAPH_V1: u16 = 1;
 const _: () = assert!(nebula_schema::VALUE_CANON_VERSION == VALUE_CANON_VERSION_GRAPH_V1);
 const _: () = assert!(nebula_schema::SCHEMA_WIRE_VERSION == SCHEMA_WIRE_VERSION_GRAPH_V1);
 
-/// One stable, secret-free activation diagnostic emitted by the plan compiler.
-///
-/// Values are constructed only inside this crate so the compiler can guarantee
-/// that the five fields contain identifiers, versions, paths, or safe
-/// sentinels rather than configuration or secret payloads.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ActivationDiagnostic {
-    code: String,
-    path: String,
-    expected: String,
-    actual: String,
-    remediation: String,
-}
-
-/// Longest a single diagnostic field may be, in bytes.
-///
-/// Diagnostics travel into logs and HTTP responses, and several fields embed
-/// author-supplied text: a `path` names a node key, an `actual` reports the
-/// contract that was observed. Neither is bounded by anything upstream, so a
-/// workflow carrying a megabyte-long key would push a megabyte per diagnostic
-/// into every log line and error body that mentions it. The bound is generous
-/// enough that no honest identifier reaches it.
-pub(crate) const MAX_DIAGNOSTIC_FIELD_BYTES: usize = 512;
-
-/// Marker appended to a field that was cut to fit [`MAX_DIAGNOSTIC_FIELD_BYTES`].
-///
-/// A truncated value must be visibly truncated: a consumer comparing `actual`
-/// against a known contract has to be able to tell "this differs" from "this is
-/// the first 512 bytes of something that differs".
-const TRUNCATION_MARKER: &str = "…";
-
-/// Cut `field` to the byte bound, splitting only on a `char` boundary.
-///
-/// Slicing a `String` mid-codepoint panics, and these fields carry
-/// author-supplied text, so the split point is walked back to the nearest
-/// boundary rather than assumed.
-fn bounded_field(field: String) -> String {
-    if field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES {
-        return field;
-    }
-    let mut end = MAX_DIAGNOSTIC_FIELD_BYTES;
-    while end > 0 && !field.is_char_boundary(end) {
-        end -= 1;
-    }
-    let mut truncated = String::with_capacity(end + TRUNCATION_MARKER.len());
-    truncated.push_str(&field[..end]);
-    truncated.push_str(TRUNCATION_MARKER);
-    truncated
-}
-
-impl ActivationDiagnostic {
-    pub(crate) fn new(
-        code: impl Into<String>,
-        path: impl Into<String>,
-        expected: impl Into<String>,
-        actual: impl Into<String>,
-        remediation: impl Into<String>,
-    ) -> Option<Self> {
-        // `code` is a stable machine-readable contract, so it is checked
-        // against the bound rather than cut to fit: a truncated code would
-        // silently name a different diagnostic. Compiler-authored codes are
-        // short, so exceeding the bound is a construction bug, not input.
-        let code = code.into();
-        if code.len() > MAX_DIAGNOSTIC_FIELD_BYTES {
-            return None;
-        }
-
-        let value = Self {
-            code,
-            path: bounded_field(path.into()),
-            expected: bounded_field(expected.into()),
-            actual: bounded_field(actual.into()),
-            remediation: bounded_field(remediation.into()),
-        };
-
-        [
-            value.code.as_str(),
-            value.path.as_str(),
-            value.expected.as_str(),
-            value.actual.as_str(),
-            value.remediation.as_str(),
-        ]
-        .iter()
-        .all(|field| !field.trim().is_empty())
-        .then_some(value)
-    }
-
-    /// Stable machine-readable diagnostic code.
-    #[must_use]
-    pub fn code(&self) -> &str {
-        &self.code
-    }
-
-    /// Canonical path to the incompatible workflow or registry element.
-    #[must_use]
-    pub fn path(&self) -> &str {
-        &self.path
-    }
-
-    /// Secret-free description of the required contract.
-    #[must_use]
-    pub fn expected(&self) -> &str {
-        &self.expected
-    }
-
-    /// Secret-free description of the observed contract or a safe sentinel.
-    #[must_use]
-    pub fn actual(&self) -> &str {
-        &self.actual
-    }
-
-    /// Stable, actionable remediation guidance.
-    #[must_use]
-    pub fn remediation(&self) -> &str {
-        &self.remediation
-    }
-}
-
-impl fmt::Debug for ActivationDiagnostic {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("ActivationDiagnostic")
-            .field("code", &self.code)
-            .field("path", &self.path)
-            .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Display for ActivationDiagnostic {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{} at {}", self.code, self.path)
-    }
-}
-
 /// A non-empty, canonically ordered set of plan-activation diagnostics.
 #[derive(thiserror::Error)]
 #[error("workflow plan compilation failed")]
@@ -169,24 +36,24 @@ pub struct PlanCompilationError {
 }
 
 impl PlanCompilationError {
-    pub(crate) fn new(mut diagnostics: Vec<ActivationDiagnostic>) -> Option<Self> {
-        diagnostics.sort();
-        diagnostics.dedup();
+    pub(crate) fn new(diagnostics: Vec<ActivationDiagnostic>) -> Option<Self> {
+        let diagnostics = nebula_error::canonical_diagnostics(diagnostics);
         (!diagnostics.is_empty()).then(|| Self {
             diagnostics: diagnostics.into_boxed_slice(),
         })
     }
 
     pub(crate) fn invalid_compiled_record() -> Self {
+        let diagnostic = ActivationDiagnostic::new(
+            "PLUGIN_PLAN_GRAPH_V1:INVALID_COMPILED_RECORD",
+            "/workflow",
+            "<canonical-graph-v1-plan>",
+            "<unsupported-variant>",
+            "repair the reported workflow or component contract",
+        )
+        .expect("the compiled-record diagnostic has five non-empty constant fields");
         Self {
-            diagnostics: vec![ActivationDiagnostic {
-                code: "PLUGIN_PLAN_GRAPH_V1:INVALID_COMPILED_RECORD".to_owned(),
-                path: "/workflow".to_owned(),
-                expected: "<canonical-graph-v1-plan>".to_owned(),
-                actual: "<unsupported-variant>".to_owned(),
-                remediation: "repair the reported workflow or component contract".to_owned(),
-            }]
-            .into_boxed_slice(),
+            diagnostics: vec![diagnostic].into_boxed_slice(),
         }
     }
 
@@ -882,6 +749,83 @@ pub enum ExecutablePlanIntegrityError {
         /// Identity recomputed from canonical content.
         computed: ExecutablePlanRevisionId,
     },
+}
+
+impl nebula_error::ActivationDiagnostics for ExecutablePlanIntegrityError {
+    fn activation_diagnostics(&self) -> Vec<ActivationDiagnostic> {
+        let (code, path, expected, actual, remediation) = match self {
+            Self::UnsupportedFormat => (
+                "PLUGIN_PLAN_INTEGRITY:UNSUPPORTED_FORMAT",
+                "/plan/record_format".to_owned(),
+                "graph_v1_json".to_owned(),
+                "<unsupported-format>".to_owned(),
+                "recompile the workflow with a runtime that writes Graph-v1 plans",
+            ),
+            // The section is a stable path, never a payload value: a
+            // non-canonical section can hold parameter defaults.
+            Self::NonCanonical { section } => (
+                "PLUGIN_PLAN_INTEGRITY:NON_CANONICAL",
+                format!("/plan/{section}"),
+                "a canonically ordered, duplicate-free section".to_owned(),
+                "a section that is empty, unsorted, or duplicated".to_owned(),
+                "recompile the workflow: the record was not produced by a canonical compiler",
+            ),
+            Self::ConvertersUnsupported => (
+                "PLUGIN_PLAN_INTEGRITY:CONVERTERS_UNSUPPORTED",
+                "/plan/converters".to_owned(),
+                "an empty converter set".to_owned(),
+                "a non-empty converter set".to_owned(),
+                "recompile the workflow: Graph-v1 plans cannot carry converters",
+            ),
+            Self::UnknownCredentialCapability => (
+                "PLUGIN_PLAN_INTEGRITY:UNKNOWN_CAPABILITY",
+                "/plan/bindings/required_capability_bits".to_owned(),
+                "capability bits this runtime defines".to_owned(),
+                "<unknown-capability-bits>".to_owned(),
+                "run a worker whose credential contract defines every recorded capability",
+            ),
+            Self::CanonicalEncoding => (
+                "PLUGIN_PLAN_INTEGRITY:CANONICAL_ENCODING",
+                "/plan".to_owned(),
+                "a canonically encodable record".to_owned(),
+                "<uncanonicalizable-value>".to_owned(),
+                "recompile the workflow: a recorded value cannot be canonically encoded",
+            ),
+            // Both identities are content digests, so reporting them leaks
+            // nothing about the plan they address.
+            Self::RevisionIdMismatch { claimed, computed } => (
+                "PLUGIN_PLAN_INTEGRITY:REVISION_ID_MISMATCH",
+                "/plan/id".to_owned(),
+                computed.to_string(),
+                claimed.to_string(),
+                "discard the record: its claimed identity does not match its own content",
+            ),
+        };
+
+        vec![
+            ActivationDiagnostic::new(code, &path, expected, actual, remediation).unwrap_or_else(
+                || {
+                    ActivationDiagnostic::new(
+                        code,
+                        "/plan",
+                        "<contract>",
+                        "<unavailable>",
+                        "recompile the workflow against a canonical compiler",
+                    )
+                    .unwrap_or_else(|| {
+                        unreachable!("the fallback diagnostic uses non-empty constants")
+                    })
+                },
+            ),
+        ]
+    }
+}
+
+impl nebula_error::ActivationDiagnostics for PlanCompilationError {
+    fn activation_diagnostics(&self) -> Vec<ActivationDiagnostic> {
+        // Already canonical: `new` sorts and dedups on construction.
+        self.diagnostics.to_vec()
+    }
 }
 
 /// Integrity-checked, immutable, authority-free executable plan revision.
@@ -2525,71 +2469,62 @@ mod tests {
         assert!(PlanCompilationError::new(Vec::new()).is_none());
     }
 
-    /// Author-supplied text reaches `path` and `actual`, so an unbounded
-    /// workflow value would push its whole length into every log line and error
-    /// body that names the diagnostic.
+    /// Every integrity rejection reports all five NS14 fields.
+    ///
+    /// The list is exhaustive by construction: `activation_diagnostics` matches
+    /// the enum without a wildcard, so a new variant fails to compile there
+    /// before it can reach a caller with a missing field.
     #[test]
-    fn author_supplied_fields_are_bounded_and_visibly_truncated() {
-        let overlong = "n".repeat(MAX_DIAGNOSTIC_FIELD_BYTES * 4);
-        let bounded = diagnostic(
-            "E010",
-            &overlong,
-            "a contract",
-            &overlong,
-            "shorten the key",
-        );
+    fn every_plan_integrity_rejection_reports_all_five_fields() {
+        use nebula_error::ActivationDiagnostics;
 
-        for field in [bounded.path(), bounded.actual()] {
+        let rejections = [
+            ExecutablePlanIntegrityError::UnsupportedFormat,
+            ExecutablePlanIntegrityError::NonCanonical {
+                section: "bindings",
+            },
+            ExecutablePlanIntegrityError::ConvertersUnsupported,
+            ExecutablePlanIntegrityError::UnknownCredentialCapability,
+            ExecutablePlanIntegrityError::CanonicalEncoding,
+            ExecutablePlanIntegrityError::RevisionIdMismatch {
+                claimed: ExecutablePlanRevisionId::from_bytes([0x11; 32]),
+                computed: ExecutablePlanRevisionId::from_bytes([0x22; 32]),
+            },
+        ];
+
+        for rejection in &rejections {
+            let diagnostics = rejection.activation_diagnostics();
             assert!(
-                field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
-                "a diagnostic field must not carry an unbounded workflow value"
+                !diagnostics.is_empty(),
+                "a rejection with nothing to report is not actionable"
             );
-            assert!(
-                field.ends_with(TRUNCATION_MARKER),
-                "a truncated value must be visibly truncated, so a consumer cannot \
-                 mistake a prefix for the whole contract"
-            );
+            for reported in diagnostics {
+                for field in [
+                    reported.code(),
+                    reported.path(),
+                    reported.expected(),
+                    reported.actual(),
+                    reported.remediation(),
+                ] {
+                    assert!(!field.trim().is_empty(), "NS14 requires all five fields");
+                }
+            }
         }
-        assert_eq!(
-            bounded.code(),
-            "E010",
-            "a short field is left exactly as-is"
-        );
-        assert_eq!(bounded.expected(), "a contract");
     }
 
-    /// The bound splits on a `char` boundary: these fields carry author-supplied
-    /// text, and slicing a `String` mid-codepoint panics.
+    /// A compilation rejection hands its diagnostics through already canonical,
+    /// so two runs over the same workflow report the same sequence.
     #[test]
-    fn truncation_splits_on_a_char_boundary() {
-        // Three bytes per char, so the bound lands mid-codepoint.
-        let multibyte = "日".repeat(MAX_DIAGNOSTIC_FIELD_BYTES);
-        let bounded = diagnostic("E011", &multibyte, "a contract", &multibyte, "shorten it");
+    fn compilation_diagnostics_come_through_canonically_ordered() {
+        use nebula_error::ActivationDiagnostics;
 
-        assert!(bounded.path().ends_with(TRUNCATION_MARKER));
-        assert!(
-            bounded.path().len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
-            "walking back to a boundary must not push the value over the bound"
-        );
-        assert!(
-            bounded
-                .path()
-                .trim_end_matches(TRUNCATION_MARKER)
-                .chars()
-                .all(|character| character == '日'),
-            "truncation must not produce a partial codepoint"
-        );
-    }
+        let later = diagnostic("E002", "/nodes/b", "a contract", "second", "fix it");
+        let earlier = diagnostic("E001", "/nodes/a", "a contract", "first", "fix it");
+        let error =
+            PlanCompilationError::new(vec![later.clone(), earlier.clone(), earlier.clone()])
+                .expect("the fixture has diagnostics");
 
-    /// A code is a stable machine-readable contract, so it is rejected rather
-    /// than cut: a truncated code would silently name a different diagnostic.
-    #[test]
-    fn an_overlong_code_is_rejected_rather_than_truncated() {
-        let overlong_code = "E".repeat(MAX_DIAGNOSTIC_FIELD_BYTES + 1);
-        assert!(
-            ActivationDiagnostic::new(&overlong_code, "/workflow", "a", "b", "fix").is_none(),
-            "a code that does not fit its own contract is a construction bug"
-        );
+        assert_eq!(error.activation_diagnostics(), vec![earlier, later]);
     }
 
     fn recorded_semver(major: u64, minor: u64, patch: u64) -> RecordedSemverV1 {

--- a/crates/plugin/src/plan.rs
+++ b/crates/plugin/src/plan.rs
@@ -41,6 +41,42 @@ pub struct ActivationDiagnostic {
     remediation: String,
 }
 
+/// Longest a single diagnostic field may be, in bytes.
+///
+/// Diagnostics travel into logs and HTTP responses, and several fields embed
+/// author-supplied text: a `path` names a node key, an `actual` reports the
+/// contract that was observed. Neither is bounded by anything upstream, so a
+/// workflow carrying a megabyte-long key would push a megabyte per diagnostic
+/// into every log line and error body that mentions it. The bound is generous
+/// enough that no honest identifier reaches it.
+pub(crate) const MAX_DIAGNOSTIC_FIELD_BYTES: usize = 512;
+
+/// Marker appended to a field that was cut to fit [`MAX_DIAGNOSTIC_FIELD_BYTES`].
+///
+/// A truncated value must be visibly truncated: a consumer comparing `actual`
+/// against a known contract has to be able to tell "this differs" from "this is
+/// the first 512 bytes of something that differs".
+const TRUNCATION_MARKER: &str = "…";
+
+/// Cut `field` to the byte bound, splitting only on a `char` boundary.
+///
+/// Slicing a `String` mid-codepoint panics, and these fields carry
+/// author-supplied text, so the split point is walked back to the nearest
+/// boundary rather than assumed.
+fn bounded_field(field: String) -> String {
+    if field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES {
+        return field;
+    }
+    let mut end = MAX_DIAGNOSTIC_FIELD_BYTES;
+    while end > 0 && !field.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = String::with_capacity(end + TRUNCATION_MARKER.len());
+    truncated.push_str(&field[..end]);
+    truncated.push_str(TRUNCATION_MARKER);
+    truncated
+}
+
 impl ActivationDiagnostic {
     pub(crate) fn new(
         code: impl Into<String>,
@@ -49,12 +85,21 @@ impl ActivationDiagnostic {
         actual: impl Into<String>,
         remediation: impl Into<String>,
     ) -> Option<Self> {
+        // `code` is a stable machine-readable contract, so it is checked
+        // against the bound rather than cut to fit: a truncated code would
+        // silently name a different diagnostic. Compiler-authored codes are
+        // short, so exceeding the bound is a construction bug, not input.
+        let code = code.into();
+        if code.len() > MAX_DIAGNOSTIC_FIELD_BYTES {
+            return None;
+        }
+
         let value = Self {
-            code: code.into(),
-            path: path.into(),
-            expected: expected.into(),
-            actual: actual.into(),
-            remediation: remediation.into(),
+            code,
+            path: bounded_field(path.into()),
+            expected: bounded_field(expected.into()),
+            actual: bounded_field(actual.into()),
+            remediation: bounded_field(remediation.into()),
         };
 
         [
@@ -2478,6 +2523,73 @@ mod tests {
         assert!(!format!("{earlier}").contains(ACTUAL_CONTRACT_DETAIL));
         assert!(!format!("{earlier:?}").contains(ACTUAL_CONTRACT_DETAIL));
         assert!(PlanCompilationError::new(Vec::new()).is_none());
+    }
+
+    /// Author-supplied text reaches `path` and `actual`, so an unbounded
+    /// workflow value would push its whole length into every log line and error
+    /// body that names the diagnostic.
+    #[test]
+    fn author_supplied_fields_are_bounded_and_visibly_truncated() {
+        let overlong = "n".repeat(MAX_DIAGNOSTIC_FIELD_BYTES * 4);
+        let bounded = diagnostic(
+            "E010",
+            &overlong,
+            "a contract",
+            &overlong,
+            "shorten the key",
+        );
+
+        for field in [bounded.path(), bounded.actual()] {
+            assert!(
+                field.len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
+                "a diagnostic field must not carry an unbounded workflow value"
+            );
+            assert!(
+                field.ends_with(TRUNCATION_MARKER),
+                "a truncated value must be visibly truncated, so a consumer cannot \
+                 mistake a prefix for the whole contract"
+            );
+        }
+        assert_eq!(
+            bounded.code(),
+            "E010",
+            "a short field is left exactly as-is"
+        );
+        assert_eq!(bounded.expected(), "a contract");
+    }
+
+    /// The bound splits on a `char` boundary: these fields carry author-supplied
+    /// text, and slicing a `String` mid-codepoint panics.
+    #[test]
+    fn truncation_splits_on_a_char_boundary() {
+        // Three bytes per char, so the bound lands mid-codepoint.
+        let multibyte = "日".repeat(MAX_DIAGNOSTIC_FIELD_BYTES);
+        let bounded = diagnostic("E011", &multibyte, "a contract", &multibyte, "shorten it");
+
+        assert!(bounded.path().ends_with(TRUNCATION_MARKER));
+        assert!(
+            bounded.path().len() <= MAX_DIAGNOSTIC_FIELD_BYTES + TRUNCATION_MARKER.len(),
+            "walking back to a boundary must not push the value over the bound"
+        );
+        assert!(
+            bounded
+                .path()
+                .trim_end_matches(TRUNCATION_MARKER)
+                .chars()
+                .all(|character| character == '日'),
+            "truncation must not produce a partial codepoint"
+        );
+    }
+
+    /// A code is a stable machine-readable contract, so it is rejected rather
+    /// than cut: a truncated code would silently name a different diagnostic.
+    #[test]
+    fn an_overlong_code_is_rejected_rather_than_truncated() {
+        let overlong_code = "E".repeat(MAX_DIAGNOSTIC_FIELD_BYTES + 1);
+        assert!(
+            ActivationDiagnostic::new(&overlong_code, "/workflow", "a", "b", "fix").is_none(),
+            "a code that does not fit its own contract is a construction bug"
+        );
     }
 
     fn recorded_semver(major: u64, minor: u64, patch: u64) -> RecordedSemverV1 {

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -481,8 +481,11 @@ fn parameter_path(node: &NodeKey, param_key: &str) -> String {
 }
 
 /// Path to one connection, named by the endpoints it wires.
+///
+/// Matches the JSON Pointer convention the API already puts on the wire, so a
+/// client that keys on `errors[].pointer` keeps working.
 fn connection_path(from: &NodeKey, to: &NodeKey) -> String {
-    format!("/connections/{from}->{to}")
+    format!("/connections/{from}/{to}")
 }
 
 impl nebula_error::ActivationDiagnostics for WorkflowError {
@@ -511,14 +514,14 @@ impl nebula_error::ActivationDiagnostics for WorkflowError {
             ),
             Self::UnknownNode(key) => diagnostic(
                 "WORKFLOW:UNKNOWN_NODE",
-                "/connections".to_owned(),
+                format!("/nodes/{key}"),
                 "a connection endpoint naming a declared node".to_owned(),
                 key.to_string(),
                 "declare the node, or remove the connection that names it",
             ),
             Self::SelfLoop(key) => diagnostic(
                 "WORKFLOW:SELF_LOOP",
-                "/connections".to_owned(),
+                format!("/nodes/{key}"),
                 "a connection between two different nodes".to_owned(),
                 format!("{key}->{key}"),
                 "remove the self-referencing connection",
@@ -559,21 +562,21 @@ impl nebula_error::ActivationDiagnostics for WorkflowError {
             ),
             Self::InvalidActionKey { key, reason } => diagnostic(
                 "WORKFLOW:INVALID_ACTION_KEY",
-                "/nodes/action_key".to_owned(),
+                "/nodes".to_owned(),
                 "a well-formed action key".to_owned(),
                 key.clone(),
                 reason,
             ),
             Self::InvalidPluginKey { key, reason } => diagnostic(
                 "WORKFLOW:INVALID_PLUGIN_KEY",
-                "/nodes/plugin_key".to_owned(),
+                "/nodes".to_owned(),
                 "a well-formed plugin key".to_owned(),
                 key.clone(),
                 reason,
             ),
             Self::InvalidTrigger { reason } => diagnostic(
                 "WORKFLOW:INVALID_TRIGGER",
-                "/triggers".to_owned(),
+                "/trigger".to_owned(),
                 "a well-formed trigger".to_owned(),
                 reason.clone(),
                 "correct the trigger configuration",

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -482,8 +482,9 @@ fn parameter_path(node: &NodeKey, param_key: &str) -> String {
 
 /// Path to one connection, named by the endpoints it wires.
 ///
-/// Matches the JSON Pointer convention the API already puts on the wire, so a
-/// client that keys on `errors[].pointer` keeps working.
+/// Author-defined keys rather than an array index: an index changes meaning
+/// the moment a connection is inserted above this one, so a stored or diffed
+/// diagnostic would silently point elsewhere.
 fn connection_path(from: &NodeKey, to: &NodeKey) -> String {
     format!("/connections/{from}/{to}")
 }

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -434,3 +434,414 @@ impl std::fmt::Display for ReferenceTypeUndecidableDetails {
         )
     }
 }
+
+/// Render a detail list, or a sentinel when it is empty.
+///
+/// An empty list makes `actual` blank, which the diagnostic contract refuses —
+/// and the whole diagnostic then falls back to a coarse `/workflow` path,
+/// losing the very element the author has to change. A sentinel keeps the
+/// specific code and path while still saying honestly that no detail was
+/// reported.
+fn join_or_sentinel<T: std::fmt::Display>(items: &[T]) -> String {
+    if items.is_empty() {
+        return "<no detail reported>".to_owned();
+    }
+    join_display(items)
+}
+
+/// Build one diagnostic, falling back to a complete but coarse one.
+///
+/// Every call site supplies five non-empty values, so construction cannot
+/// legitimately fail. The fallback exists because a rejection that reports
+/// nothing is worse than one that reports a coarse code: a caller must never
+/// receive an empty diagnostic list.
+fn diagnostic(
+    code: &str,
+    path: String,
+    expected: String,
+    actual: String,
+    remediation: &str,
+) -> nebula_error::ActivationDiagnostic {
+    nebula_error::ActivationDiagnostic::new(code, &path, expected, actual, remediation)
+        .or_else(|| {
+            nebula_error::ActivationDiagnostic::new(
+                code,
+                "/workflow",
+                "<contract>",
+                "<unavailable>",
+                "repair the reported workflow element",
+            )
+        })
+        .unwrap_or_else(|| unreachable!("the fallback diagnostic uses non-empty constants"))
+}
+
+/// Path to one node's parameter, or to the node when the parameter is unknown.
+fn parameter_path(node: &NodeKey, param_key: &str) -> String {
+    format!("/nodes/{node}/parameters/{param_key}")
+}
+
+/// Path to one connection, named by the endpoints it wires.
+fn connection_path(from: &NodeKey, to: &NodeKey) -> String {
+    format!("/connections/{from}->{to}")
+}
+
+impl nebula_error::ActivationDiagnostics for WorkflowError {
+    fn activation_diagnostics(&self) -> Vec<nebula_error::ActivationDiagnostic> {
+        let single = match self {
+            Self::EmptyName => diagnostic(
+                "WORKFLOW:EMPTY_NAME",
+                "/name".to_owned(),
+                "a non-empty workflow name".to_owned(),
+                "an empty name".to_owned(),
+                "give the workflow a name",
+            ),
+            Self::NoNodes => diagnostic(
+                "WORKFLOW:NO_NODES",
+                "/nodes".to_owned(),
+                "at least one node".to_owned(),
+                "no nodes".to_owned(),
+                "add at least one node to the workflow",
+            ),
+            Self::DuplicateNodeKey(key) => diagnostic(
+                "WORKFLOW:DUPLICATE_NODE_KEY",
+                format!("/nodes/{key}"),
+                "one node per key".to_owned(),
+                "two or more nodes sharing this key".to_owned(),
+                "rename one of the nodes so every key is unique",
+            ),
+            Self::UnknownNode(key) => diagnostic(
+                "WORKFLOW:UNKNOWN_NODE",
+                "/connections".to_owned(),
+                "a connection endpoint naming a declared node".to_owned(),
+                key.to_string(),
+                "declare the node, or remove the connection that names it",
+            ),
+            Self::SelfLoop(key) => diagnostic(
+                "WORKFLOW:SELF_LOOP",
+                "/connections".to_owned(),
+                "a connection between two different nodes".to_owned(),
+                format!("{key}->{key}"),
+                "remove the self-referencing connection",
+            ),
+            Self::CycleDetected => diagnostic(
+                "WORKFLOW:CYCLE_DETECTED",
+                "/connections".to_owned(),
+                "an acyclic graph".to_owned(),
+                "a graph containing a cycle".to_owned(),
+                "break the cycle: execution order cannot be derived from a cyclic graph",
+            ),
+            Self::NoEntryNodes => diagnostic(
+                "WORKFLOW:NO_ENTRY_NODES",
+                "/nodes".to_owned(),
+                "at least one node with no incoming edge".to_owned(),
+                "every node has an incoming edge".to_owned(),
+                "remove an incoming edge so execution has somewhere to start",
+            ),
+            Self::InvalidParameterReference {
+                node_key,
+                source_node_key,
+            } => diagnostic(
+                "WORKFLOW:INVALID_PARAM_REF",
+                format!("/nodes/{node_key}/parameters"),
+                "a reference to a declared node".to_owned(),
+                source_node_key.to_string(),
+                "declare the referenced node, or point the parameter at an existing one",
+            ),
+            Self::ReferenceWithoutConnection {
+                node_key,
+                source_node_key,
+            } => diagnostic(
+                "WORKFLOW:REFERENCE_WITHOUT_CONNECTION",
+                format!("/nodes/{node_key}/parameters"),
+                format!("a connection from {source_node_key}"),
+                "a reference with no connection edge behind it".to_owned(),
+                "add the connection so the scheduler can see the dependency and order the nodes",
+            ),
+            Self::InvalidActionKey { key, reason } => diagnostic(
+                "WORKFLOW:INVALID_ACTION_KEY",
+                "/nodes/action_key".to_owned(),
+                "a well-formed action key".to_owned(),
+                key.clone(),
+                reason,
+            ),
+            Self::InvalidPluginKey { key, reason } => diagnostic(
+                "WORKFLOW:INVALID_PLUGIN_KEY",
+                "/nodes/plugin_key".to_owned(),
+                "a well-formed plugin key".to_owned(),
+                key.clone(),
+                reason,
+            ),
+            Self::InvalidTrigger { reason } => diagnostic(
+                "WORKFLOW:INVALID_TRIGGER",
+                "/triggers".to_owned(),
+                "a well-formed trigger".to_owned(),
+                reason.clone(),
+                "correct the trigger configuration",
+            ),
+            Self::UnsupportedSchema { version, max } => diagnostic(
+                "WORKFLOW:UNSUPPORTED_SCHEMA",
+                "/schema_version".to_owned(),
+                format!("at most {max}"),
+                version.to_string(),
+                "re-export the workflow from a version this runtime supports",
+            ),
+            Self::InvalidOwnerId => diagnostic(
+                "WORKFLOW:INVALID_OWNER_ID",
+                "/owner_id".to_owned(),
+                "a non-blank owner id".to_owned(),
+                "an empty or blank owner id".to_owned(),
+                "set an owner id on the workflow",
+            ),
+            Self::GraphError(reason) => diagnostic(
+                "WORKFLOW:GRAPH_ERROR",
+                "/connections".to_owned(),
+                "a constructible dependency graph".to_owned(),
+                reason.clone(),
+                "repair the connections so a dependency graph can be built",
+            ),
+            Self::DuplicateConnection { from, to } => diagnostic(
+                "WORKFLOW:DUPLICATE_CONNECTION",
+                connection_path(from, to),
+                "one connection per (source, target, port) triple".to_owned(),
+                "two or more identical connections".to_owned(),
+                "remove the redundant connection: duplicates confuse incoming-edge counting",
+            ),
+            Self::PortSchemaIncompatible(details) => diagnostic(
+                "WORKFLOW:PORT_SCHEMA_INCOMPATIBLE",
+                connection_path(&details.from_node, &details.to_node),
+                "an output schema assignable to the consumer's input schema".to_owned(),
+                join_or_sentinel(&details.incompatibilities),
+                "align the producer output with the consumer input, or insert a mapping node",
+            ),
+            Self::PortSchemaUndecidable(details) => diagnostic(
+                "WORKFLOW:PORT_SCHEMA_UNDECIDABLE",
+                connection_path(&details.from_node, &details.to_node),
+                "a statically decidable edge".to_owned(),
+                join_or_sentinel(&details.reasons),
+                "type the dynamic or opaque field, or validate in Gradual mode",
+            ),
+            Self::InvalidRetryConfig { node, reason } => diagnostic(
+                "WORKFLOW:INVALID_RETRY_CONFIG",
+                node.as_ref().map_or_else(
+                    || "/config/retry_policy".to_owned(),
+                    |key| format!("/nodes/{key}/retry_policy"),
+                ),
+                "a retry policy the scheduler can honour".to_owned(),
+                reason.clone(),
+                "correct the retry policy, or remove it to disable retries",
+            ),
+            Self::ReferencePathUnresolved(details) => diagnostic(
+                "WORKFLOW:REFERENCE_PATH_UNRESOLVED",
+                parameter_path(&details.consumer_node, &details.param_key),
+                format!(
+                    "a path resolvable through the output schema of {}",
+                    details.producer_node
+                ),
+                format!("{}: {}", details.output_path, details.reason),
+                "correct the output path, or widen the producer's output schema",
+            ),
+            Self::ReferenceTypeIncompatible(details) => diagnostic(
+                "WORKFLOW:REFERENCE_TYPE_INCOMPATIBLE",
+                parameter_path(&details.consumer_node, &details.param_key),
+                format!(
+                    "a leaf at {} assignable to this parameter",
+                    details.output_path
+                ),
+                join_or_sentinel(&details.incompatibilities),
+                "reference a compatible field, or change the parameter's expected type",
+            ),
+            Self::ReferenceTypeUndecidable(details) => diagnostic(
+                "WORKFLOW:REFERENCE_TYPE_UNDECIDABLE",
+                parameter_path(&details.consumer_node, &details.param_key),
+                format!("a statically decidable leaf at {}", details.output_path),
+                join_or_sentinel(&details.reasons),
+                "type the dynamic or opaque field, or validate in Gradual mode",
+            ),
+        };
+        vec![single]
+    }
+}
+
+#[cfg(test)]
+mod activation_diagnostic_tests {
+    use nebula_error::ActivationDiagnostics;
+
+    use super::*;
+
+    fn node(name: &'static str) -> NodeKey {
+        name.parse().expect("the fixture node key is well-formed")
+    }
+
+    /// One instance of every rejection this crate can produce.
+    ///
+    /// `activation_diagnostics` matches the enum without a wildcard, so a new
+    /// variant fails to compile there before it can reach a caller. This list
+    /// is the runtime half of that guarantee: it proves each variant actually
+    /// fills all five fields rather than merely having an arm.
+    fn every_rejection() -> Vec<WorkflowError> {
+        let incompat = || {
+            Box::new(PortSchemaIncompatDetails {
+                from_node: node("a"),
+                to_node: node("b"),
+                from_port: None,
+                to_port: None,
+                incompatibilities: Vec::new(),
+            })
+        };
+        vec![
+            WorkflowError::EmptyName,
+            WorkflowError::NoNodes,
+            WorkflowError::DuplicateNodeKey(node("a")),
+            WorkflowError::UnknownNode(node("a")),
+            WorkflowError::SelfLoop(node("a")),
+            WorkflowError::CycleDetected,
+            WorkflowError::NoEntryNodes,
+            WorkflowError::InvalidParameterReference {
+                node_key: node("a"),
+                source_node_key: node("b"),
+            },
+            WorkflowError::ReferenceWithoutConnection {
+                node_key: node("a"),
+                source_node_key: node("b"),
+            },
+            WorkflowError::InvalidActionKey {
+                key: "bad key".to_owned(),
+                reason: "keys must be dotted".to_owned(),
+            },
+            WorkflowError::InvalidPluginKey {
+                key: "bad key".to_owned(),
+                reason: "keys must be lowercase".to_owned(),
+            },
+            WorkflowError::InvalidTrigger {
+                reason: "cron expression is empty".to_owned(),
+            },
+            WorkflowError::UnsupportedSchema { version: 9, max: 1 },
+            WorkflowError::InvalidOwnerId,
+            WorkflowError::GraphError("edge resolution failed".to_owned()),
+            WorkflowError::DuplicateConnection {
+                from: node("a"),
+                to: node("b"),
+            },
+            WorkflowError::PortSchemaIncompatible(incompat()),
+            WorkflowError::PortSchemaUndecidable(Box::new(PortSchemaUndecidableDetails {
+                from_node: node("a"),
+                to_node: node("b"),
+                from_port: None,
+                to_port: None,
+                reasons: Vec::new(),
+            })),
+            WorkflowError::InvalidRetryConfig {
+                node: Some(node("a")),
+                reason: "max_attempts must be >= 1".to_owned(),
+            },
+            WorkflowError::InvalidRetryConfig {
+                node: None,
+                reason: "max_attempts must be >= 1".to_owned(),
+            },
+            WorkflowError::ReferencePathUnresolved(Box::new(ReferencePathUnresolvedDetails {
+                consumer_node: node("b"),
+                param_key: "input".to_owned(),
+                producer_node: node("a"),
+                output_path: "$.items[0]".to_owned(),
+                reason: "descend past leaf".to_owned(),
+            })),
+            WorkflowError::ReferenceTypeIncompatible(Box::new(ReferenceTypeIncompatDetails {
+                consumer_node: node("b"),
+                param_key: "input".to_owned(),
+                producer_node: node("a"),
+                output_path: "$.count".to_owned(),
+                incompatibilities: Vec::new(),
+            })),
+            WorkflowError::ReferenceTypeUndecidable(Box::new(ReferenceTypeUndecidableDetails {
+                consumer_node: node("b"),
+                param_key: "input".to_owned(),
+                producer_node: node("a"),
+                output_path: "$.count".to_owned(),
+                reasons: Vec::new(),
+            })),
+        ]
+    }
+
+    #[test]
+    fn every_workflow_rejection_reports_all_five_fields() {
+        for rejection in every_rejection() {
+            let diagnostics = rejection.activation_diagnostics();
+            assert!(
+                !diagnostics.is_empty(),
+                "a rejection with nothing to report is not actionable: {rejection:?}"
+            );
+            for reported in diagnostics {
+                for (name, field) in [
+                    ("code", reported.code()),
+                    ("path", reported.path()),
+                    ("expected", reported.expected()),
+                    ("actual", reported.actual()),
+                    ("remediation", reported.remediation()),
+                ] {
+                    assert!(
+                        !field.trim().is_empty(),
+                        "NS14 requires all five fields; `{name}` was blank for {rejection:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Codes are the machine-readable half of the contract, so two different
+    /// rejections must never answer to the same one.
+    #[test]
+    fn each_rejection_carries_a_distinct_stable_code() {
+        let mut codes: Vec<String> = every_rejection()
+            .iter()
+            .flat_map(|rejection| {
+                rejection
+                    .activation_diagnostics()
+                    .into_iter()
+                    .map(|reported| reported.code().to_owned())
+            })
+            .collect();
+        codes.sort();
+        codes.dedup();
+
+        // Both `InvalidRetryConfig` fixtures share one code by design; every
+        // other variant contributes its own.
+        assert_eq!(
+            codes.len(),
+            every_rejection().len() - 1,
+            "two rejections must not answer to the same code"
+        );
+        assert!(codes.iter().all(|code| code.starts_with("WORKFLOW:")));
+    }
+
+    /// The path points at the element the author has to change, so a UI can
+    /// highlight it instead of making the author search.
+    #[test]
+    fn the_path_names_the_offending_element() {
+        let reported =
+            WorkflowError::ReferenceTypeIncompatible(Box::new(ReferenceTypeIncompatDetails {
+                consumer_node: node("consumer"),
+                param_key: "input".to_owned(),
+                producer_node: node("producer"),
+                output_path: "$.count".to_owned(),
+                incompatibilities: Vec::new(),
+            }))
+            .activation_diagnostics();
+
+        let only = reported.first().expect("one diagnostic is reported");
+        assert_eq!(only.path(), "/nodes/consumer/parameters/input");
+
+        let workflow_default = WorkflowError::InvalidRetryConfig {
+            node: None,
+            reason: "max_attempts must be >= 1".to_owned(),
+        }
+        .activation_diagnostics();
+        assert_eq!(
+            workflow_default
+                .first()
+                .expect("one diagnostic is reported")
+                .path(),
+            "/config/retry_policy",
+            "a workflow-default policy points at the config, not at a node"
+        );
+    }
+}


### PR DESCRIPTION
Closes #979.

## What

Every activation rejection now carries the complete five-field NS14 diagnostic — `code`, `path`, `expected`, `actual`, `remediation` — from the crate that raised it all the way onto the RFC 9457 wire, without being flattened into prose at any layer.

## The type had to move down a layer first

`ActivationDiagnostic` lived in `nebula-plugin` (Business), but `WorkflowError` — which must produce the same shape — lives in `nebula-workflow` (Core), and Core may not depend on Business. Migrating the workflow variants onto the plugin type was impossible in principle; it would have failed `cargo deny` on the first commit.

It now lives in `nebula-error` (Cross-cutting), already a dependency of the validator, the compiler, and the API. That is what the issue means by "one **lower-layer** diagnostic type". It gained two things the shared contract needs:

- `ActivationDiagnostics` — the trait every rejection implements, so a caller rendering an error need not know which layer refused it.
- `canonical_diagnostics` — one sort-and-dedupe for every producer, so "deterministic ordering" is a single fact rather than each layer's own choice.

## Coverage

36 variants across four types: `WorkflowError` (22), `ExecutablePlanIntegrityError` (6), `WorkerFlavorIntegrityError` (3), `PlanRegistryCompatibilityError` (3), plus `PlanCompilationError`. Every match is wildcard-free, so a new variant fails to compile before it can reach a caller with fields missing — and a test instantiates every variant and asserts all five fields are non-blank, because an exhaustive match only proves an arm exists, not that it fills the contract.

## Bounding

`path` embeds an author-supplied node key and `actual` reports an observed contract; neither was bounded. Fields are now cut to 512 bytes with a visible marker, splitting on a `char` boundary. `code` is **rejected** rather than cut — it is a stable machine-readable contract and a truncated code would silently name a different diagnostic.

## Two defects found while building this

- An empty detail list (`PortSchemaIncompatible` and three siblings) made `actual` blank, so the diagnostic failed its own completeness check and the whole rejection fell back to a coarse `/workflow` path — losing the element the author has to change, exactly when the schema checker had least to say. Empty lists now render an explicit sentinel and keep their specific code and path.
- The API kept a second `WorkflowError` → pointer table. It is deleted rather than kept in sync: each diagnostic carries its own path, and two mappings for one fact drift.

## Wire changes

Workflow paths were aligned to the conventions the API table already emitted (`/connections/{from}/{to}`, `/trigger`, `/nodes/{key}`), so a client keying on `errors[].pointer` keeps working.

One deliberate change: structural rejections no longer collapse to the RFC 6901 root pointer. NS14 requires a non-empty path, and a cycle is always a property of the connections, so `/connections` is both required and strictly more useful. The test asserting the old root pointer encoded the pre-NS14 contract and was updated, not deleted.

`expected`/`actual`/`remediation` are optional on `ValidationFieldError`: request-level validators reject a malformed field rather than a mismatched contract, so they omit the NS14 fields instead of inventing them.

## Secret safety

Identity mismatches report both sides — these are content digests, so they leak nothing about the artifacts they address, and a caller needs both to know which artifact to move. Contract mismatches report only the stable section path and never the differing contract body, which can carry schema defaults and credential metadata. `Debug` and `Display` on the diagnostic expose only `code` and `path`.

## Evidence

- 6727 workspace tests pass (3 skipped), including new per-variant field-completeness, code-distinctness, path-targeting, ordering, truncation, and boundary-splitting cases.
- `cargo clippy --all-targets --all-features` clean.
- `task quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured activation diagnostics for workflow, plan, plugin, and compatibility validation errors.
  - Validation responses now include stable error codes, precise field or logical paths, expected and actual values, and remediation guidance.
  - Added consistent diagnostic normalization, including ordering, deduplication, and safe handling of sensitive or oversized values.
  - Added diagnostic contract reporting for comprehensive validation coverage.

- **Bug Fixes**
  - Improved connection and gateway validation errors with more actionable details.
  - Standardized credential and gateway validation error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->