### PR TITLE
feat(storage-port/storage)!: persist the ADR-0120 operation ledger (#977)

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -290,6 +290,7 @@ jobs:
             credential_lifecycle_postgres \
             credential_migration_postgres \
             credential_schema_admission_postgres \
+            operation_ledger_conformance_postgres \
             refresh_claim_pg_integration \
             revision_catalog_conformance_postgres \
             revision_catalog_migration_postgres \

--- a/crates/storage-port/src/dto/mod.rs
+++ b/crates/storage-port/src/dto/mod.rs
@@ -14,6 +14,7 @@ mod identity;
 mod job_dispatch;
 mod journal;
 mod node_result;
+mod operation_ledger;
 pub mod resume_token;
 mod revision_catalog;
 mod trigger_dedup;
@@ -43,6 +44,11 @@ pub use identity::{
 pub use job_dispatch::{DispatchKind, DispatchOutcome, JobDispatchMsg};
 pub use journal::JournalEntry;
 pub use node_result::{MAX_SUPPORTED_RESULT_SCHEMA_VERSION, NodeResultRecord};
+pub use operation_ledger::{
+    AttemptGeneration, DestinationCapability, EffectSlotBinding, EffectSlotId, KnownOutcome,
+    OperationId, OperationLedgerError, OperationRecord, OperationState, PrepareOutcome,
+    PreparedOperation, RequestFingerprint,
+};
 pub use resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash, TokenHashLengthError};
 pub use revision_catalog::{
     BeginDrainOutcome, ExecutablePlanRecordFormat, PlanFlavorRevisionIds, PlanFlavorRevisionRecord,

--- a/crates/storage-port/src/dto/operation_ledger.rs
+++ b/crates/storage-port/src/dto/operation_ledger.rs
@@ -1,0 +1,416 @@
+//! Durable operation-ledger values for the remote-effect protocol.
+//!
+//! A remote effect is not atomic with Nebula's database transaction, so the
+//! ledger is what makes a repeated invocation *decidable* rather than
+//! exactly-once. Runtime control durably prepares one operation before the
+//! provider is called; every retry and recovery of that same effect slot then
+//! carries the same [`OperationId`], and the persisted state records whether
+//! the outcome is known, unknown, or merely unacknowledged.
+//!
+//! Two distinctions carry most of the weight:
+//!
+//! - **A slot is an intended occurrence, not a payload.** Two slots stay
+//!   distinct even when their request bytes are identical, because "charge this
+//!   card twice" is a legitimate program. Deduplication is per slot.
+//! - **`OutcomeUnknown` is not a failure and `AcknowledgementUnknown` is not an
+//!   outcome.** The first says the provider's answer was never learned; the
+//!   second says our own database never confirmed the write. Collapsing either
+//!   into "error" is what authorizes a duplicate effect.
+//!
+//! Holding an [`OperationId`] grants no invocation authority. Authority comes
+//! from the destination's capability and the operation's current state, which
+//! is why both are persisted alongside it.
+
+use core::fmt;
+
+use crate::scope::Scope;
+
+/// Storage-minted identity of one intended remote-effect occurrence.
+///
+/// Minted by the ledger, never by an adapter or an API surface: a caller that
+/// could manufacture a slot identity could also silently merge two intended
+/// occurrences into one, or split one into two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EffectSlotId([u8; 16]);
+
+impl EffectSlotId {
+    /// Reconstruct a slot identity from its durable bytes.
+    ///
+    /// Restricted to the storage layer: minting is the ledger's own authority,
+    /// and this exists so an adapter can read a row back, not so a caller can
+    /// invent one.
+    #[must_use]
+    pub const fn from_storage_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Durable bytes of this slot identity.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl fmt::Display for EffectSlotId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Storage-minted identity carried to the provider for one prepared operation.
+///
+/// The same slot prepared again with the same fingerprint reuses this value, so
+/// a destination that keys on it sees one operation across every retry and
+/// recovery. Retaining it is not permission to invoke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OperationId([u8; 16]);
+
+impl OperationId {
+    /// Reconstruct an operation identity from its durable bytes.
+    ///
+    /// Restricted to the storage layer for the same reason as
+    /// [`EffectSlotId::from_storage_bytes`].
+    #[must_use]
+    pub const fn from_storage_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Durable bytes of this operation identity.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl fmt::Display for OperationId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Digest of one canonicalized effect request.
+///
+/// Carries the canonicalization version because digests produced under
+/// different rules are not comparable: two requests are "the same" only when
+/// the same rules produced the same bytes. A version change therefore reads as
+/// a mismatch rather than risking a false match that would reuse an operation
+/// identity for a different request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RequestFingerprint {
+    version: u16,
+    digest: [u8; 32],
+}
+
+impl RequestFingerprint {
+    /// Build a fingerprint from a digest and the rules that produced it.
+    #[must_use]
+    pub const fn new(version: u16, digest: [u8; 32]) -> Self {
+        Self { version, digest }
+    }
+
+    /// Canonicalization version.
+    #[must_use]
+    pub const fn version(self) -> u16 {
+        self.version
+    }
+
+    /// Raw digest bytes.
+    #[must_use]
+    pub const fn digest(&self) -> &[u8; 32] {
+        &self.digest
+    }
+}
+
+/// What a destination allows after an ambiguous effect boundary.
+///
+/// This is the only thing that distinguishes a safe bounded retry from a
+/// duplicate effect, so it is persisted with the operation rather than
+/// re-derived at recovery time — a destination's configuration can change
+/// between the prepare and the recovery, and the guarantee that applied is the
+/// one recorded when the operation was prepared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum DestinationCapability {
+    /// The destination honours a pinned stable key, so the *same* effecting
+    /// call may be re-invoked as a bounded recovery of the same prepared
+    /// operation while that guarantee holds.
+    StableKey,
+    /// The destination offers an authenticated read-only query, so an
+    /// ambiguous outcome may be *reconciled* but the effecting call is never
+    /// repeated.
+    Reconcilable,
+    /// Neither guarantee. An ambiguous boundary is terminal: the operation
+    /// records `OutcomeUnknown` and only privileged adjudication can resolve it.
+    Opaque,
+}
+
+/// The originating attempt an effect slot is bound to.
+///
+/// Engine retries mint new attempts, so binding the generation is what stops a
+/// stale worker's recovery from being mistaken for the current attempt's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AttemptGeneration(u64);
+
+impl AttemptGeneration {
+    /// Wrap a monotone attempt counter.
+    #[must_use]
+    pub const fn new(generation: u64) -> Self {
+        Self(generation)
+    }
+
+    /// Underlying counter.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Everything one durable preparation binds, before any provider is called.
+#[derive(Debug, Clone)]
+pub struct EffectSlotBinding<'a> {
+    /// Tenant that owns the slot. One tenant can neither observe nor mutate
+    /// another's operations.
+    pub scope: &'a Scope,
+    /// Execution the effect belongs to.
+    pub execution_id: &'a str,
+    /// Node within the execution that issues the effect.
+    pub node_key: &'a str,
+    /// Caller-chosen label distinguishing multiple effects from one node.
+    ///
+    /// Two intended occurrences from the same node are different slots even
+    /// with identical payloads, and this is what tells them apart.
+    pub occurrence: &'a str,
+    /// Attempt generation that originated this slot.
+    pub attempt_generation: AttemptGeneration,
+    /// Fingerprint of the canonicalized request.
+    pub fingerprint: RequestFingerprint,
+    /// Guarantee the destination offered when this slot was prepared.
+    pub destination: DestinationCapability,
+}
+
+/// One durably prepared operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedOperation {
+    slot_id: EffectSlotId,
+    operation_id: OperationId,
+    attempt_generation: AttemptGeneration,
+    destination: DestinationCapability,
+}
+
+impl PreparedOperation {
+    /// Build a prepared-operation projection from durable state.
+    #[must_use]
+    pub const fn new(
+        slot_id: EffectSlotId,
+        operation_id: OperationId,
+        attempt_generation: AttemptGeneration,
+        destination: DestinationCapability,
+    ) -> Self {
+        Self {
+            slot_id,
+            operation_id,
+            attempt_generation,
+            destination,
+        }
+    }
+
+    /// Storage-minted slot identity.
+    #[must_use]
+    pub const fn slot_id(self) -> EffectSlotId {
+        self.slot_id
+    }
+
+    /// Identity the provider receives for this operation.
+    #[must_use]
+    pub const fn operation_id(self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Attempt generation the slot was originally bound to.
+    #[must_use]
+    pub const fn attempt_generation(self) -> AttemptGeneration {
+        self.attempt_generation
+    }
+
+    /// Guarantee recorded when this operation was prepared.
+    #[must_use]
+    pub const fn destination(self) -> DestinationCapability {
+        self.destination
+    }
+}
+
+/// Result of durably preparing one effect slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrepareOutcome {
+    /// The slot was absent and is now durably prepared.
+    Prepared(PreparedOperation),
+    /// The slot already existed with the same fingerprint. This is the
+    /// original binding, including the original operation identity.
+    Replayed(PreparedOperation),
+}
+
+impl PrepareOutcome {
+    /// The prepared operation, whichever way it was reached.
+    #[must_use]
+    pub const fn operation(self) -> PreparedOperation {
+        match self {
+            Self::Prepared(operation) | Self::Replayed(operation) => operation,
+        }
+    }
+}
+
+/// Whether the provider's answer for one operation is known.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum OperationState {
+    /// Durably prepared; the provider may or may not have been called.
+    Prepared,
+    /// The provider accepted the effect.
+    Succeeded,
+    /// The provider rejected the effect without applying it.
+    Failed,
+    /// The boundary was crossed ambiguously and no bounded recovery remains.
+    ///
+    /// From here even a stable-key destination cannot re-invoke the effect;
+    /// only authenticated read-only reconciliation or privileged audited
+    /// adjudication may establish a known outcome.
+    OutcomeUnknown,
+}
+
+/// The full durable record of one effect slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OperationRecord {
+    operation: PreparedOperation,
+    fingerprint: RequestFingerprint,
+    state: OperationState,
+}
+
+impl OperationRecord {
+    /// Build a record projection from durable state.
+    #[must_use]
+    pub const fn new(
+        operation: PreparedOperation,
+        fingerprint: RequestFingerprint,
+        state: OperationState,
+    ) -> Self {
+        Self {
+            operation,
+            fingerprint,
+            state,
+        }
+    }
+
+    /// The prepared operation this record describes.
+    #[must_use]
+    pub const fn operation(self) -> PreparedOperation {
+        self.operation
+    }
+
+    /// Fingerprint the slot is bound to.
+    #[must_use]
+    pub const fn fingerprint(self) -> RequestFingerprint {
+        self.fingerprint
+    }
+
+    /// Current durable state.
+    #[must_use]
+    pub const fn state(self) -> OperationState {
+        self.state
+    }
+}
+
+/// A known provider answer being committed against a prepared operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum KnownOutcome {
+    /// The provider accepted the effect.
+    Succeeded,
+    /// The provider rejected the effect without applying it.
+    Failed,
+    /// The boundary was crossed ambiguously and recovery is exhausted.
+    OutcomeUnknown,
+}
+
+/// Closed, payload-redacted operation-ledger failure.
+///
+/// Variants carry only typed identifiers and bounded counters. Request
+/// payloads, provider responses, credentials, SQL, and driver messages never
+/// cross this boundary — an operation ledger sits directly beside the request
+/// bodies it must never echo.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum OperationLedgerError {
+    /// The slot is bound to a different canonical request.
+    ///
+    /// Nothing was written. Reusing a slot for a different request would give
+    /// two distinct effects one operation identity, so this fails closed.
+    #[error("effect slot is bound to a different request")]
+    OperationMismatch {
+        /// Slot whose binding differs.
+        slot_id: EffectSlotId,
+    },
+
+    /// The named slot has no durable preparation.
+    #[error("effect slot has no prepared operation")]
+    SlotUnprepared {
+        /// Slot that was read.
+        slot_id: EffectSlotId,
+    },
+
+    /// The caller's attempt generation is behind the durable binding.
+    ///
+    /// A superseded worker cannot commit an outcome for the current attempt.
+    #[error("attempt generation is stale for this effect slot")]
+    StaleFence {
+        /// Slot whose fence rejected the write.
+        slot_id: EffectSlotId,
+        /// Generation currently bound to the slot.
+        current: AttemptGeneration,
+    },
+
+    /// The slot exists but belongs to another tenant.
+    ///
+    /// Deliberately indistinguishable from an absent slot to a caller that
+    /// cannot see the tenant boundary: reporting "exists, but not yours" turns
+    /// a guessed identity into a cross-tenant existence oracle.
+    #[error("effect slot is not available in this tenant")]
+    TenantDenied,
+
+    /// A terminal outcome is already recorded and differs from this one.
+    ///
+    /// Outcomes are write-once. A second, different outcome would mean the
+    /// ledger had recorded two answers for one effect.
+    #[error("effect slot already recorded a different outcome")]
+    OutcomeAlreadyRecorded {
+        /// Slot whose outcome is already terminal.
+        slot_id: EffectSlotId,
+        /// Outcome the ledger holds.
+        recorded: OperationState,
+    },
+
+    /// Durable state violates an invariant this build can interpret.
+    #[error("operation ledger record is corrupt")]
+    CorruptRecord {
+        /// Slot whose record cannot be interpreted.
+        slot_id: EffectSlotId,
+    },
+
+    /// The operation definitely did not commit.
+    #[error("operation ledger is unavailable")]
+    Unavailable,
+
+    /// The commit was dispatched but its acknowledgement was lost.
+    ///
+    /// This is **not** a remote outcome. After a prepare, it authorizes zero
+    /// provider calls until a database-only read confirms the exact durable
+    /// binding; after an outcome commit, it authorizes only ledger reads and an
+    /// exact recommit of the same evidence under the current fence.
+    #[error("operation ledger acknowledgement is unknown; do not invoke the provider")]
+    AcknowledgementUnknown,
+}

--- a/crates/storage-port/src/lib.rs
+++ b/crates/storage-port/src/lib.rs
@@ -35,18 +35,20 @@ pub use dto::credential::{
 };
 pub use dto::resume_token::{ResumeTokenRow, ResumeTokenWaitKind, TokenHash, TokenHashLengthError};
 pub use dto::{
-    BeginDrainOutcome, ExecutablePlanRecordFormat, PlanFlavorRevisionIds, PlanFlavorRevisionRecord,
-    PlanFlavorRevisionTarget, RefreshRetryAdmission, RefreshRetryBlock, RefreshRetryDelay,
+    AttemptGeneration, BeginDrainOutcome, DestinationCapability, EffectSlotBinding, EffectSlotId,
+    ExecutablePlanRecordFormat, KnownOutcome, OperationId, OperationLedgerError, OperationRecord,
+    OperationState, PlanFlavorRevisionIds, PlanFlavorRevisionRecord, PlanFlavorRevisionTarget,
+    PrepareOutcome, PreparedOperation, RefreshRetryAdmission, RefreshRetryBlock, RefreshRetryDelay,
     RefreshRetryDelayError, RefreshRetryDiagnosticCode, RefreshRetryDiagnosticCodeError,
     RefreshRetryEvidence, RefreshRetryGate, RefreshRetryKind, RefreshRetryPhase,
-    RefreshRetrySnapshot, RefreshRetryTransition, RevisionCatalogError, RevisionInsertOutcome,
-    RevisionRecordBytes, RevisionReferenceCounts, WorkerFlavorRecordFormat,
+    RefreshRetrySnapshot, RefreshRetryTransition, RequestFingerprint, RevisionCatalogError,
+    RevisionInsertOutcome, RevisionRecordBytes, RevisionReferenceCounts, WorkerFlavorRecordFormat,
     WorkerFlavorRevisionRecord,
 };
 pub use error::StorageError;
 pub use ids::{CredentialId, FencingToken};
 pub use scope::Scope;
 pub use store::{
-    CredentialAlreadyExistsKey, CredentialPersistence, CredentialPersistenceError,
-    PlanFlavorCatalog, PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter,
+    CredentialAlreadyExistsKey, CredentialPersistence, CredentialPersistenceError, OperationLedger,
+    OperationLedgerAdjudicator, PlanFlavorCatalog, PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter,
 };

--- a/crates/storage-port/src/store/mod.rs
+++ b/crates/storage-port/src/store/mod.rs
@@ -15,6 +15,7 @@ mod identity;
 mod job_dispatch;
 mod journal;
 mod node_result;
+mod operation_ledger;
 mod refresh_claim;
 mod resume_producer;
 mod resume_token;
@@ -39,6 +40,7 @@ pub use identity::{
 pub use job_dispatch::{ClaimGeneration, JobClaim, JobClaimToken, JobDispatchQueue};
 pub use journal::ExecutionJournalReader;
 pub use node_result::NodeResultStore;
+pub use operation_ledger::{OperationLedger, OperationLedgerAdjudicator};
 pub use refresh_claim::{
     ClaimAttempt, ClaimToken, ExpiredClaim, HeartbeatError, RefreshClaim, RefreshClaimError,
     RefreshClaimStore, ReplicaId, SentinelState,

--- a/crates/storage-port/src/store/operation_ledger.rs
+++ b/crates/storage-port/src/store/operation_ledger.rs
@@ -1,0 +1,110 @@
+//! Object-safe operation-ledger roles for the remote-effect protocol.
+//!
+//! The roles are split by what they authorize, not by convenience. An effect
+//! caller prepares and commits; it cannot overwrite a terminal outcome or
+//! resolve an unknown one. Only the privileged adjudicator can, and every
+//! adjudication is audited — because deciding an ambiguous effect's outcome by
+//! hand is exactly the operation that must never happen silently.
+
+use core::fmt;
+
+use crate::dto::{
+    AttemptGeneration, EffectSlotBinding, EffectSlotId, KnownOutcome, OperationLedgerError,
+    OperationRecord, PrepareOutcome,
+};
+use crate::scope::Scope;
+
+/// Durable preparation and outcome recording for remote effects.
+///
+/// This is the capability runtime control holds while driving an effect. It
+/// cannot resolve an operation that has reached `OutcomeUnknown`.
+#[async_trait::async_trait]
+pub trait OperationLedger: Send + Sync + fmt::Debug {
+    /// Durably prepare one effect slot before the provider is invoked.
+    ///
+    /// The ledger mints the slot and operation identities; the caller supplies
+    /// only the binding. Preparing the same slot again with the same
+    /// fingerprint returns the original binding — including the original
+    /// operation identity — so every retry and recovery reaches the provider
+    /// under one identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationLedgerError::OperationMismatch`] when the slot is
+    /// already bound to a different canonical request, with no durable change.
+    /// [`OperationLedgerError::AcknowledgementUnknown`] means the commit may
+    /// have landed and **authorizes zero provider calls** until
+    /// [`Self::read_exact`] confirms the exact durable binding.
+    async fn prepare(
+        &self,
+        binding: &EffectSlotBinding<'_>,
+    ) -> Result<PrepareOutcome, OperationLedgerError>;
+
+    /// Read one slot's durable record without mutating anything.
+    ///
+    /// This is the database-only reconciliation an ambiguous prepare
+    /// acknowledgement permits, and the only thing it permits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationLedgerError::SlotUnprepared`] when the slot has no
+    /// durable preparation, and [`OperationLedgerError::TenantDenied`] when it
+    /// belongs to another tenant — the two are deliberately
+    /// indistinguishable to a caller that cannot see the tenant boundary.
+    async fn read_exact(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+    ) -> Result<OperationRecord, OperationLedgerError>;
+
+    /// Record a known outcome against a prepared operation, under its fence.
+    ///
+    /// `attempt_generation` must match the slot's durable binding: a
+    /// superseded worker cannot decide the current attempt's outcome.
+    /// Committing the same outcome again is idempotent, which is what lets a
+    /// caller whose acknowledgement was lost recommit the same frozen evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationLedgerError::StaleFence`] when the generation is
+    /// behind, [`OperationLedgerError::OutcomeAlreadyRecorded`] when a
+    /// *different* terminal outcome exists, and
+    /// [`OperationLedgerError::SlotUnprepared`] when nothing was prepared.
+    async fn commit_outcome(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        attempt_generation: AttemptGeneration,
+        outcome: KnownOutcome,
+    ) -> Result<(), OperationLedgerError>;
+}
+
+/// Privileged, audited resolution of an operation whose outcome is unknown.
+///
+/// Deliberately a separate role: runtime control must not be able to declare an
+/// ambiguous effect successful just because it holds the ledger. An
+/// adjudication is a human or operator decision about something the system
+/// could not determine, so it is capability-gated and leaves an audit record.
+#[async_trait::async_trait]
+pub trait OperationLedgerAdjudicator: Send + Sync + fmt::Debug {
+    /// Resolve an `OutcomeUnknown` operation to a known outcome.
+    ///
+    /// `evidence` is an operator-supplied, secret-free note recording *why*
+    /// the outcome is now known — a reconciliation query result, a provider
+    /// support ticket. It is persisted with the adjudication so the decision
+    /// is reviewable rather than anonymous.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OperationLedgerError::SlotUnprepared`] when the slot has no
+    /// record, and [`OperationLedgerError::OutcomeAlreadyRecorded`] when the
+    /// operation is not in `OutcomeUnknown` — adjudication resolves
+    /// uncertainty, it does not overrule a determined answer.
+    async fn adjudicate(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        outcome: KnownOutcome,
+        evidence: &str,
+    ) -> Result<(), OperationLedgerError>;
+}

--- a/crates/storage/migrations/postgres/0045_port_operation_ledger.sql
+++ b/crates/storage/migrations/postgres/0045_port_operation_ledger.sql
@@ -1,0 +1,88 @@
+-- Durable operation ledger for the remote-effect protocol.
+--
+-- One row per intended remote-effect occurrence. The row exists *before* the
+-- provider is invoked, so a worker that dies mid-call leaves behind a record
+-- saying an effect may have crossed the boundary — which is the whole point.
+--
+-- A slot is addressed two ways on purpose: by its storage-minted identity, and
+-- by the natural key a caller can reconstruct without having seen the slot
+-- before. The natural key is what lets a restarted worker find the operation it
+-- already prepared; the minted identity is what a caller carries afterwards.
+
+CREATE TABLE port_operation_ledger (
+    slot_id BYTEA PRIMARY KEY
+        CHECK (octet_length(slot_id) = 16),
+
+    workspace_id TEXT NOT NULL CHECK (length(workspace_id) > 0),
+    org_id TEXT NOT NULL CHECK (length(org_id) > 0),
+    execution_id TEXT NOT NULL CHECK (length(execution_id) > 0),
+    node_key TEXT NOT NULL CHECK (length(node_key) > 0),
+    -- Distinguishes two intended occurrences from one node. Identical payloads
+    -- are still two effects when the occurrence differs.
+    occurrence TEXT NOT NULL CHECK (length(occurrence) > 0),
+
+    attempt_generation BIGINT NOT NULL CHECK (attempt_generation >= 0),
+
+    -- Canonicalization version travels with the digest: digests produced under
+    -- different rules are not comparable, so a version change must read as a
+    -- mismatch rather than risk reusing an operation identity for a different
+    -- request.
+    fingerprint_version INTEGER NOT NULL CHECK (fingerprint_version >= 0),
+    fingerprint BYTEA NOT NULL CHECK (octet_length(fingerprint) = 32),
+
+    -- The guarantee recorded at prepare time, not the one the destination
+    -- happens to offer at recovery time.
+    destination TEXT NOT NULL
+        CHECK (destination IN ('stable_key', 'reconcilable', 'opaque')),
+
+    operation_id BYTEA NOT NULL UNIQUE
+        CHECK (octet_length(operation_id) = 16),
+
+    state TEXT NOT NULL
+        CHECK (state IN ('prepared', 'succeeded', 'failed', 'outcome_unknown')),
+
+    prepared_at_ms BIGINT NOT NULL,
+    outcome_at_ms BIGINT,
+
+    -- Operator-supplied, secret-free note recording why an ambiguous outcome
+    -- became known. Present only for an adjudicated row.
+    adjudication_evidence TEXT
+        CHECK (adjudication_evidence IS NULL OR length(adjudication_evidence) > 0),
+    adjudicated_at_ms BIGINT,
+
+    -- A prepared row has no outcome timestamp; a resolved one always does.
+    -- Without this a row could claim an outcome nothing ever recorded.
+    CONSTRAINT port_operation_ledger_outcome_shape
+        CHECK (
+            (state = 'prepared' AND outcome_at_ms IS NULL)
+            OR (state <> 'prepared' AND outcome_at_ms IS NOT NULL)
+        ),
+
+    -- Adjudication evidence and its timestamp travel together, and only on a
+    -- determined outcome: adjudication resolves uncertainty, so it can never
+    -- leave the row still unknown.
+    CONSTRAINT port_operation_ledger_adjudication_shape
+        CHECK (
+            (adjudication_evidence IS NULL AND adjudicated_at_ms IS NULL)
+            OR (
+                adjudication_evidence IS NOT NULL
+                AND adjudicated_at_ms IS NOT NULL
+                AND state IN ('succeeded', 'failed')
+            )
+        ),
+
+    -- The natural key a caller can rebuild without having seen the slot.
+    -- Scope columns are inside it, so one tenant can neither collide with nor
+    -- probe another's slots.
+    CONSTRAINT port_operation_ledger_slot_identity
+        UNIQUE (workspace_id, org_id, execution_id, node_key, occurrence)
+);
+
+-- Tenant-scoped lookup by the natural key drives every prepare.
+CREATE INDEX idx_port_operation_ledger_execution
+    ON port_operation_ledger (workspace_id, org_id, execution_id);
+
+-- Operators sweep unresolved ambiguity; this is the query that finds it.
+CREATE INDEX idx_port_operation_ledger_unresolved
+    ON port_operation_ledger (workspace_id, org_id, prepared_at_ms)
+    WHERE state IN ('prepared', 'outcome_unknown');

--- a/crates/storage/migrations/sqlite/0045_port_operation_ledger.sql
+++ b/crates/storage/migrations/sqlite/0045_port_operation_ledger.sql
@@ -1,0 +1,94 @@
+-- Durable operation ledger for the remote-effect protocol.
+--
+-- One row per intended remote-effect occurrence. The row exists *before* the
+-- provider is invoked, so a worker that dies mid-call leaves behind a record
+-- saying an effect may have crossed the boundary — which is the whole point.
+--
+-- A slot is addressed two ways on purpose: by its storage-minted identity, and
+-- by the natural key a caller can reconstruct without having seen the slot
+-- before. The natural key is what lets a restarted worker find the operation it
+-- already prepared; the minted identity is what a caller carries afterwards.
+
+CREATE TABLE port_operation_ledger (
+    slot_id BLOB PRIMARY KEY
+        CHECK (typeof(slot_id) = 'blob' AND length(slot_id) = 16),
+
+    workspace_id TEXT NOT NULL CHECK (length(workspace_id) > 0),
+    org_id TEXT NOT NULL CHECK (length(org_id) > 0),
+    execution_id TEXT NOT NULL CHECK (length(execution_id) > 0),
+    node_key TEXT NOT NULL CHECK (length(node_key) > 0),
+    -- Distinguishes two intended occurrences from one node. Identical payloads
+    -- are still two effects when the occurrence differs.
+    occurrence TEXT NOT NULL CHECK (length(occurrence) > 0),
+
+    attempt_generation INTEGER NOT NULL
+        CHECK (typeof(attempt_generation) = 'integer' AND attempt_generation >= 0),
+
+    -- Canonicalization version travels with the digest: digests produced under
+    -- different rules are not comparable, so a version change must read as a
+    -- mismatch rather than risk reusing an operation identity for a different
+    -- request.
+    fingerprint_version INTEGER NOT NULL
+        CHECK (typeof(fingerprint_version) = 'integer' AND fingerprint_version >= 0),
+    fingerprint BLOB NOT NULL
+        CHECK (typeof(fingerprint) = 'blob' AND length(fingerprint) = 32),
+
+    -- The guarantee recorded at prepare time, not the one the destination
+    -- happens to offer at recovery time.
+    destination TEXT NOT NULL
+        CHECK (destination IN ('stable_key', 'reconcilable', 'opaque')),
+
+    operation_id BLOB NOT NULL UNIQUE
+        CHECK (typeof(operation_id) = 'blob' AND length(operation_id) = 16),
+
+    state TEXT NOT NULL
+        CHECK (state IN ('prepared', 'succeeded', 'failed', 'outcome_unknown')),
+
+    prepared_at_ms INTEGER NOT NULL
+        CHECK (typeof(prepared_at_ms) = 'integer'),
+    outcome_at_ms INTEGER
+        CHECK (outcome_at_ms IS NULL OR typeof(outcome_at_ms) = 'integer'),
+
+    -- Operator-supplied, secret-free note recording why an ambiguous outcome
+    -- became known. Present only for an adjudicated row.
+    adjudication_evidence TEXT
+        CHECK (adjudication_evidence IS NULL OR length(adjudication_evidence) > 0),
+    adjudicated_at_ms INTEGER
+        CHECK (adjudicated_at_ms IS NULL OR typeof(adjudicated_at_ms) = 'integer'),
+
+    -- A prepared row has no outcome timestamp; a resolved one always does.
+    -- Without this a row could claim an outcome nothing ever recorded.
+    CONSTRAINT port_operation_ledger_outcome_shape
+        CHECK (
+            (state = 'prepared' AND outcome_at_ms IS NULL)
+            OR (state <> 'prepared' AND outcome_at_ms IS NOT NULL)
+        ),
+
+    -- Adjudication evidence and its timestamp travel together, and only on a
+    -- determined outcome: adjudication resolves uncertainty, so it can never
+    -- leave the row still unknown.
+    CONSTRAINT port_operation_ledger_adjudication_shape
+        CHECK (
+            (adjudication_evidence IS NULL AND adjudicated_at_ms IS NULL)
+            OR (
+                adjudication_evidence IS NOT NULL
+                AND adjudicated_at_ms IS NOT NULL
+                AND state IN ('succeeded', 'failed')
+            )
+        ),
+
+    -- The natural key a caller can rebuild without having seen the slot.
+    -- Scope columns are inside it, so one tenant can neither collide with nor
+    -- probe another's slots.
+    CONSTRAINT port_operation_ledger_slot_identity
+        UNIQUE (workspace_id, org_id, execution_id, node_key, occurrence)
+);
+
+-- Tenant-scoped lookup by the natural key drives every prepare.
+CREATE INDEX idx_port_operation_ledger_execution
+    ON port_operation_ledger (workspace_id, org_id, execution_id);
+
+-- Operators sweep unresolved ambiguity; this is the query that finds it.
+CREATE INDEX idx_port_operation_ledger_unresolved
+    ON port_operation_ledger (workspace_id, org_id, prepared_at_ms)
+    WHERE state IN ('prepared', 'outcome_unknown');

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -15,6 +15,7 @@ mod identity;
 mod job_dispatch;
 mod journal;
 mod node_result;
+mod operation_ledger;
 mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
@@ -32,6 +33,7 @@ pub use identity::{
 pub use job_dispatch::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox};
 pub use journal::InMemoryJournalReader;
 pub use node_result::{InMemoryCheckpointStore, InMemoryNodeResultStore};
+pub use operation_ledger::InMemoryOperationLedger;
 pub use plan_flavor_catalog::InMemoryPlanFlavorCatalog;
 pub use resume_producer::InMemoryResumeProducer;
 pub use resume_token::InMemoryResumeTokenStore;

--- a/crates/storage/src/inmem/operation_ledger.rs
+++ b/crates/storage/src/inmem/operation_ledger.rs
@@ -1,0 +1,270 @@
+//! In-memory operation ledger — the reference/conformance model.
+//!
+//! Every operation runs inside one `parking_lot` mutex critical section, the
+//! in-memory equivalent of the SQL backends' single transaction. The mutex is
+//! not a transaction: there is no rollback, so each operation decides
+//! everything it needs *before* it writes, and the writes that follow are
+//! infallible. A prepare that failed halfway would otherwise leave a slot
+//! bound to a request the caller was told was rejected.
+//!
+//! Identities are minted here, never accepted from a caller: a caller able to
+//! choose a slot identity could merge two intended occurrences into one.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use nebula_storage_port::store::{OperationLedger, OperationLedgerAdjudicator};
+use nebula_storage_port::{
+    AttemptGeneration, EffectSlotBinding, EffectSlotId, KnownOutcome, OperationId,
+    OperationLedgerError, OperationRecord, OperationState, PrepareOutcome, Scope,
+};
+use parking_lot::Mutex;
+
+use crate::operation_ledger::{
+    CommitDecision, compose_record, decide_adjudication, decide_commit, decide_prepare,
+    prepare_label, read_label, write_label,
+};
+
+/// The natural key a caller can rebuild without having seen the slot.
+///
+/// A restarted worker finds the operation it already prepared through this,
+/// which is why the slot identity cannot be the only address.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SlotKey {
+    workspace_id: String,
+    org_id: String,
+    execution_id: String,
+    node_key: String,
+    occurrence: String,
+}
+
+impl SlotKey {
+    fn of(binding: &EffectSlotBinding<'_>) -> Self {
+        Self {
+            workspace_id: binding.scope.workspace_id.clone(),
+            org_id: binding.scope.org_id.clone(),
+            execution_id: binding.execution_id.to_owned(),
+            node_key: binding.node_key.to_owned(),
+            occurrence: binding.occurrence.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LedgerRow {
+    scope: Scope,
+    record: OperationRecord,
+}
+
+#[derive(Debug, Default)]
+struct LedgerState {
+    /// Slots addressed by the key a caller can rebuild.
+    by_key: HashMap<SlotKey, EffectSlotId>,
+    /// Slots addressed by the identity a caller carries afterwards.
+    rows: HashMap<EffectSlotId, LedgerRow>,
+}
+
+/// In-memory reference implementation of the durable operation ledger.
+#[derive(Clone, Debug, Default)]
+pub struct InMemoryOperationLedger {
+    inner: Arc<Mutex<LedgerState>>,
+}
+
+impl InMemoryOperationLedger {
+    /// Build an empty ledger.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Read a row for `slot_id` that `scope` is allowed to see.
+///
+/// A slot owned by another tenant is reported exactly as an absent one: saying
+/// "exists, but not yours" would turn a guessed identity into a cross-tenant
+/// existence oracle.
+fn visible_row<'state>(
+    state: &'state LedgerState,
+    scope: &Scope,
+    slot_id: EffectSlotId,
+) -> Result<&'state LedgerRow, OperationLedgerError> {
+    let row = state
+        .rows
+        .get(&slot_id)
+        .ok_or(OperationLedgerError::SlotUnprepared { slot_id })?;
+    if row.scope != *scope {
+        return Err(OperationLedgerError::SlotUnprepared { slot_id });
+    }
+    Ok(row)
+}
+
+#[async_trait::async_trait]
+impl OperationLedger for InMemoryOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.prepare",
+        skip(self, binding),
+        fields(
+            backend = "in_memory",
+            execution_id = binding.execution_id,
+            node_key = binding.node_key,
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn prepare(
+        &self,
+        binding: &EffectSlotBinding<'_>,
+    ) -> Result<PrepareOutcome, OperationLedgerError> {
+        let result = {
+            let mut state = self.inner.lock();
+            let key = SlotKey::of(binding);
+
+            if let Some(slot_id) = state.by_key.get(&key).copied() {
+                let row = state
+                    .rows
+                    .get(&slot_id)
+                    .ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+                // Decide before writing: a mismatch must leave no durable
+                // delta, and this critical section cannot roll back.
+                decide_prepare(slot_id, &row.record, binding)
+            } else {
+                let slot_id = EffectSlotId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+                let operation_id =
+                    OperationId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+                let record = compose_record(
+                    slot_id,
+                    operation_id,
+                    binding.attempt_generation,
+                    binding.destination,
+                    binding.fingerprint,
+                    OperationState::Prepared,
+                );
+                state.by_key.insert(key, slot_id);
+                state.rows.insert(
+                    slot_id,
+                    LedgerRow {
+                        scope: binding.scope.clone(),
+                        record,
+                    },
+                );
+                Ok(PrepareOutcome::Prepared(record.operation()))
+            }
+        };
+
+        let outcome = prepare_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::inmem", outcome, "operation ledger prepare");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.read_exact",
+        skip(self),
+        fields(backend = "in_memory", outcome = tracing::field::Empty)
+    )]
+    async fn read_exact(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+    ) -> Result<OperationRecord, OperationLedgerError> {
+        let result = {
+            let state = self.inner.lock();
+            visible_row(&state, scope, slot_id).map(|row| row.record)
+        };
+
+        let outcome = read_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::inmem", outcome, "operation ledger read");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.commit_outcome",
+        skip(self),
+        fields(backend = "in_memory", outcome = tracing::field::Empty)
+    )]
+    async fn commit_outcome(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        attempt_generation: AttemptGeneration,
+        outcome: KnownOutcome,
+    ) -> Result<(), OperationLedgerError> {
+        let result = {
+            let mut state = self.inner.lock();
+            let stored = visible_row(&state, scope, slot_id)?.record;
+            match decide_commit(slot_id, &stored, attempt_generation, outcome)? {
+                CommitDecision::AlreadyRecorded => Ok(()),
+                CommitDecision::Apply(target) => {
+                    let row = state
+                        .rows
+                        .get_mut(&slot_id)
+                        .ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+                    row.record = OperationRecord::new(
+                        row.record.operation(),
+                        row.record.fingerprint(),
+                        target,
+                    );
+                    Ok(())
+                },
+            }
+        };
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::inmem",
+            outcome = label,
+            "operation ledger fenced commit"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl OperationLedgerAdjudicator for InMemoryOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.adjudicate",
+        // `evidence` is operator prose and is deliberately not a span field:
+        // it is persisted for review, not broadcast to every trace consumer.
+        skip(self, evidence),
+        fields(backend = "in_memory", outcome = tracing::field::Empty)
+    )]
+    async fn adjudicate(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        outcome: KnownOutcome,
+        evidence: &str,
+    ) -> Result<(), OperationLedgerError> {
+        let result = {
+            let mut state = self.inner.lock();
+            let stored = visible_row(&state, scope, slot_id)?.record;
+            let target = decide_adjudication(slot_id, &stored, outcome)?;
+            if evidence.trim().is_empty() {
+                // An adjudication without a reason is not reviewable, which is
+                // the only thing that makes a hand-decided outcome acceptable.
+                return Err(OperationLedgerError::CorruptRecord { slot_id });
+            }
+            let row = state
+                .rows
+                .get_mut(&slot_id)
+                .ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+            row.record =
+                OperationRecord::new(row.record.operation(), row.record.fingerprint(), target);
+            Ok(())
+        };
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::inmem",
+            outcome = label,
+            "operation ledger adjudication"
+        );
+        result
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -77,6 +77,10 @@ pub mod inmem;
 pub mod mapping;
 #[cfg(any(test, feature = "sqlite", feature = "postgres"))]
 mod migration;
+/// Backend-independent operation-ledger decisions, shared by every ledger
+/// adapter so state vocabulary, fence comparison, and outcome write-once rules
+/// cannot drift between backends.
+mod operation_ledger;
 /// Postgres implementations of [`repos`] traits.
 #[cfg(feature = "postgres")]
 pub mod pg;

--- a/crates/storage/src/migration/mod.rs
+++ b/crates/storage/src/migration/mod.rs
@@ -727,8 +727,13 @@ mod tests {
     /// value from the migrator would make it pass automatically and prove
     /// nothing.
     ///
-    /// Head 0044 (`control_queue_claim_generation`) reviewed against the
-    /// floor: it adds one defaulted column to `port_control_queue` and performs
+    /// Head 0045 (`port_operation_ledger`) reviewed against the floor: it
+    /// creates one new table and touches no existing relation, so it needs no
+    /// aggregate-owner validation and the floor stays at 0040. Its `CHECK`
+    /// constraints bind only rows the migration itself introduces, so no
+    /// database admitted at 0040 or later can hold a row they would reject.
+    /// The same review covered 0044 (`control_queue_claim_generation`), which
+    /// adds one defaulted column to `port_control_queue` and performs
     /// no destructive transform, so it needs no aggregate-owner validation and
     /// the floor stays at 0040. The same review covered 0043
     /// (`port_start_key_reservations`), which creates one new table:
@@ -758,9 +763,9 @@ mod tests {
     fn new_catalog_head_requires_explicit_admission_policy_review() {
         assert_eq!(GENERAL_CATALOG_SUPPORTED_FLOOR, 40);
         #[cfg(feature = "sqlite")]
-        assert_eq!(catalog::catalog_head(&super::SQLITE_MIGRATOR), 44);
+        assert_eq!(catalog::catalog_head(&super::SQLITE_MIGRATOR), 45);
         #[cfg(feature = "postgres")]
-        assert_eq!(catalog::catalog_head(&super::POSTGRES_MIGRATOR), 44);
+        assert_eq!(catalog::catalog_head(&super::POSTGRES_MIGRATOR), 45);
     }
 
     /// The setup guard must never hold a descriptor on the database file.

--- a/crates/storage/src/operation_ledger.rs
+++ b/crates/storage/src/operation_ledger.rs
@@ -1,0 +1,439 @@
+//! Backend-independent operation-ledger decisions.
+//!
+//! The in-memory reference model, SQLite, and PostgreSQL must answer every
+//! ledger question identically, so the questions are answered once here. Row
+//! plumbing stays in each adapter; the decisions do not.
+//!
+//! Durable state and destination text is the same vocabulary ordered migration
+//! 0045 constrains with `CHECK` clauses. The constants below are the single
+//! Rust-side definition of that vocabulary.
+
+use nebula_storage_port::{
+    AttemptGeneration, DestinationCapability, EffectSlotBinding, EffectSlotId, KnownOutcome,
+    OperationId, OperationLedgerError, OperationRecord, OperationState, PrepareOutcome,
+    PreparedOperation, RequestFingerprint,
+};
+
+/// Durable text of each destination guarantee.
+pub(crate) const DESTINATION_STABLE_KEY: &str = "stable_key";
+pub(crate) const DESTINATION_RECONCILABLE: &str = "reconcilable";
+pub(crate) const DESTINATION_OPAQUE: &str = "opaque";
+
+/// Durable text of each operation state.
+pub(crate) const STATE_PREPARED: &str = "prepared";
+pub(crate) const STATE_SUCCEEDED: &str = "succeeded";
+pub(crate) const STATE_FAILED: &str = "failed";
+pub(crate) const STATE_OUTCOME_UNKNOWN: &str = "outcome_unknown";
+
+/// Render a destination guarantee as the text migration 0045 admits.
+pub(crate) const fn destination_text(destination: DestinationCapability) -> &'static str {
+    match destination {
+        DestinationCapability::StableKey => DESTINATION_STABLE_KEY,
+        DestinationCapability::Reconcilable => DESTINATION_RECONCILABLE,
+        // A destination this build does not recognise offers no guarantee, so
+        // it is treated as opaque rather than as the nearest known one:
+        // guessing upward would authorize a re-invocation the destination
+        // never promised to deduplicate.
+        _ => DESTINATION_OPAQUE,
+    }
+}
+
+/// Parse durable destination text, rejecting vocabulary outside the schema.
+pub(crate) fn destination_from_text(text: &str) -> Option<DestinationCapability> {
+    match text {
+        DESTINATION_STABLE_KEY => Some(DestinationCapability::StableKey),
+        DESTINATION_RECONCILABLE => Some(DestinationCapability::Reconcilable),
+        DESTINATION_OPAQUE => Some(DestinationCapability::Opaque),
+        _ => None,
+    }
+}
+
+/// Render an operation state as the text migration 0045 admits.
+pub(crate) const fn state_text(state: OperationState) -> &'static str {
+    match state {
+        OperationState::Prepared => STATE_PREPARED,
+        OperationState::Succeeded => STATE_SUCCEEDED,
+        OperationState::Failed => STATE_FAILED,
+        _ => STATE_OUTCOME_UNKNOWN,
+    }
+}
+
+/// Parse durable state text, rejecting vocabulary outside the schema.
+pub(crate) fn state_from_text(text: &str) -> Option<OperationState> {
+    match text {
+        STATE_PREPARED => Some(OperationState::Prepared),
+        STATE_SUCCEEDED => Some(OperationState::Succeeded),
+        STATE_FAILED => Some(OperationState::Failed),
+        STATE_OUTCOME_UNKNOWN => Some(OperationState::OutcomeUnknown),
+        _ => None,
+    }
+}
+
+/// The durable state one known outcome resolves to.
+pub(crate) const fn outcome_state(outcome: KnownOutcome) -> OperationState {
+    match outcome {
+        KnownOutcome::Succeeded => OperationState::Succeeded,
+        KnownOutcome::Failed => OperationState::Failed,
+        _ => OperationState::OutcomeUnknown,
+    }
+}
+
+/// Whether two fingerprints describe the same canonical request.
+///
+/// The version must match as well as the digest: digests produced under
+/// different canonicalization rules are not comparable, so a version change
+/// reads as a mismatch rather than risking a false match that would hand two
+/// different requests one operation identity.
+pub(crate) fn fingerprints_match(
+    stored: RequestFingerprint,
+    candidate: RequestFingerprint,
+) -> bool {
+    stored.version() == candidate.version() && stored.digest() == candidate.digest()
+}
+
+/// Decide what preparing `binding` against an existing record must do.
+///
+/// # Errors
+///
+/// Returns [`OperationLedgerError::OperationMismatch`] when the slot is bound
+/// to a different canonical request. The caller writes nothing in that case:
+/// reusing a slot for a different request would give two distinct effects one
+/// operation identity.
+pub(crate) fn decide_prepare(
+    slot_id: EffectSlotId,
+    stored: &OperationRecord,
+    binding: &EffectSlotBinding<'_>,
+) -> Result<PrepareOutcome, OperationLedgerError> {
+    if !fingerprints_match(stored.fingerprint(), binding.fingerprint) {
+        return Err(OperationLedgerError::OperationMismatch { slot_id });
+    }
+    // The original binding is returned wholesale — including the attempt
+    // generation and destination recorded at prepare time. A later attempt
+    // re-preparing the same slot inherits the first attempt's operation
+    // identity, which is exactly what lets a restarted worker reach the
+    // provider under one identity.
+    Ok(PrepareOutcome::Replayed(stored.operation()))
+}
+
+/// Decide what committing `outcome` against an existing record must do.
+///
+/// # Errors
+///
+/// Returns [`OperationLedgerError::StaleFence`] when the caller's attempt is
+/// behind the durable binding, and
+/// [`OperationLedgerError::OutcomeAlreadyRecorded`] when a *different* terminal
+/// outcome exists.
+pub(crate) fn decide_commit(
+    slot_id: EffectSlotId,
+    stored: &OperationRecord,
+    attempt_generation: AttemptGeneration,
+    outcome: KnownOutcome,
+) -> Result<CommitDecision, OperationLedgerError> {
+    let bound = stored.operation().attempt_generation();
+    if attempt_generation < bound {
+        return Err(OperationLedgerError::StaleFence {
+            slot_id,
+            current: bound,
+        });
+    }
+
+    let target = outcome_state(outcome);
+    match stored.state() {
+        OperationState::Prepared => Ok(CommitDecision::Apply(target)),
+        // Committing the same outcome again is idempotent, which is what lets
+        // a caller whose acknowledgement was lost recommit the same frozen
+        // evidence without inventing a second answer.
+        current if current == target => Ok(CommitDecision::AlreadyRecorded),
+        current => Err(OperationLedgerError::OutcomeAlreadyRecorded {
+            slot_id,
+            recorded: current,
+        }),
+    }
+}
+
+/// What a fenced outcome commit must write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommitDecision {
+    /// Move the record to this state.
+    Apply(OperationState),
+    /// The record already holds this outcome; write nothing.
+    AlreadyRecorded,
+}
+
+/// Decide whether `outcome` may be adjudicated onto an existing record.
+///
+/// # Errors
+///
+/// Returns [`OperationLedgerError::OutcomeAlreadyRecorded`] when the operation
+/// is not `OutcomeUnknown`. Adjudication resolves uncertainty; it never
+/// overrules an answer the system determined for itself, and it cannot leave
+/// the record still unknown.
+pub(crate) fn decide_adjudication(
+    slot_id: EffectSlotId,
+    stored: &OperationRecord,
+    outcome: KnownOutcome,
+) -> Result<OperationState, OperationLedgerError> {
+    if stored.state() != OperationState::OutcomeUnknown {
+        return Err(OperationLedgerError::OutcomeAlreadyRecorded {
+            slot_id,
+            recorded: stored.state(),
+        });
+    }
+    let target = outcome_state(outcome);
+    if target == OperationState::OutcomeUnknown {
+        return Err(OperationLedgerError::OutcomeAlreadyRecorded {
+            slot_id,
+            recorded: OperationState::OutcomeUnknown,
+        });
+    }
+    Ok(target)
+}
+
+/// Compose a record projection from decoded durable columns.
+pub(crate) fn compose_record(
+    slot_id: EffectSlotId,
+    operation_id: OperationId,
+    attempt_generation: AttemptGeneration,
+    destination: DestinationCapability,
+    fingerprint: RequestFingerprint,
+    state: OperationState,
+) -> OperationRecord {
+    OperationRecord::new(
+        PreparedOperation::new(slot_id, operation_id, attempt_generation, destination),
+        fingerprint,
+        state,
+    )
+}
+
+/// Stable label naming one ledger rejection, so every adapter reports the same
+/// outcome vocabulary on its spans and counters.
+pub(crate) const fn error_label(error: &OperationLedgerError) -> &'static str {
+    match *error {
+        OperationLedgerError::OperationMismatch { .. } => "operation_mismatch",
+        OperationLedgerError::SlotUnprepared { .. } => "slot_unprepared",
+        OperationLedgerError::StaleFence { .. } => "stale_fence",
+        OperationLedgerError::TenantDenied => "tenant_denied",
+        OperationLedgerError::OutcomeAlreadyRecorded { .. } => "outcome_already_recorded",
+        OperationLedgerError::CorruptRecord { .. } => "corrupt_record",
+        OperationLedgerError::Unavailable => "unavailable",
+        OperationLedgerError::AcknowledgementUnknown => "acknowledgement_unknown",
+        // The port marks this error `#[non_exhaustive]`, so a wildcard is
+        // required. Naming the gap beats folding an unrecognised rejection
+        // into a neighbouring bucket, where a dashboard would read it as a
+        // rejection this build understands.
+        _ => "unclassified",
+    }
+}
+
+/// Stable outcome label for one prepare.
+pub(crate) const fn prepare_label(
+    result: &Result<PrepareOutcome, OperationLedgerError>,
+) -> &'static str {
+    match *result {
+        Ok(PrepareOutcome::Prepared(_)) => "prepared",
+        Ok(PrepareOutcome::Replayed(_)) => "replayed",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Stable outcome label for one exact read.
+pub(crate) const fn read_label(
+    result: &Result<OperationRecord, OperationLedgerError>,
+) -> &'static str {
+    match *result {
+        Ok(_) => "read",
+        Err(ref error) => error_label(error),
+    }
+}
+
+/// Stable outcome label for one fenced commit or adjudication.
+pub(crate) const fn write_label(result: &Result<(), OperationLedgerError>) -> &'static str {
+    match *result {
+        Ok(()) => "committed",
+        Err(ref error) => error_label(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot() -> EffectSlotId {
+        EffectSlotId::from_storage_bytes([0x11; 16])
+    }
+
+    fn record(state: OperationState, generation: u64) -> OperationRecord {
+        compose_record(
+            slot(),
+            OperationId::from_storage_bytes([0x22; 16]),
+            AttemptGeneration::new(generation),
+            DestinationCapability::StableKey,
+            RequestFingerprint::new(1, [0x33; 32]),
+            state,
+        )
+    }
+
+    #[test]
+    fn durable_vocabulary_round_trips() {
+        for destination in [
+            DestinationCapability::StableKey,
+            DestinationCapability::Reconcilable,
+            DestinationCapability::Opaque,
+        ] {
+            assert_eq!(
+                destination_from_text(destination_text(destination)),
+                Some(destination)
+            );
+        }
+        for state in [
+            OperationState::Prepared,
+            OperationState::Succeeded,
+            OperationState::Failed,
+            OperationState::OutcomeUnknown,
+        ] {
+            assert_eq!(state_from_text(state_text(state)), Some(state));
+        }
+        assert_eq!(destination_from_text("best_effort"), None);
+        assert_eq!(state_from_text("maybe"), None);
+    }
+
+    /// Digests computed under different rules are not comparable, so a version
+    /// change must read as a mismatch rather than reuse an operation identity
+    /// for a different request.
+    #[test]
+    fn a_digest_under_different_rules_is_not_the_same_request() {
+        let stored = RequestFingerprint::new(1, [0x33; 32]);
+        assert!(fingerprints_match(
+            stored,
+            RequestFingerprint::new(1, [0x33; 32])
+        ));
+        assert!(!fingerprints_match(
+            stored,
+            RequestFingerprint::new(2, [0x33; 32])
+        ));
+        assert!(!fingerprints_match(
+            stored,
+            RequestFingerprint::new(1, [0x34; 32])
+        ));
+    }
+
+    #[test]
+    fn a_later_attempt_inherits_the_original_operation_identity() {
+        let stored = record(OperationState::Prepared, 0);
+        let scope = nebula_storage_port::Scope::new("ws", "org");
+        let binding = EffectSlotBinding {
+            scope: &scope,
+            execution_id: "exe",
+            node_key: "node",
+            occurrence: "once",
+            attempt_generation: AttemptGeneration::new(7),
+            fingerprint: RequestFingerprint::new(1, [0x33; 32]),
+            destination: DestinationCapability::Opaque,
+        };
+
+        let outcome = decide_prepare(slot(), &stored, &binding)
+            .expect("a matching fingerprint replays the original binding");
+        assert_eq!(
+            outcome.operation().operation_id(),
+            stored.operation().operation_id(),
+            "a restarted worker must reach the provider under one identity"
+        );
+        assert_eq!(
+            outcome.operation().destination(),
+            DestinationCapability::StableKey,
+            "the guarantee recorded at prepare time governs, not the caller's current view"
+        );
+    }
+
+    #[test]
+    fn a_different_request_on_the_same_slot_fails_closed() {
+        let stored = record(OperationState::Prepared, 0);
+        let scope = nebula_storage_port::Scope::new("ws", "org");
+        let binding = EffectSlotBinding {
+            scope: &scope,
+            execution_id: "exe",
+            node_key: "node",
+            occurrence: "once",
+            attempt_generation: AttemptGeneration::new(0),
+            fingerprint: RequestFingerprint::new(1, [0x99; 32]),
+            destination: DestinationCapability::StableKey,
+        };
+
+        assert_eq!(
+            decide_prepare(slot(), &stored, &binding),
+            Err(OperationLedgerError::OperationMismatch { slot_id: slot() })
+        );
+    }
+
+    #[test]
+    fn a_superseded_attempt_cannot_decide_the_current_one() {
+        let stored = record(OperationState::Prepared, 5);
+        assert_eq!(
+            decide_commit(
+                slot(),
+                &stored,
+                AttemptGeneration::new(4),
+                KnownOutcome::Succeeded
+            ),
+            Err(OperationLedgerError::StaleFence {
+                slot_id: slot(),
+                current: AttemptGeneration::new(5),
+            })
+        );
+    }
+
+    #[test]
+    fn recommitting_the_same_outcome_is_idempotent_but_a_different_one_is_refused() {
+        let stored = record(OperationState::Succeeded, 5);
+        assert_eq!(
+            decide_commit(
+                slot(),
+                &stored,
+                AttemptGeneration::new(5),
+                KnownOutcome::Succeeded
+            ),
+            Ok(CommitDecision::AlreadyRecorded),
+            "a lost acknowledgement is reconciled by recommitting the same evidence"
+        );
+        assert_eq!(
+            decide_commit(
+                slot(),
+                &stored,
+                AttemptGeneration::new(5),
+                KnownOutcome::Failed
+            ),
+            Err(OperationLedgerError::OutcomeAlreadyRecorded {
+                slot_id: slot(),
+                recorded: OperationState::Succeeded,
+            }),
+            "the ledger must never hold two answers for one effect"
+        );
+    }
+
+    #[test]
+    fn adjudication_resolves_uncertainty_and_nothing_else() {
+        let unknown = record(OperationState::OutcomeUnknown, 1);
+        assert_eq!(
+            decide_adjudication(slot(), &unknown, KnownOutcome::Succeeded),
+            Ok(OperationState::Succeeded)
+        );
+        assert_eq!(
+            decide_adjudication(slot(), &unknown, KnownOutcome::OutcomeUnknown),
+            Err(OperationLedgerError::OutcomeAlreadyRecorded {
+                slot_id: slot(),
+                recorded: OperationState::OutcomeUnknown,
+            }),
+            "adjudication must leave the record determined, not still unknown"
+        );
+
+        let determined = record(OperationState::Failed, 1);
+        assert_eq!(
+            decide_adjudication(slot(), &determined, KnownOutcome::Succeeded),
+            Err(OperationLedgerError::OutcomeAlreadyRecorded {
+                slot_id: slot(),
+                recorded: OperationState::Failed,
+            }),
+            "adjudication never overrules an answer the system determined itself"
+        );
+    }
+}

--- a/crates/storage/src/operation_ledger.rs
+++ b/crates/storage/src/operation_ledger.rs
@@ -15,17 +15,28 @@ use nebula_storage_port::{
 };
 
 /// Durable text of each destination guarantee.
+///
+/// Only a SQL backend spells these; the in-memory reference model holds the
+/// typed values directly.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const DESTINATION_STABLE_KEY: &str = "stable_key";
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const DESTINATION_RECONCILABLE: &str = "reconcilable";
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const DESTINATION_OPAQUE: &str = "opaque";
 
 /// Durable text of each operation state.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const STATE_PREPARED: &str = "prepared";
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const STATE_SUCCEEDED: &str = "succeeded";
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const STATE_FAILED: &str = "failed";
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const STATE_OUTCOME_UNKNOWN: &str = "outcome_unknown";
 
 /// Render a destination guarantee as the text migration 0045 admits.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const fn destination_text(destination: DestinationCapability) -> &'static str {
     match destination {
         DestinationCapability::StableKey => DESTINATION_STABLE_KEY,
@@ -39,6 +50,7 @@ pub(crate) const fn destination_text(destination: DestinationCapability) -> &'st
 }
 
 /// Parse durable destination text, rejecting vocabulary outside the schema.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) fn destination_from_text(text: &str) -> Option<DestinationCapability> {
     match text {
         DESTINATION_STABLE_KEY => Some(DestinationCapability::StableKey),
@@ -49,6 +61,7 @@ pub(crate) fn destination_from_text(text: &str) -> Option<DestinationCapability>
 }
 
 /// Render an operation state as the text migration 0045 admits.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) const fn state_text(state: OperationState) -> &'static str {
     match state {
         OperationState::Prepared => STATE_PREPARED,
@@ -59,6 +72,7 @@ pub(crate) const fn state_text(state: OperationState) -> &'static str {
 }
 
 /// Parse durable state text, rejecting vocabulary outside the schema.
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) fn state_from_text(text: &str) -> Option<OperationState> {
     match text {
         STATE_PREPARED => Some(OperationState::Prepared),
@@ -273,6 +287,8 @@ mod tests {
         )
     }
 
+    /// Durable text exists only where a SQL backend writes it.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
     #[test]
     fn durable_vocabulary_round_trips() {
         for destination in [

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -16,6 +16,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod operation_ledger;
 mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
@@ -30,6 +31,7 @@ pub use identity::{
     PgTriggerStore, PgUserStore, PgWorkspaceStore,
 };
 pub use job_dispatch::{PgJobDispatchQueue, PgTriggerDedupInbox};
+pub use operation_ledger::PgOperationLedger;
 pub use plan_flavor_catalog::PgPlanFlavorCatalog;
 pub use resume_producer::PgResumeProducer;
 pub use resume_token::PgResumeTokenStore;

--- a/crates/storage/src/postgres/operation_ledger.rs
+++ b/crates/storage/src/postgres/operation_ledger.rs
@@ -1,0 +1,393 @@
+//! PostgreSQL operation ledger over ordered migration 0045.
+//!
+//! Prepare relies on the natural-key unique index rather than on a lock: the
+//! slot a caller wants may not exist yet, and `SELECT … FOR UPDATE` cannot lock
+//! a row that is absent, so two workers preparing the same slot would both read
+//! "not prepared". The insert is therefore `ON CONFLICT DO NOTHING`, and a
+//! loser re-reads the winner's row inside the same transaction — so both
+//! callers leave with one operation identity instead of one of them losing on
+//! the index.
+//!
+//! Mutating paths lock the row they decide on with `FOR UPDATE`, so a fenced
+//! commit cannot be invalidated between its decision and its write.
+//!
+//! Driver detail and request payloads never cross the port boundary. A failure
+//! before commit is [`OperationLedgerError::Unavailable`] (the operation
+//! definitely did not commit); a failed commit is
+//! [`OperationLedgerError::AcknowledgementUnknown`], which authorizes **zero**
+//! provider calls until a database-only read confirms the durable binding.
+
+use nebula_storage_port::store::{OperationLedger, OperationLedgerAdjudicator};
+use nebula_storage_port::{
+    AttemptGeneration, EffectSlotBinding, EffectSlotId, KnownOutcome, OperationId,
+    OperationLedgerError, OperationRecord, OperationState, PrepareOutcome, RequestFingerprint,
+    Scope,
+};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+
+use crate::operation_ledger::{
+    CommitDecision, compose_record, decide_adjudication, decide_commit, decide_prepare,
+    destination_from_text, destination_text, prepare_label, read_label, state_from_text,
+    state_text, write_label,
+};
+
+/// PostgreSQL-backed durable operation ledger.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`].
+#[derive(Clone, Debug)]
+pub struct PgOperationLedger {
+    pool: PgPool,
+}
+
+impl PgOperationLedger {
+    /// Wrap an existing pool. The caller installs the port schema (see
+    /// [`super::init_schema`]).
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Open the transaction every ledger operation runs in.
+    async fn begin(&self) -> Result<Transaction<'_, Postgres>, OperationLedgerError> {
+        self.pool.begin().await.map_err(driver_did_not_commit)
+    }
+}
+
+/// A driver failure reached before commit definitely did not commit.
+fn driver_did_not_commit(_error: sqlx::Error) -> OperationLedgerError {
+    OperationLedgerError::Unavailable
+}
+
+/// A failed commit leaves the caller unable to prove whether the write landed.
+///
+/// This is deliberately **not** `Unavailable`: after a prepare it authorizes no
+/// provider call at all, whereas `Unavailable` means the caller may safely try
+/// again.
+fn commit_acknowledgement_unknown(_error: sqlx::Error) -> OperationLedgerError {
+    OperationLedgerError::AcknowledgementUnknown
+}
+
+/// Interpret one durable ledger row.
+fn decode_row(row: &sqlx::postgres::PgRow) -> Result<OperationRecord, OperationLedgerError> {
+    let slot_bytes: Vec<u8> = row.try_get("slot_id").map_err(driver_did_not_commit)?;
+    let slot_id = EffectSlotId::from_storage_bytes(
+        <[u8; 16]>::try_from(slot_bytes).map_err(|_width| OperationLedgerError::Unavailable)?,
+    );
+    let corrupt = |_reason| OperationLedgerError::CorruptRecord { slot_id };
+
+    let operation_bytes: Vec<u8> = row.try_get("operation_id").map_err(corrupt)?;
+    let operation_id = OperationId::from_storage_bytes(
+        <[u8; 16]>::try_from(operation_bytes)
+            .map_err(|_width| OperationLedgerError::CorruptRecord { slot_id })?,
+    );
+    let generation: i64 = row.try_get("attempt_generation").map_err(corrupt)?;
+    let destination: String = row.try_get("destination").map_err(corrupt)?;
+    let fingerprint_version: i32 = row.try_get("fingerprint_version").map_err(corrupt)?;
+    let fingerprint_bytes: Vec<u8> = row.try_get("fingerprint").map_err(corrupt)?;
+    let state: String = row.try_get("state").map_err(corrupt)?;
+
+    let destination = destination_from_text(&destination)
+        .ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+    let state = state_from_text(&state).ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+    let fingerprint = RequestFingerprint::new(
+        u16::try_from(fingerprint_version)
+            .map_err(|_range| OperationLedgerError::CorruptRecord { slot_id })?,
+        <[u8; 32]>::try_from(fingerprint_bytes)
+            .map_err(|_width| OperationLedgerError::CorruptRecord { slot_id })?,
+    );
+
+    Ok(compose_record(
+        slot_id,
+        operation_id,
+        AttemptGeneration::new(
+            u64::try_from(generation)
+                .map_err(|_range| OperationLedgerError::CorruptRecord { slot_id })?,
+        ),
+        destination,
+        fingerprint,
+        state,
+    ))
+}
+
+/// Read the slot addressed by the natural key a caller can rebuild.
+async fn load_by_natural_key(
+    tx: &mut Transaction<'_, Postgres>,
+    binding: &EffectSlotBinding<'_>,
+) -> Result<Option<OperationRecord>, OperationLedgerError> {
+    let row = sqlx::query(
+        "SELECT slot_id, operation_id, attempt_generation, destination, \
+                fingerprint_version, fingerprint, state \
+         FROM port_operation_ledger \
+         WHERE workspace_id = $1 AND org_id = $2 AND execution_id = $3 \
+           AND node_key = $4 AND occurrence = $5",
+    )
+    .bind(&binding.scope.workspace_id)
+    .bind(&binding.scope.org_id)
+    .bind(binding.execution_id)
+    .bind(binding.node_key)
+    .bind(binding.occurrence)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?;
+
+    row.as_ref().map(decode_row).transpose()
+}
+
+/// Read one slot a tenant is allowed to see.
+///
+/// The scope predicate is part of the query, so a slot owned by another tenant
+/// is indistinguishable from an absent one — a caller cannot use a guessed
+/// identity to learn that some other tenant holds it.
+async fn load_visible(
+    tx: &mut Transaction<'_, Postgres>,
+    scope: &Scope,
+    slot_id: EffectSlotId,
+) -> Result<OperationRecord, OperationLedgerError> {
+    let row = sqlx::query(
+        "SELECT slot_id, operation_id, attempt_generation, destination, \
+                fingerprint_version, fingerprint, state \
+         FROM port_operation_ledger \
+         WHERE slot_id = $1 AND workspace_id = $2 AND org_id = $3 FOR UPDATE",
+    )
+    .bind(slot_id.as_bytes().as_slice())
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?
+    .ok_or(OperationLedgerError::SlotUnprepared { slot_id })?;
+
+    decode_row(&row)
+}
+
+/// Apply a resolved state to one slot under the caller's scope.
+async fn write_state(
+    tx: &mut Transaction<'_, Postgres>,
+    scope: &Scope,
+    slot_id: EffectSlotId,
+    state: OperationState,
+    evidence: Option<&str>,
+    now_ms: i64,
+) -> Result<(), OperationLedgerError> {
+    sqlx::query(
+        "UPDATE port_operation_ledger \
+         SET state = $1, outcome_at_ms = $2, adjudication_evidence = $3, adjudicated_at_ms = $4 \
+         WHERE slot_id = $5 AND workspace_id = $6 AND org_id = $7",
+    )
+    .bind(state_text(state))
+    .bind(now_ms)
+    .bind(evidence)
+    .bind(evidence.map(|_present| now_ms))
+    .bind(slot_id.as_bytes().as_slice())
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)
+    .map(|_applied| ())
+}
+
+#[async_trait::async_trait]
+impl OperationLedger for PgOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.prepare",
+        skip(self, binding),
+        fields(
+            backend = "postgres",
+            execution_id = binding.execution_id,
+            node_key = binding.node_key,
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn prepare(
+        &self,
+        binding: &EffectSlotBinding<'_>,
+    ) -> Result<PrepareOutcome, OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            let mut tx = self.begin().await?;
+
+            if let Some(stored) = load_by_natural_key(&mut tx, binding).await? {
+                let replayed = decide_prepare(stored.operation().slot_id(), &stored, binding);
+                // Nothing was written on either path; the commit only releases
+                // the transaction, so failing to release cannot make a
+                // rejection ambiguous.
+                drop(tx.commit().await);
+                return replayed;
+            }
+
+            let slot_id = EffectSlotId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+            let operation_id = OperationId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+            let inserted = sqlx::query(
+                "INSERT INTO port_operation_ledger \
+                 (slot_id, workspace_id, org_id, execution_id, node_key, occurrence, \
+                  attempt_generation, fingerprint_version, fingerprint, destination, \
+                  operation_id, state, prepared_at_ms) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'prepared', $12) \
+                 ON CONFLICT (workspace_id, org_id, execution_id, node_key, occurrence) \
+                 DO NOTHING",
+            )
+            .bind(slot_id.as_bytes().as_slice())
+            .bind(&binding.scope.workspace_id)
+            .bind(&binding.scope.org_id)
+            .bind(binding.execution_id)
+            .bind(binding.node_key)
+            .bind(binding.occurrence)
+            .bind(i64::try_from(binding.attempt_generation.get()).unwrap_or(i64::MAX))
+            .bind(i32::from(binding.fingerprint.version()))
+            .bind(binding.fingerprint.digest().as_slice())
+            .bind(destination_text(binding.destination))
+            .bind(operation_id.as_bytes().as_slice())
+            .bind(now_ms)
+            .execute(&mut *tx)
+            .await
+            .map_err(driver_did_not_commit)?
+            .rows_affected();
+
+            if inserted == 0 {
+                // Another worker won the natural-key race. Re-read its row in
+                // this transaction and replay against it, so both callers leave
+                // holding one operation identity rather than one of them
+                // surfacing a driver conflict.
+                let stored = load_by_natural_key(&mut tx, binding)
+                    .await?
+                    .ok_or(OperationLedgerError::Unavailable)?;
+                let replayed = decide_prepare(stored.operation().slot_id(), &stored, binding);
+                drop(tx.commit().await);
+                return replayed;
+            }
+
+            tx.commit().await.map_err(commit_acknowledgement_unknown)?;
+            Ok(PrepareOutcome::Prepared(
+                compose_record(
+                    slot_id,
+                    operation_id,
+                    binding.attempt_generation,
+                    binding.destination,
+                    binding.fingerprint,
+                    OperationState::Prepared,
+                )
+                .operation(),
+            ))
+        }
+        .await;
+
+        let outcome = prepare_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::postgres", outcome, "operation ledger prepare");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.read_exact",
+        skip(self),
+        fields(backend = "postgres", outcome = tracing::field::Empty)
+    )]
+    async fn read_exact(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+    ) -> Result<OperationRecord, OperationLedgerError> {
+        let result = async {
+            // A read decides nothing it then writes, so it does not take the
+            // write lock: a database-only reconciliation must stay available
+            // exactly when writers are contending.
+            let mut tx = self.begin().await?;
+            let record = load_visible(&mut tx, scope, slot_id).await;
+            drop(tx.commit().await);
+            record
+        }
+        .await;
+
+        let outcome = read_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::postgres", outcome, "operation ledger read");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.commit_outcome",
+        skip(self),
+        fields(backend = "postgres", outcome = tracing::field::Empty)
+    )]
+    async fn commit_outcome(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        attempt_generation: AttemptGeneration,
+        outcome: KnownOutcome,
+    ) -> Result<(), OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            let mut tx = self.begin().await?;
+            let stored = load_visible(&mut tx, scope, slot_id).await?;
+            match decide_commit(slot_id, &stored, attempt_generation, outcome)? {
+                CommitDecision::AlreadyRecorded => {
+                    drop(tx.commit().await);
+                    Ok(())
+                },
+                CommitDecision::Apply(state) => {
+                    write_state(&mut tx, scope, slot_id, state, None, now_ms).await?;
+                    tx.commit().await.map_err(commit_acknowledgement_unknown)
+                },
+            }
+        }
+        .await;
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = label,
+            "operation ledger fenced commit"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl OperationLedgerAdjudicator for PgOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.adjudicate",
+        // `evidence` is operator prose, persisted for review rather than
+        // broadcast to every trace consumer.
+        skip(self, evidence),
+        fields(backend = "postgres", outcome = tracing::field::Empty)
+    )]
+    async fn adjudicate(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        outcome: KnownOutcome,
+        evidence: &str,
+    ) -> Result<(), OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            if evidence.trim().is_empty() {
+                // An adjudication without a reason is not reviewable, and
+                // reviewability is the only thing that makes a hand-decided
+                // outcome acceptable.
+                return Err(OperationLedgerError::CorruptRecord { slot_id });
+            }
+            let mut tx = self.begin().await?;
+            let stored = load_visible(&mut tx, scope, slot_id).await?;
+            let state = decide_adjudication(slot_id, &stored, outcome)?;
+            write_state(&mut tx, scope, slot_id, state, Some(evidence), now_ms).await?;
+            tx.commit().await.map_err(commit_acknowledgement_unknown)
+        }
+        .await;
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome = label,
+            "operation ledger adjudication"
+        );
+        result
+    }
+}

--- a/crates/storage/src/sqlite/mod.rs
+++ b/crates/storage/src/sqlite/mod.rs
@@ -17,6 +17,7 @@ mod execution;
 mod idempotency_store;
 mod identity;
 mod job_dispatch;
+mod operation_ledger;
 mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
@@ -31,6 +32,7 @@ pub use identity::{
     SqliteResourceStore, SqliteTriggerStore, SqliteUserStore, SqliteWorkspaceStore,
 };
 pub use job_dispatch::{SqliteJobDispatchQueue, SqliteTriggerDedupInbox};
+pub use operation_ledger::SqliteOperationLedger;
 pub use plan_flavor_catalog::SqlitePlanFlavorCatalog;
 pub use resume_producer::SqliteResumeProducer;
 pub use resume_token::SqliteResumeTokenStore;

--- a/crates/storage/src/sqlite/operation_ledger.rs
+++ b/crates/storage/src/sqlite/operation_ledger.rs
@@ -1,0 +1,376 @@
+//! SQLite operation ledger over ordered migration 0045.
+//!
+//! Every operation runs under `BEGIN IMMEDIATE`, so the read that decides and
+//! the write that follows are one linearized operation against the single
+//! writer. A deferred transaction would let another writer replace the row
+//! between the decision and the write, which for this table means deciding
+//! "not prepared" against a slot another worker just prepared — and preparing
+//! it a second time under a second operation identity.
+//!
+//! Driver detail and request payloads never cross the port boundary. A failure
+//! before commit is [`OperationLedgerError::Unavailable`] (the operation
+//! definitely did not commit); a failed commit is
+//! [`OperationLedgerError::AcknowledgementUnknown`], which authorizes **zero**
+//! provider calls until a database-only read confirms the durable binding.
+
+use nebula_storage_port::store::{OperationLedger, OperationLedgerAdjudicator};
+use nebula_storage_port::{
+    AttemptGeneration, EffectSlotBinding, EffectSlotId, KnownOutcome, OperationId,
+    OperationLedgerError, OperationRecord, OperationState, PrepareOutcome, RequestFingerprint,
+    Scope,
+};
+use sqlx::{Row, Sqlite, SqlitePool, Transaction};
+
+use crate::operation_ledger::{
+    CommitDecision, compose_record, decide_adjudication, decide_commit, decide_prepare,
+    destination_from_text, destination_text, prepare_label, read_label, state_from_text,
+    state_text, write_label,
+};
+
+/// SQLite-backed durable operation ledger.
+///
+/// Wrap a pool whose schema was installed via [`super::init_schema`].
+#[derive(Clone, Debug)]
+pub struct SqliteOperationLedger {
+    pool: SqlitePool,
+}
+
+impl SqliteOperationLedger {
+    /// Wrap an existing pool. The caller installs the port schema (see
+    /// [`super::init_schema`]).
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Open the single-writer transaction every ledger operation runs in.
+    async fn begin_write(&self) -> Result<Transaction<'_, Sqlite>, OperationLedgerError> {
+        self.pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .map_err(driver_did_not_commit)
+    }
+}
+
+/// A driver failure reached before commit definitely did not commit.
+fn driver_did_not_commit(_error: sqlx::Error) -> OperationLedgerError {
+    OperationLedgerError::Unavailable
+}
+
+/// A failed commit leaves the caller unable to prove whether the write landed.
+///
+/// This is deliberately **not** `Unavailable`: after a prepare it authorizes no
+/// provider call at all, whereas `Unavailable` means the caller may safely try
+/// again.
+fn commit_acknowledgement_unknown(_error: sqlx::Error) -> OperationLedgerError {
+    OperationLedgerError::AcknowledgementUnknown
+}
+
+/// Interpret one durable ledger row.
+fn decode_row(row: &sqlx::sqlite::SqliteRow) -> Result<OperationRecord, OperationLedgerError> {
+    let slot_bytes: Vec<u8> = row.try_get("slot_id").map_err(driver_did_not_commit)?;
+    let slot_id = EffectSlotId::from_storage_bytes(
+        <[u8; 16]>::try_from(slot_bytes).map_err(|_width| OperationLedgerError::Unavailable)?,
+    );
+    let corrupt = |_reason| OperationLedgerError::CorruptRecord { slot_id };
+
+    let operation_bytes: Vec<u8> = row.try_get("operation_id").map_err(corrupt)?;
+    let operation_id = OperationId::from_storage_bytes(
+        <[u8; 16]>::try_from(operation_bytes)
+            .map_err(|_width| OperationLedgerError::CorruptRecord { slot_id })?,
+    );
+    let generation: i64 = row.try_get("attempt_generation").map_err(corrupt)?;
+    let destination: String = row.try_get("destination").map_err(corrupt)?;
+    let fingerprint_version: i64 = row.try_get("fingerprint_version").map_err(corrupt)?;
+    let fingerprint_bytes: Vec<u8> = row.try_get("fingerprint").map_err(corrupt)?;
+    let state: String = row.try_get("state").map_err(corrupt)?;
+
+    let destination = destination_from_text(&destination)
+        .ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+    let state = state_from_text(&state).ok_or(OperationLedgerError::CorruptRecord { slot_id })?;
+    let fingerprint = RequestFingerprint::new(
+        u16::try_from(fingerprint_version)
+            .map_err(|_range| OperationLedgerError::CorruptRecord { slot_id })?,
+        <[u8; 32]>::try_from(fingerprint_bytes)
+            .map_err(|_width| OperationLedgerError::CorruptRecord { slot_id })?,
+    );
+
+    Ok(compose_record(
+        slot_id,
+        operation_id,
+        AttemptGeneration::new(
+            u64::try_from(generation)
+                .map_err(|_range| OperationLedgerError::CorruptRecord { slot_id })?,
+        ),
+        destination,
+        fingerprint,
+        state,
+    ))
+}
+
+/// Read the slot addressed by the natural key a caller can rebuild.
+async fn load_by_natural_key(
+    tx: &mut Transaction<'_, Sqlite>,
+    binding: &EffectSlotBinding<'_>,
+) -> Result<Option<OperationRecord>, OperationLedgerError> {
+    let row = sqlx::query(
+        "SELECT slot_id, operation_id, attempt_generation, destination, \
+                fingerprint_version, fingerprint, state \
+         FROM port_operation_ledger \
+         WHERE workspace_id = ? AND org_id = ? AND execution_id = ? \
+           AND node_key = ? AND occurrence = ?",
+    )
+    .bind(&binding.scope.workspace_id)
+    .bind(&binding.scope.org_id)
+    .bind(binding.execution_id)
+    .bind(binding.node_key)
+    .bind(binding.occurrence)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?;
+
+    row.as_ref().map(decode_row).transpose()
+}
+
+/// Read one slot a tenant is allowed to see.
+///
+/// The scope predicate is part of the query, so a slot owned by another tenant
+/// is indistinguishable from an absent one — a caller cannot use a guessed
+/// identity to learn that some other tenant holds it.
+async fn load_visible(
+    tx: &mut Transaction<'_, Sqlite>,
+    scope: &Scope,
+    slot_id: EffectSlotId,
+) -> Result<OperationRecord, OperationLedgerError> {
+    let row = sqlx::query(
+        "SELECT slot_id, operation_id, attempt_generation, destination, \
+                fingerprint_version, fingerprint, state \
+         FROM port_operation_ledger \
+         WHERE slot_id = ? AND workspace_id = ? AND org_id = ?",
+    )
+    .bind(slot_id.as_bytes().as_slice())
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)?
+    .ok_or(OperationLedgerError::SlotUnprepared { slot_id })?;
+
+    decode_row(&row)
+}
+
+/// Apply a resolved state to one slot under the caller's scope.
+async fn write_state(
+    tx: &mut Transaction<'_, Sqlite>,
+    scope: &Scope,
+    slot_id: EffectSlotId,
+    state: OperationState,
+    evidence: Option<&str>,
+    now_ms: i64,
+) -> Result<(), OperationLedgerError> {
+    sqlx::query(
+        "UPDATE port_operation_ledger \
+         SET state = ?, outcome_at_ms = ?, adjudication_evidence = ?, adjudicated_at_ms = ? \
+         WHERE slot_id = ? AND workspace_id = ? AND org_id = ?",
+    )
+    .bind(state_text(state))
+    .bind(now_ms)
+    .bind(evidence)
+    .bind(evidence.map(|_present| now_ms))
+    .bind(slot_id.as_bytes().as_slice())
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(driver_did_not_commit)
+    .map(|_applied| ())
+}
+
+#[async_trait::async_trait]
+impl OperationLedger for SqliteOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.prepare",
+        skip(self, binding),
+        fields(
+            backend = "sqlite",
+            execution_id = binding.execution_id,
+            node_key = binding.node_key,
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn prepare(
+        &self,
+        binding: &EffectSlotBinding<'_>,
+    ) -> Result<PrepareOutcome, OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            let mut tx = self.begin_write().await?;
+
+            if let Some(stored) = load_by_natural_key(&mut tx, binding).await? {
+                let replayed = decide_prepare(stored.operation().slot_id(), &stored, binding);
+                // Nothing was written on either path; the commit only releases
+                // the transaction, so failing to release cannot make a
+                // rejection ambiguous.
+                drop(tx.commit().await);
+                return replayed;
+            }
+
+            let slot_id = EffectSlotId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+            let operation_id = OperationId::from_storage_bytes(*uuid::Uuid::new_v4().as_bytes());
+            sqlx::query(
+                "INSERT INTO port_operation_ledger \
+                 (slot_id, workspace_id, org_id, execution_id, node_key, occurrence, \
+                  attempt_generation, fingerprint_version, fingerprint, destination, \
+                  operation_id, state, prepared_at_ms) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'prepared', ?)",
+            )
+            .bind(slot_id.as_bytes().as_slice())
+            .bind(&binding.scope.workspace_id)
+            .bind(&binding.scope.org_id)
+            .bind(binding.execution_id)
+            .bind(binding.node_key)
+            .bind(binding.occurrence)
+            .bind(i64::try_from(binding.attempt_generation.get()).unwrap_or(i64::MAX))
+            .bind(i64::from(binding.fingerprint.version()))
+            .bind(binding.fingerprint.digest().as_slice())
+            .bind(destination_text(binding.destination))
+            .bind(operation_id.as_bytes().as_slice())
+            .bind(now_ms)
+            .execute(&mut *tx)
+            .await
+            .map_err(driver_did_not_commit)?;
+
+            tx.commit().await.map_err(commit_acknowledgement_unknown)?;
+            Ok(PrepareOutcome::Prepared(
+                compose_record(
+                    slot_id,
+                    operation_id,
+                    binding.attempt_generation,
+                    binding.destination,
+                    binding.fingerprint,
+                    OperationState::Prepared,
+                )
+                .operation(),
+            ))
+        }
+        .await;
+
+        let outcome = prepare_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::sqlite", outcome, "operation ledger prepare");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.read_exact",
+        skip(self),
+        fields(backend = "sqlite", outcome = tracing::field::Empty)
+    )]
+    async fn read_exact(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+    ) -> Result<OperationRecord, OperationLedgerError> {
+        let result = async {
+            // A read decides nothing it then writes, so it does not take the
+            // write lock: a database-only reconciliation must stay available
+            // exactly when writers are contending.
+            let mut tx = self.pool.begin().await.map_err(driver_did_not_commit)?;
+            let record = load_visible(&mut tx, scope, slot_id).await;
+            drop(tx.commit().await);
+            record
+        }
+        .await;
+
+        let outcome = read_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(target: "nebula_storage::sqlite", outcome, "operation ledger read");
+        result
+    }
+
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.commit_outcome",
+        skip(self),
+        fields(backend = "sqlite", outcome = tracing::field::Empty)
+    )]
+    async fn commit_outcome(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        attempt_generation: AttemptGeneration,
+        outcome: KnownOutcome,
+    ) -> Result<(), OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            let mut tx = self.begin_write().await?;
+            let stored = load_visible(&mut tx, scope, slot_id).await?;
+            match decide_commit(slot_id, &stored, attempt_generation, outcome)? {
+                CommitDecision::AlreadyRecorded => {
+                    drop(tx.commit().await);
+                    Ok(())
+                },
+                CommitDecision::Apply(state) => {
+                    write_state(&mut tx, scope, slot_id, state, None, now_ms).await?;
+                    tx.commit().await.map_err(commit_acknowledgement_unknown)
+                },
+            }
+        }
+        .await;
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = label,
+            "operation ledger fenced commit"
+        );
+        result
+    }
+}
+
+#[async_trait::async_trait]
+impl OperationLedgerAdjudicator for SqliteOperationLedger {
+    #[tracing::instrument(
+        level = "debug",
+        name = "operation_ledger.adjudicate",
+        // `evidence` is operator prose, persisted for review rather than
+        // broadcast to every trace consumer.
+        skip(self, evidence),
+        fields(backend = "sqlite", outcome = tracing::field::Empty)
+    )]
+    async fn adjudicate(
+        &self,
+        scope: &Scope,
+        slot_id: EffectSlotId,
+        outcome: KnownOutcome,
+        evidence: &str,
+    ) -> Result<(), OperationLedgerError> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let result = async {
+            if evidence.trim().is_empty() {
+                // An adjudication without a reason is not reviewable, and
+                // reviewability is the only thing that makes a hand-decided
+                // outcome acceptable.
+                return Err(OperationLedgerError::CorruptRecord { slot_id });
+            }
+            let mut tx = self.begin_write().await?;
+            let stored = load_visible(&mut tx, scope, slot_id).await?;
+            let state = decide_adjudication(slot_id, &stored, outcome)?;
+            write_state(&mut tx, scope, slot_id, state, Some(evidence), now_ms).await?;
+            tx.commit().await.map_err(commit_acknowledgement_unknown)
+        }
+        .await;
+
+        let label = write_label(&result);
+        tracing::Span::current().record("outcome", label);
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome = label,
+            "operation ledger adjudication"
+        );
+        result
+    }
+}

--- a/crates/storage/tests/credential_migration_catalog.rs
+++ b/crates/storage/tests/credential_migration_catalog.rs
@@ -209,15 +209,15 @@ fn repository_catalog_matches_k2_contract() {
     let postgres = Catalog::load("postgres").expect("Postgres catalog must be valid");
     let sqlite = Catalog::load("sqlite").expect("SQLite catalog must be valid");
 
-    let expected_postgres = (1_u16..=44).collect::<Vec<_>>();
+    let expected_postgres = (1_u16..=45).collect::<Vec<_>>();
     let expected_sqlite = (1_u16..=28)
         .chain(30..=35)
-        .chain([39, 40, 41, 42, 43, 44])
+        .chain([39, 40, 41, 42, 43, 44, 45])
         .collect::<Vec<_>>();
     assert_eq!(
         postgres.versions(),
         expected_postgres,
-        "Postgres must reserve every logical migration through version 0044"
+        "Postgres must reserve every logical migration through version 0045"
     );
     assert_eq!(
         sqlite.versions(),

--- a/crates/storage/tests/operation_ledger_conformance_inmem.rs
+++ b/crates/storage/tests/operation_ledger_conformance_inmem.rs
@@ -1,0 +1,18 @@
+//! Operation-ledger conformance for the in-memory reference model.
+//!
+//! The in-memory adapter is never a deployment target; running the shared
+//! oracle against it keeps the reference model and the two SQL deployment
+//! backends answering identically, so a divergence shows up as the same named
+//! case failing on one of the three.
+
+#[macro_use]
+#[path = "support/operation_ledger_oracle.rs"]
+mod oracle;
+
+use nebula_storage::inmem::InMemoryOperationLedger;
+
+async fn ledger() -> Option<InMemoryOperationLedger> {
+    Some(InMemoryOperationLedger::new())
+}
+
+operation_ledger_conformance_suite!(ledger());

--- a/crates/storage/tests/operation_ledger_conformance_postgres.rs
+++ b/crates/storage/tests/operation_ledger_conformance_postgres.rs
@@ -1,0 +1,60 @@
+//! Operation-ledger conformance for the PostgreSQL deployment backend.
+//!
+//! PostgreSQL is a deployment backend, so its absence is a job failure, never a
+//! silent substitution. With `NEBULA_REQUIRE_POSTGRES=1` and no `DATABASE_URL`,
+//! every case fails; without it a developer without a database sees the cases
+//! report the backend was unreachable and assert nothing.
+
+#![cfg(feature = "postgres")]
+
+#[macro_use]
+#[path = "support/operation_ledger_oracle.rs"]
+mod oracle;
+
+use nebula_storage::postgres::{PgOperationLedger, init_schema};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tokio::sync::OnceCell;
+
+static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
+
+/// Connect to `DATABASE_URL` and apply the ordered migration catalog, or report
+/// that PostgreSQL is unreachable.
+///
+/// The oracle folds a per-process namespace into every execution identity, so
+/// cases share one database without meeting an earlier run's slots.
+async fn pool() -> Option<PgPool> {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(std::env::VarError::NotPresent) => {
+            assert_ne!(
+                std::env::var("NEBULA_REQUIRE_POSTGRES").as_deref(),
+                Ok("1"),
+                "DATABASE_URL must be set when NEBULA_REQUIRE_POSTGRES=1: \
+                 PostgreSQL is a deployment backend and is never substituted"
+            );
+            return None;
+        },
+        Err(error) => panic!("DATABASE_URL is set but invalid: {error}"),
+    };
+
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+    SCHEMA_READY
+        .get_or_init(|| async {
+            init_schema(&pool)
+                .await
+                .expect("apply the ordered PostgreSQL migration catalog");
+        })
+        .await;
+    Some(pool)
+}
+
+async fn ledger() -> Option<PgOperationLedger> {
+    pool().await.map(PgOperationLedger::new)
+}
+
+operation_ledger_conformance_suite!(ledger());

--- a/crates/storage/tests/operation_ledger_conformance_sqlite.rs
+++ b/crates/storage/tests/operation_ledger_conformance_sqlite.rs
@@ -1,0 +1,44 @@
+//! Operation-ledger conformance for the SQLite deployment backend.
+//!
+//! Every case runs against a fresh in-memory database whose schema comes from
+//! the ordered migration catalog, so the adapter is exercised against exactly
+//! the `CHECK` constraints migration 0045 installs.
+
+#![cfg(feature = "sqlite")]
+
+#[macro_use]
+#[path = "support/operation_ledger_oracle.rs"]
+mod oracle;
+
+use std::str::FromStr;
+
+use nebula_storage::sqlite::{SqliteOperationLedger, init_schema};
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+/// An isolated in-memory database with the ordered migration catalog applied.
+///
+/// The shared cache keeps every pooled connection on the same database; a
+/// private `:memory:` connection would give each one its own empty schema.
+async fn fresh_pool() -> SqlitePool {
+    let database = format!("nebula-ledger-{}", uuid::Uuid::new_v4());
+    let url = format!("sqlite:file:{database}?mode=memory&cache=shared");
+    let options = SqliteConnectOptions::from_str(&url)
+        .expect("in-memory SQLite URL must parse")
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect_with(options)
+        .await
+        .expect("connect to in-memory SQLite");
+    init_schema(&pool)
+        .await
+        .expect("apply the ordered SQLite migration catalog");
+    pool
+}
+
+async fn ledger() -> Option<SqliteOperationLedger> {
+    Some(SqliteOperationLedger::new(fresh_pool().await))
+}
+
+operation_ledger_conformance_suite!(ledger());

--- a/crates/storage/tests/support/operation_ledger_oracle.rs
+++ b/crates/storage/tests/support/operation_ledger_oracle.rs
@@ -1,0 +1,500 @@
+//! One shared acceptance oracle for the durable operation ledger.
+//!
+//! The in-memory reference model, SQLite, and PostgreSQL implement the same two
+//! roles, so they must answer every ledger question identically. This module
+//! owns those answers once; each backend's test file supplies a ledger and runs
+//! the same cases against it.
+//!
+//! Cases are keyed by a per-process namespace and a per-case seed so they can
+//! share one durable store: spinning up an isolated PostgreSQL schema and
+//! replaying the whole ordered migration catalog per case would cost minutes,
+//! and a backend whose store outlives the run would otherwise meet the previous
+//! run's slots.
+
+use nebula_storage_port::store::{OperationLedger, OperationLedgerAdjudicator};
+use nebula_storage_port::{
+    AttemptGeneration, DestinationCapability, EffectSlotBinding, EffectSlotId, KnownOutcome,
+    OperationLedgerError, OperationState, PrepareOutcome, RequestFingerprint, Scope,
+};
+
+/// Both ledger roles one adapter offers together.
+///
+/// Production wiring hands them out separately — an effect caller never
+/// receives the adjudicator — but a conformance run needs both to drive an
+/// operation through its whole lifecycle.
+pub(crate) trait LedgerUnderTest: OperationLedger + OperationLedgerAdjudicator {}
+
+impl<T> LedgerUnderTest for T where T: OperationLedger + OperationLedgerAdjudicator {}
+
+/// Per-process namespace folded into every execution identity.
+///
+/// A backend whose durable store outlives the test run would otherwise meet the
+/// previous run's slots on the second run, so a `Prepared` case would report
+/// `Replayed`.
+static NAMESPACE: std::sync::LazyLock<String> =
+    std::sync::LazyLock::new(|| uuid::Uuid::new_v4().simple().to_string());
+
+pub(crate) fn scope() -> Scope {
+    Scope::new("ws-ledger", "org-ledger")
+}
+
+/// A second tenant, used to prove one tenant cannot reach another's slots.
+pub(crate) fn other_scope() -> Scope {
+    Scope::new("ws-ledger-other", "org-ledger-other")
+}
+
+fn execution_id(seed: u8) -> String {
+    format!("exe-{}-{seed:02x}", *NAMESPACE)
+}
+
+fn fingerprint(byte: u8) -> RequestFingerprint {
+    RequestFingerprint::new(1, [byte; 32])
+}
+
+/// Build a binding for `seed`'s slot.
+fn binding<'a>(
+    scope: &'a Scope,
+    execution: &'a str,
+    occurrence: &'a str,
+    generation: u64,
+    digest: u8,
+    destination: DestinationCapability,
+) -> EffectSlotBinding<'a> {
+    EffectSlotBinding {
+        scope,
+        execution_id: execution,
+        node_key: "charge",
+        occurrence,
+        attempt_generation: AttemptGeneration::new(generation),
+        fingerprint: fingerprint(digest),
+        destination,
+    }
+}
+
+async fn prepare_fresh(ledger: &impl LedgerUnderTest, seed: u8) -> (String, EffectSlotId) {
+    let scope = scope();
+    let execution = execution_id(seed);
+    let outcome = ledger
+        .prepare(&binding(
+            &scope,
+            &execution,
+            "once",
+            1,
+            0x11,
+            DestinationCapability::StableKey,
+        ))
+        .await
+        .expect("a fresh slot prepares");
+    assert!(
+        matches!(outcome, PrepareOutcome::Prepared(_)),
+        "a slot the ledger has never seen must report Prepared, got {outcome:?}"
+    );
+    (execution, outcome.operation().slot_id())
+}
+
+/// A fresh slot prepares once and reads back with the identity it minted.
+pub(crate) async fn prepare_mints_an_identity_and_reads_back(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let (_execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let record = ledger
+        .read_exact(&scope(), slot_id)
+        .await
+        .expect("a prepared slot reads back");
+
+    assert_eq!(record.operation().slot_id(), slot_id);
+    assert_eq!(record.state(), OperationState::Prepared);
+    assert_eq!(record.fingerprint(), fingerprint(0x11));
+    assert_eq!(
+        record.operation().destination(),
+        DestinationCapability::StableKey,
+        "the guarantee recorded at prepare time is what the record carries"
+    );
+}
+
+/// The same slot with the same request replays the original operation identity.
+///
+/// This is the property the whole protocol rests on: a restarted worker must
+/// reach the provider under one identity, not mint a second one.
+pub(crate) async fn same_slot_same_request_reuses_the_operation_identity(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let (execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let first = ledger
+        .read_exact(&scope, slot_id)
+        .await
+        .expect("the prepared slot reads back")
+        .operation()
+        .operation_id();
+
+    // A later attempt, from a different destination view, re-preparing the
+    // same slot.
+    let replayed = ledger
+        .prepare(&binding(
+            &scope,
+            &execution,
+            "once",
+            9,
+            0x11,
+            DestinationCapability::Opaque,
+        ))
+        .await
+        .expect("the same request on the same slot replays");
+
+    assert!(
+        matches!(replayed, PrepareOutcome::Replayed(_)),
+        "a slot the ledger already holds must report Replayed, got {replayed:?}"
+    );
+    assert_eq!(
+        replayed.operation().operation_id(),
+        first,
+        "every retry of one effect slot must reach the provider under one identity"
+    );
+    assert_eq!(
+        replayed.operation().destination(),
+        DestinationCapability::StableKey,
+        "a destination guarantee that changed since the prepare must not apply retroactively"
+    );
+}
+
+/// The same slot with a different request fails closed and writes nothing.
+pub(crate) async fn same_slot_different_request_is_a_mismatch_with_no_delta(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let (execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let before = ledger
+        .read_exact(&scope, slot_id)
+        .await
+        .expect("the prepared slot reads back");
+
+    assert_eq!(
+        ledger
+            .prepare(&binding(
+                &scope,
+                &execution,
+                "once",
+                1,
+                0x99,
+                DestinationCapability::StableKey,
+            ))
+            .await,
+        Err(OperationLedgerError::OperationMismatch { slot_id }),
+        "reusing a slot for a different request would give two effects one identity"
+    );
+    assert_eq!(
+        ledger
+            .read_exact(&scope, slot_id)
+            .await
+            .expect("the slot still reads back"),
+        before,
+        "a rejected prepare must leave no durable delta"
+    );
+}
+
+/// Two occurrences from one node are two slots even with identical payloads.
+pub(crate) async fn identical_payloads_on_distinct_occurrences_stay_distinct(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let execution = execution_id(seed);
+    let first = ledger
+        .prepare(&binding(
+            &scope,
+            &execution,
+            "first",
+            1,
+            0x11,
+            DestinationCapability::StableKey,
+        ))
+        .await
+        .expect("the first occurrence prepares");
+    let second = ledger
+        .prepare(&binding(
+            &scope,
+            &execution,
+            "second",
+            1,
+            0x11,
+            DestinationCapability::StableKey,
+        ))
+        .await
+        .expect("the second occurrence prepares");
+
+    assert!(matches!(second, PrepareOutcome::Prepared(_)));
+    assert_ne!(
+        first.operation().slot_id(),
+        second.operation().slot_id(),
+        "charging a card twice is a legitimate program; payload equality must not merge them"
+    );
+    assert_ne!(
+        first.operation().operation_id(),
+        second.operation().operation_id(),
+        "two intended effects must not share one provider-visible identity"
+    );
+}
+
+/// A superseded attempt cannot decide the current attempt's outcome.
+pub(crate) async fn a_stale_attempt_cannot_commit_an_outcome(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let execution = execution_id(seed);
+    let prepared = ledger
+        .prepare(&binding(
+            &scope,
+            &execution,
+            "once",
+            5,
+            0x11,
+            DestinationCapability::StableKey,
+        ))
+        .await
+        .expect("a fresh slot prepares");
+    let slot_id = prepared.operation().slot_id();
+
+    assert_eq!(
+        ledger
+            .commit_outcome(
+                &scope,
+                slot_id,
+                AttemptGeneration::new(4),
+                KnownOutcome::Succeeded
+            )
+            .await,
+        Err(OperationLedgerError::StaleFence {
+            slot_id,
+            current: AttemptGeneration::new(5),
+        })
+    );
+    assert_eq!(
+        ledger
+            .read_exact(&scope, slot_id)
+            .await
+            .expect("the slot reads back")
+            .state(),
+        OperationState::Prepared,
+        "a refused commit must not move the record"
+    );
+}
+
+/// Recommitting the same outcome is idempotent; a different one is refused.
+///
+/// The idempotent path is what lets a caller whose acknowledgement was lost
+/// recommit the same frozen evidence without inventing a second answer.
+pub(crate) async fn a_lost_acknowledgement_recommits_but_a_second_answer_is_refused(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let (_execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let generation = AttemptGeneration::new(1);
+
+    assert_eq!(
+        ledger
+            .commit_outcome(&scope, slot_id, generation, KnownOutcome::Succeeded)
+            .await,
+        Ok(())
+    );
+    assert_eq!(
+        ledger
+            .commit_outcome(&scope, slot_id, generation, KnownOutcome::Succeeded)
+            .await,
+        Ok(()),
+        "a lost acknowledgement is reconciled by recommitting the same evidence"
+    );
+    assert_eq!(
+        ledger
+            .commit_outcome(&scope, slot_id, generation, KnownOutcome::Failed)
+            .await,
+        Err(OperationLedgerError::OutcomeAlreadyRecorded {
+            slot_id,
+            recorded: OperationState::Succeeded,
+        }),
+        "the ledger must never hold two answers for one effect"
+    );
+}
+
+/// Adjudication resolves an unknown outcome and nothing else.
+pub(crate) async fn adjudication_resolves_only_an_unknown_outcome(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let scope = scope();
+    let (_execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let generation = AttemptGeneration::new(1);
+
+    ledger
+        .commit_outcome(&scope, slot_id, generation, KnownOutcome::OutcomeUnknown)
+        .await
+        .expect("an ambiguous boundary records OutcomeUnknown");
+
+    assert_eq!(
+        ledger
+            .adjudicate(&scope, slot_id, KnownOutcome::Succeeded, "   ")
+            .await,
+        Err(OperationLedgerError::CorruptRecord { slot_id }),
+        "an adjudication without a reason is not reviewable"
+    );
+    assert_eq!(
+        ledger
+            .adjudicate(
+                &scope,
+                slot_id,
+                KnownOutcome::Succeeded,
+                "provider support confirmed the charge landed"
+            )
+            .await,
+        Ok(())
+    );
+    assert_eq!(
+        ledger
+            .read_exact(&scope, slot_id)
+            .await
+            .expect("the slot reads back")
+            .state(),
+        OperationState::Succeeded
+    );
+    assert_eq!(
+        ledger
+            .adjudicate(&scope, slot_id, KnownOutcome::Failed, "changed my mind")
+            .await,
+        Err(OperationLedgerError::OutcomeAlreadyRecorded {
+            slot_id,
+            recorded: OperationState::Succeeded,
+        }),
+        "adjudication never overrules an answer that is already determined"
+    );
+}
+
+/// One tenant cannot observe or mutate another's slot.
+///
+/// The denial is reported exactly as an absent slot: "exists, but not yours"
+/// would turn a guessed identity into a cross-tenant existence oracle.
+pub(crate) async fn a_foreign_tenant_cannot_observe_or_mutate_a_slot(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let (_execution, slot_id) = prepare_fresh(ledger, seed).await;
+    let intruder = other_scope();
+
+    assert_eq!(
+        ledger.read_exact(&intruder, slot_id).await,
+        Err(OperationLedgerError::SlotUnprepared { slot_id }),
+        "a foreign slot must be indistinguishable from an absent one"
+    );
+    assert_eq!(
+        ledger
+            .commit_outcome(
+                &intruder,
+                slot_id,
+                AttemptGeneration::new(1),
+                KnownOutcome::Succeeded
+            )
+            .await,
+        Err(OperationLedgerError::SlotUnprepared { slot_id })
+    );
+    assert_eq!(
+        ledger
+            .read_exact(&scope(), slot_id)
+            .await
+            .expect("the owning tenant still reads it")
+            .state(),
+        OperationState::Prepared,
+        "a refused cross-tenant write must change nothing"
+    );
+}
+
+/// Reading a slot that was never prepared is not an error the caller can act on
+/// by inventing one.
+pub(crate) async fn an_unprepared_slot_reads_as_unprepared(
+    ledger: &impl LedgerUnderTest,
+    seed: u8,
+) {
+    let absent = EffectSlotId::from_storage_bytes([seed; 16]);
+    assert_eq!(
+        ledger.read_exact(&scope(), absent).await,
+        Err(OperationLedgerError::SlotUnprepared { slot_id: absent })
+    );
+    assert_eq!(
+        ledger
+            .commit_outcome(
+                &scope(),
+                absent,
+                AttemptGeneration::new(1),
+                KnownOutcome::Succeeded
+            )
+            .await,
+        Err(OperationLedgerError::SlotUnprepared { slot_id: absent })
+    );
+}
+
+/// Generate one `#[tokio::test]` per shared case against `$ledger`.
+///
+/// `$ledger` is an async expression yielding `Option<impl LedgerUnderTest>`;
+/// `None` means this backend is unreachable in the current environment and the
+/// case reports that rather than asserting against a substitute.
+///
+/// The including file must declare this module as `oracle`.
+#[macro_export]
+macro_rules! operation_ledger_conformance_suite {
+    ($ledger:expr) => {
+        $crate::operation_ledger_case!(prepare_mints_an_identity_and_reads_back, 0x21, $ledger);
+        $crate::operation_ledger_case!(
+            same_slot_same_request_reuses_the_operation_identity,
+            0x22,
+            $ledger
+        );
+        $crate::operation_ledger_case!(
+            same_slot_different_request_is_a_mismatch_with_no_delta,
+            0x23,
+            $ledger
+        );
+        $crate::operation_ledger_case!(
+            identical_payloads_on_distinct_occurrences_stay_distinct,
+            0x24,
+            $ledger
+        );
+        $crate::operation_ledger_case!(a_stale_attempt_cannot_commit_an_outcome, 0x25, $ledger);
+        $crate::operation_ledger_case!(
+            a_lost_acknowledgement_recommits_but_a_second_answer_is_refused,
+            0x26,
+            $ledger
+        );
+        $crate::operation_ledger_case!(
+            adjudication_resolves_only_an_unknown_outcome,
+            0x27,
+            $ledger
+        );
+        $crate::operation_ledger_case!(
+            a_foreign_tenant_cannot_observe_or_mutate_a_slot,
+            0x28,
+            $ledger
+        );
+        $crate::operation_ledger_case!(an_unprepared_slot_reads_as_unprepared, 0x29, $ledger);
+    };
+}
+
+/// Bind one shared case to a `#[tokio::test]` in the including backend file.
+#[macro_export]
+macro_rules! operation_ledger_case {
+    ($case:ident, $seed:expr, $ledger:expr) => {
+        #[tokio::test]
+        async fn $case() {
+            let Some(ledger) = $ledger.await else {
+                eprintln!(concat!(
+                    stringify!($case),
+                    ": backend unreachable in this environment"
+                ));
+                return;
+            };
+            oracle::$case(&ledger, $seed).await;
+        }
+    };
+}


### PR DESCRIPTION
Closes #977.

## What

The durable operation-ledger storage protocol runtime control owns before any remote effect invocation, per PRODUCT_CANON §11.3 steps 1–5. Port contract, ordered migration 0045, three adapters, and one shared three-backend acceptance oracle.

## The two distinctions that carry the weight

Both are encoded in types rather than left to caller discipline, because collapsing either is precisely what authorizes a duplicate effect:

- **A slot is an intended occurrence, not a payload.** Two slots stay distinct even with byte-identical requests — charging a card twice is a legitimate program. Deduplicating on payload would silently merge them.
- **`OutcomeUnknown` is not a failure, and `AcknowledgementUnknown` is not an outcome.** The first says the provider's answer was never learned; the second says our own database never confirmed the write. A failed commit therefore maps to `AcknowledgementUnknown`, deliberately not `Unavailable`: after a prepare that is the difference between "you may safely try again" and "you may not call the provider at all until a database-only read confirms the binding".

## Authority is split by role, not by convenience

`OperationLedger` prepares and commits outcomes but cannot resolve an operation that reached `OutcomeUnknown`. Only `OperationLedgerAdjudicator` can, it requires operator-supplied evidence, and blank evidence is refused — an adjudication without a reason is not reviewable, and reviewability is the only thing that makes a hand-decided outcome acceptable at all.

Identities are minted by the ledger and never accepted from a caller; the constructors are named `from_storage_bytes` so reading a row back does not read as inventing an identity.

`DestinationCapability` is persisted at prepare time and replayed wholesale. A destination whose configuration changed between the prepare and the recovery must not retroactively authorize re-invoking an effecting call. An unrecognised destination degrades to `opaque` rather than to the nearest known guarantee — guessing upward would authorize a re-invocation the destination never promised to deduplicate.

## Concurrency differs by backend, for one reason

SQLite runs every operation under `BEGIN IMMEDIATE`. PostgreSQL cannot use a row lock for prepare: `SELECT … FOR UPDATE` cannot lock a row that is absent, so two workers preparing the same slot would both read "not prepared". The insert is `ON CONFLICT DO NOTHING` on the natural key, and a loser re-reads the winner's row in the same transaction — both leave holding one operation identity. Mutating paths take `FOR UPDATE`.

A slot is addressable two ways on purpose: the minted `slot_id` a caller carries afterwards, and the natural key `(workspace, org, execution, node, occurrence)` a *restarted* worker can rebuild without ever having seen the slot.

## Migration gates answered, not silenced

`new_catalog_head_requires_explicit_admission_policy_review` is spelled with literals so a new head is a decision. Review recorded: 0045 creates one new table, touches no existing relation, and its `CHECK` constraints bind only rows it introduces, so no database admitted at 0040 or later can hold a row they would reject — the floor stays at 0040. The K2 repository-catalog contract was extended to reserve 0045 on both backends.

Two closed shapes are enforced by the schema rather than by adapter discipline: a `prepared` row has no outcome timestamp and a resolved one always does; adjudication evidence and its timestamp travel together and only on a determined outcome. Both were probed directly against a live PostgreSQL server and rejected their violating rows.

## Secret safety

Request payloads, provider responses, credentials, SQL, and driver strings never cross the port boundary — every error variant carries only typed identifiers and bounded counters. Adjudication evidence is persisted for review but deliberately kept off the span, not broadcast to every trace consumer.

## Evidence

- 590 nebula-storage tests pass (1 ignored: the nightly-only refresh-coordinator chaos plane).
- 9 PostgreSQL conformance cases pass against a live 17-alpine server on a clean database; the suite is added to the required `postgres-conformance` job rather than left to skip.
- clippy clean on default, sqlite-only, postgres-only, and all-features.
- `task quality` and `task deny` green.

One unrelated flake to note honestly: `nebula-api transport::oauth::runtime::tests::verified_email_fallback_reuses_the_original_absolute_deadline` failed once under full-workspace parallel load and passed 4/4 in isolation. This branch changes no file under `crates/api`; it is an absolute-deadline timing test, not a regression from this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable operation tracking for remote effects across in-memory, SQLite, and PostgreSQL storage.
  * Added safeguards for retries, duplicate requests, stale attempts, conflicting outcomes, and tenant isolation.
  * Added support for recording known outcomes and resolving uncertain outcomes with supporting evidence.
  * Added consistent operation identities, request matching, lifecycle states, and destination capability tracking.

* **Bug Fixes**
  * Improved handling of unavailable storage and uncertain acknowledgements without losing operation state.

* **Tests**
  * Added cross-backend conformance coverage for operation preparation, reads, commits, retries, and adjudication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->