### PR TITLE
feat(storage-port/storage)!: end dispatch claims at durable runtime handoff (#976)

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -294,7 +294,8 @@ jobs:
             refresh_claim_pg_integration \
             revision_catalog_conformance_postgres \
             revision_catalog_migration_postgres \
-            schema_setup_postgres
+            schema_setup_postgres \
+            turn_handoff_conformance_postgres
           do
             cargo nextest run "${common[@]}" --test "$suite"
           done

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -268,6 +268,10 @@ pub(crate) struct WorkerStoreProjection {
     /// different backends is exactly the miswiring that leaves an accepted
     /// execution parked forever with every component reporting healthy.
     pub(crate) control_queue: Arc<dyn nebula_storage_port::store::ControlQueue>,
+    /// Handoff over the **same** backend the queue and execution store use:
+    /// it commits the lease write and the queue acknowledgement in one
+    /// transaction (#976), so it must share their boundary.
+    pub(crate) turn_handoff: Arc<dyn nebula_storage_port::store::ExecutionTurnHandoff>,
 }
 
 #[cfg(feature = "runtime-repair-red")]
@@ -409,6 +413,7 @@ fn build_memory_execution_stores() -> Result<ExecutionStoreBundle, TransportInit
             },
             job_dispatch_queue: Arc::new(InMemoryJobDispatchQueue::new(&exec_store)),
             control_queue: Arc::clone(&shared_control_queue),
+            turn_handoff: Arc::new(nebula_storage::inmem::InMemoryTurnHandoff::new(&exec_store)),
         }
     };
 
@@ -451,7 +456,9 @@ async fn build_sqlite_execution_stores(
         SqliteWorkflowStore, SqliteWorkflowVersionStore, init_schema,
     };
     #[cfg(feature = "runtime-repair-red")]
-    use nebula_storage::sqlite::{SqliteIdempotencyGuard, SqliteJobDispatchQueue};
+    use nebula_storage::sqlite::{
+        SqliteIdempotencyGuard, SqliteJobDispatchQueue, SqliteTurnHandoff,
+    };
     use sqlx::sqlite::{
         SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
     };
@@ -525,6 +532,8 @@ async fn build_sqlite_execution_stores(
         },
         job_dispatch_queue: Arc::new(SqliteJobDispatchQueue::new(pool.clone())),
         control_queue: Arc::clone(&shared_control_queue),
+        // Same pool as the queue and execution store — see the field docs.
+        turn_handoff: Arc::new(SqliteTurnHandoff::new(pool.clone())),
     };
     #[cfg(feature = "runtime-repair-red")]
     let backend_lifecycle = ProfileBackendLifecycle::Sqlite(pool.clone());
@@ -572,7 +581,7 @@ async fn build_pg_execution_stores(
         init_schema as pg_init_schema,
     };
     #[cfg(feature = "runtime-repair-red")]
-    use nebula_storage::postgres::{PgIdempotencyGuard, PgJobDispatchQueue};
+    use nebula_storage::postgres::{PgIdempotencyGuard, PgJobDispatchQueue, PgTurnHandoff};
     use sqlx::postgres::PgPoolOptions;
 
     let environment_dsn;
@@ -645,6 +654,8 @@ async fn build_pg_execution_stores(
         },
         job_dispatch_queue: Arc::new(PgJobDispatchQueue::new(pool.clone())),
         control_queue: Arc::clone(&shared_control_queue),
+        // Same pool as the queue and execution store — see the field docs.
+        turn_handoff: Arc::new(PgTurnHandoff::new(pool.clone())),
     };
     #[cfg(feature = "runtime-repair-red")]
     let backend_lifecycle = ProfileBackendLifecycle::Postgres(pool.clone());

--- a/apps/server/src/runtime_repair_red/profile.rs
+++ b/apps/server/src/runtime_repair_red/profile.rs
@@ -256,6 +256,7 @@ impl RuntimeRepairHarness {
                 worker_projection.execution_stores,
                 worker_projection.workflow_stores,
                 worker_projection.job_dispatch_queue,
+                worker_projection.turn_handoff,
                 PROFILE_PROCESSOR_ID,
                 engine_clock,
                 execution_event_bus,

--- a/apps/worker/src/compose.rs
+++ b/apps/worker/src/compose.rs
@@ -14,7 +14,7 @@ use nebula_engine::{
 use nebula_metrics::MetricsRegistry;
 use nebula_plugin::{ManifestError, PluginError};
 use nebula_plugin_core::CorePlugin;
-use nebula_storage_port::store::JobDispatchQueue;
+use nebula_storage_port::store::{ExecutionTurnHandoff, JobDispatchQueue};
 use nebula_worker::{WorkerBuildError, WorkerRuntimeBuilder};
 
 /// Typed errors emitted by the composition root.
@@ -87,12 +87,14 @@ pub fn build_core_flavor_runtime(
     execution_stores: ExecutionStores,
     workflow_stores: WorkflowStores,
     queue: Arc<dyn JobDispatchQueue>,
+    turn_handoff: Arc<dyn ExecutionTurnHandoff>,
     processor_id: [u8; 16],
 ) -> Result<(WorkerRuntimeBuilder, MetricsRegistry, PluginKey), ComposeError> {
     build_core_flavor_runtime_impl(
         execution_stores,
         workflow_stores,
         queue,
+        turn_handoff,
         processor_id,
         EngineEvidenceInputs::Ordinary,
     )
@@ -118,6 +120,7 @@ pub fn build_core_flavor_runtime_for_runtime_repair_red(
     execution_stores: ExecutionStores,
     workflow_stores: WorkflowStores,
     queue: Arc<dyn JobDispatchQueue>,
+    turn_handoff: Arc<dyn ExecutionTurnHandoff>,
     processor_id: [u8; 16],
     clock: Arc<dyn nebula_core::accessor::Clock>,
     event_bus: nebula_eventbus::EventBus<nebula_engine::ExecutionEvent>,
@@ -126,6 +129,7 @@ pub fn build_core_flavor_runtime_for_runtime_repair_red(
         execution_stores,
         workflow_stores,
         queue,
+        turn_handoff,
         processor_id,
         EngineEvidenceInputs::RuntimeRepair { clock, event_bus },
     )
@@ -144,6 +148,7 @@ fn build_core_flavor_runtime_impl(
     execution_stores: ExecutionStores,
     workflow_stores: WorkflowStores,
     queue: Arc<dyn JobDispatchQueue>,
+    turn_handoff: Arc<dyn ExecutionTurnHandoff>,
     processor_id: [u8; 16],
     evidence_inputs: EngineEvidenceInputs,
 ) -> Result<(WorkerRuntimeBuilder, MetricsRegistry, PluginKey), ComposeError> {
@@ -199,13 +204,18 @@ fn build_core_flavor_runtime_impl(
     // `main` can apply env-driven overrides (`batch_size`, `poll_interval`)
     // before calling `.build()`. Integration tests call `.build()` directly
     // on the returned builder, optionally adding a fast poll interval first.
+    //
+    // The turn handoff is wired here (not left to the caller) because it is a
+    // build-time requirement — an orchestrator without it cannot end dispatch
+    // claims at the durable runtime handoff (#976).
     let builder = WorkerRuntimeBuilder::from_wired_engine(
         Arc::clone(&engine),
         execution_stores,
         queue,
         vec![plugin_key.clone()],
         processor_id,
-    );
+    )
+    .with_turn_handoff(turn_handoff);
 
     tracing::info!(
         plugin = %plugin_key,

--- a/apps/worker/src/compose_main.rs
+++ b/apps/worker/src/compose_main.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 use nebula_storage::sqlite::{
     SqliteControlQueue, SqliteExecutionStore, SqliteIdempotencyGuard, SqliteJobDispatchQueue,
-    SqliteJournalReader, SqliteResumeTokenStore, SqliteWorkflowStore, SqliteWorkflowVersionStore,
-    init_schema,
+    SqliteJournalReader, SqliteResumeTokenStore, SqliteTurnHandoff, SqliteWorkflowStore,
+    SqliteWorkflowVersionStore, init_schema,
 };
 use nebula_storage::{InMemoryCheckpointStore, InMemoryNodeResultStore};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{EnvFilter, fmt};
 
 use nebula_engine::{ExecutionStores, WorkflowStores};
-use nebula_storage_port::store::{ControlQueue, JobDispatchQueue};
+use nebula_storage_port::store::{ControlQueue, ExecutionTurnHandoff, JobDispatchQueue};
 use nebula_worker_bin::compose::{
     ComposeError, WorkerConfig, WorkerConfigError, build_core_flavor_runtime,
 };
@@ -117,6 +117,7 @@ async fn build_stores(
         WorkflowStores,
         Arc<dyn JobDispatchQueue>,
         Arc<dyn ControlQueue>,
+        Arc<dyn ExecutionTurnHandoff>,
     ),
     WorkerRunError,
 > {
@@ -173,6 +174,11 @@ async fn build_stores(
         let workflow_store = Arc::new(SqliteWorkflowStore::new(pool.clone()));
         let versions_store = Arc::new(SqliteWorkflowVersionStore::new(pool.clone()));
         let queue = Arc::new(SqliteJobDispatchQueue::new(pool.clone()));
+        // Same pool as the execution store and the queue: the handoff commits
+        // the lease acquisition and the queue acknowledgement in one
+        // transaction, so it must share the boundary both are written under
+        // (#976).
+        let turn_handoff = Arc::new(SqliteTurnHandoff::new(pool.clone()));
         // Same pool as the execution store: the consumer must drain the
         // queue the API writes to, not a second one.
         let control_queue = Arc::new(SqliteControlQueue::new(pool));
@@ -190,7 +196,13 @@ async fn build_stores(
             versions: versions_store,
         };
 
-        return Ok((execution_stores, workflow_stores, queue, control_queue));
+        return Ok((
+            execution_stores,
+            workflow_stores,
+            queue,
+            control_queue,
+            turn_handoff,
+        ));
     }
 
     // ── Postgres path (opt-in; compile-verified but not CI-integration-tested) ──
@@ -224,12 +236,14 @@ async fn build_pg_stores(
         WorkflowStores,
         Arc<dyn JobDispatchQueue>,
         Arc<dyn ControlQueue>,
+        Arc<dyn ExecutionTurnHandoff>,
     ),
     WorkerRunError,
 > {
     use nebula_storage::postgres::{
         PgControlQueue, PgExecutionStore, PgIdempotencyGuard, PgJobDispatchQueue, PgJournalReader,
-        PgResumeTokenStore, PgWorkflowStore, PgWorkflowVersionStore, init_schema as pg_init_schema,
+        PgResumeTokenStore, PgTurnHandoff, PgWorkflowStore, PgWorkflowVersionStore,
+        init_schema as pg_init_schema,
     };
     use sqlx::postgres::PgPoolOptions;
 
@@ -263,6 +277,8 @@ async fn build_pg_stores(
     let workflow_store = Arc::new(PgWorkflowStore::new(pool.clone()));
     let versions_store = Arc::new(PgWorkflowVersionStore::new(pool.clone()));
     let queue = Arc::new(PgJobDispatchQueue::new(pool.clone()));
+    // Same pool as the execution store and the queue — see the SQLite arm.
+    let turn_handoff = Arc::new(PgTurnHandoff::new(pool.clone()));
     // Same pool as the execution store — see the SQLite arm.
     let control_queue = Arc::new(PgControlQueue::new(pool));
 
@@ -279,7 +295,13 @@ async fn build_pg_stores(
         versions: versions_store,
     };
 
-    Ok((execution_stores, workflow_stores, queue, control_queue))
+    Ok((
+        execution_stores,
+        workflow_stores,
+        queue,
+        control_queue,
+        turn_handoff,
+    ))
 }
 
 /// Fail-closed twin compiled when the `postgres` feature is absent.
@@ -298,6 +320,7 @@ async fn build_pg_stores(
         WorkflowStores,
         Arc<dyn JobDispatchQueue>,
         Arc<dyn ControlQueue>,
+        Arc<dyn ExecutionTurnHandoff>,
     ),
     WorkerRunError,
 > {
@@ -343,7 +366,8 @@ pub(crate) async fn run() -> Result<(), WorkerRunError> {
     }
 
     // Build the store bundle — SQLite or Postgres depending on config.
-    let (execution_stores, workflow_stores, queue, control_queue) = build_stores(&config).await?;
+    let (execution_stores, workflow_stores, queue, control_queue, turn_handoff) =
+        build_stores(&config).await?;
 
     // Assemble the core-flavor builder (boots CorePlugin + wires into engine).
     // The returned MetricsRegistry is the same instance the engine's ActionRuntime
@@ -354,6 +378,7 @@ pub(crate) async fn run() -> Result<(), WorkerRunError> {
         execution_stores,
         workflow_stores,
         queue,
+        turn_handoff,
         config.processor_id,
     )?;
 

--- a/apps/worker/tests/smoke.rs
+++ b/apps/worker/tests/smoke.rs
@@ -113,6 +113,15 @@ impl TestStores {
             versions: self.versions.clone(),
         }
     }
+
+    /// Handoff over the SAME shared core the queue and execution store use —
+    /// the lease write and the queue acknowledgement must land under one
+    /// boundary (#976).
+    fn turn_handoff(&self) -> Arc<nebula_storage::inmem::InMemoryTurnHandoff> {
+        Arc::new(nebula_storage::inmem::InMemoryTurnHandoff::new(
+            &self.execution,
+        ))
+    }
 }
 
 // ── Workflow helpers ──────────────────────────────────────────────────────────
@@ -239,6 +248,7 @@ async fn core_flavor_runtime_processes_seeded_start_job() {
         stores.execution_stores(),
         stores.workflow_stores(),
         Arc::clone(&queue),
+        stores.turn_handoff(),
         [0xCCu8; 16],
     )
     .expect("build_core_flavor_runtime must succeed");
@@ -355,6 +365,7 @@ async fn core_flavor_runtime_advertises_core_plugin_key() {
         stores.execution_stores(),
         stores.workflow_stores(),
         queue,
+        stores.turn_handoff(),
         [0x01u8; 16],
     )
     .expect("build_core_flavor_runtime must succeed with the CorePlugin installed");
@@ -387,6 +398,7 @@ fn runtime_repair_builder_seals_exact_clock_and_event_bus() {
         stores.execution_stores(),
         stores.workflow_stores(),
         queue,
+        stores.turn_handoff(),
         [0xEEu8; 16],
         clock,
         event_bus,

--- a/crates/engine/src/daemon/execution_sink.rs
+++ b/crates/engine/src/daemon/execution_sink.rs
@@ -1,18 +1,23 @@
 //! [`EngineExecutionSink`] — orchestrator→engine hand-off for the
 //! trigger-dispatch slice.
 //!
-//! Implements [`nebula_orchestrator::ExecutionSink`] by mirroring the logic
-//! of [`EngineControlDispatch`]: read the persisted status for idempotency,
-//! then call `resume_execution` for `Created`/`Paused` rows.
+//! Implements [`nebula_orchestrator::ExecutionSink`]: read the persisted
+//! status for idempotency, then drive `Created`/`Paused` rows via
+//! `resume_execution_leased` under the fence the durable handoff minted
+//! (#976). The dispatch claim is already ended and the queue row already
+//! acknowledged by the time a turn arrives here — the engine never acquires
+//! a second lease (a live lease blocks acquisition outright, even for the
+//! same holder).
 //!
 //! ## Idempotency contract (mirrors `EngineControlDispatch`)
 //!
-//! The orchestrator's reclaim sweep can redeliver a `JobDispatchMsg` whose
-//! `mark_dispatched` failed after a successful dispatch.  This sink handles
-//! re-delivery via the same guard as `EngineControlDispatch::dispatch_start`:
+//! The job queue never redelivers an acknowledged row, but a second queue
+//! row for the same execution (e.g. a restart fan-out) and the control-queue
+//! consumer reach the same engine state. This sink handles re-delivery via
+//! the same guard as `EngineControlDispatch::dispatch_start`:
 //!
 //! - **Already terminal / Running / Cancelling** → `Ok(())` (idempotent no-op).
-//! - **Created / Paused** → drive via `resume_execution`.
+//! - **Created / Paused** → drive via `resume_execution_leased`.
 //! - **Row not found** → `ExecutionSinkError::Rejected` (orphaned Start).
 //! - **`EngineError::Leased`** → `Ok(())` (sibling runner already holds the
 //!   lease; same reasoning as `EngineControlDispatch`).
@@ -24,8 +29,8 @@ use std::sync::Arc;
 
 use nebula_core::id::ExecutionId;
 use nebula_execution::ExecutionStatus;
-use nebula_orchestrator::{ExecutionSink, ExecutionSinkError};
-use nebula_storage_port::{Scope, dto::JobDispatchMsg, store::ExecutionStore};
+use nebula_orchestrator::{DispatchedTurn, ExecutionSink, ExecutionSinkError};
+use nebula_storage_port::{Scope, store::ExecutionStore};
 
 use crate::{WorkflowEngine, error::EngineError};
 
@@ -105,21 +110,27 @@ impl EngineExecutionSink {
         }
     }
 
-    /// Drive an execution through `resume_execution` under the given tenant scope.
+    /// Drive an execution through `resume_execution_leased` under the given
+    /// tenant scope, adopting the fence the durable handoff minted (#976).
     ///
-    /// Maps [`EngineError::Leased`] to `Ok(())` (sibling runner already owns
-    /// the dispatch; we should not mark the row Failed) and re-checks terminal
-    /// status before surfacing other engine errors as `Internal`.
+    /// Maps [`EngineError::Leased`] to `Ok(())` (a sibling runner owns the
+    /// transition — the accepted turn's work is being driven, just not here)
+    /// and re-checks terminal status before surfacing other engine errors as
+    /// `Internal`.
     async fn drive(
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+        fence: nebula_storage_port::FencingToken,
     ) -> Result<(), ExecutionSinkError> {
-        match self.engine.resume_execution(scope, execution_id).await {
+        match self
+            .engine
+            .resume_execution_leased(scope, execution_id, fence)
+            .await
+        {
             Ok(_) => Ok(()),
             // Concurrent dispatcher already holds the lease — the canonical
-            // idempotency outcome. Returning Ok prevents the orchestrator from
-            // marking the row Failed; the lease holder owns the transition.
+            // idempotency outcome. The lease holder owns the transition.
             Err(EngineError::Leased { .. }) => Ok(()),
             Err(e) => {
                 // Last-ditch idempotency guard: re-read in case a sibling
@@ -142,14 +153,19 @@ impl EngineExecutionSink {
 impl ExecutionSink for EngineExecutionSink {
     #[tracing::instrument(
         level = "debug",
-        skip(self, msg),
+        skip(self, turn),
         fields(
-            execution_id = %msg.execution_id,
-            command      = msg.command.as_str(),
-            reclaim      = msg.reclaim_count,
+            execution_id = %turn.msg.execution_id,
+            command      = turn.msg.command.as_str(),
+            reclaim      = turn.msg.reclaim_count,
+            fence_generation = turn.fence.generation(),
         )
     )]
-    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+    async fn dispatch(&self, turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError> {
+        let msg = turn.msg;
+        // Defense in depth: the orchestrator validates this before the
+        // handoff, so a parse failure here means a sink was handed a turn it
+        // should never have seen. Reject rather than drive.
         let execution_id = msg.execution_id.parse::<ExecutionId>().map_err(|e| {
             ExecutionSinkError::Rejected(format!(
                 "invalid execution_id `{}` in job dispatch msg: {e}",
@@ -165,7 +181,8 @@ impl ExecutionSink for EngineExecutionSink {
                 "execution {execution_id} not found — start command orphaned"
             ))),
             // Already past Created gate: running, cancelling, or terminal.
-            // Re-delivered Start is a safe no-op (idempotency contract).
+            // A second turn for this execution is a safe no-op (idempotency
+            // contract).
             Some(
                 ExecutionStatus::Running
                 | ExecutionStatus::Cancelling
@@ -175,7 +192,7 @@ impl ExecutionSink for EngineExecutionSink {
                 | ExecutionStatus::TimedOut,
             ) => Ok(()),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
-                self.drive(&msg.scope, execution_id).await
+                self.drive(&msg.scope, execution_id, turn.fence).await
             },
         }
     }
@@ -196,6 +213,8 @@ mod tests {
     };
 
     use nebula_action::ActionResult;
+    use nebula_orchestrator::DispatchedTurn;
+    use nebula_storage_port::FencingToken;
 
     use super::EngineExecutionSink;
     use crate::{
@@ -283,7 +302,13 @@ mod tests {
             0,
         );
 
-        let result = sink.dispatch(&msg).await;
+        // The fence never matters here: read_status short-circuits with
+        // `None` before any lease adoption. Generation 1 is placeholder-valid.
+        let turn = DispatchedTurn {
+            msg: &msg,
+            fence: FencingToken::from_generation(1),
+        };
+        let result = sink.dispatch(&turn).await;
 
         // New code: read_status reads under scope_b → None → Rejected.
         // Old code: read_status reads under ("nebula","nebula") → finds the row →

--- a/crates/engine/src/engine/mod.rs
+++ b/crates/engine/src/engine/mod.rs
@@ -1784,6 +1784,70 @@ impl WorkflowEngine {
             "execution lease acquired"
         );
 
+        Ok(Some(self.spawn_lease_guard(
+            backend,
+            execution_id,
+            holder,
+            frontier_cancel,
+        )))
+    }
+
+    /// Adopt a lease the durable handoff already minted (#976) and run the
+    /// same heartbeat loop an acquired lease gets.
+    ///
+    /// The handoff (`ExecutionTurnHandoff::accept_turn`) acquires the lease
+    /// and acknowledges the queue row in one transaction; the engine must
+    /// drive the turn under that fence rather than acquire again — a live
+    /// lease blocks acquisition outright, even for the same holder. Renewal
+    /// and release are fence-gated, so the holder string recorded at handoff
+    /// time never gates this engine's ownership; the fence does.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError::PlanningFailed`] when no execution stores are
+    /// configured: a handoff fence without a storage seam is a wiring bug,
+    /// not a library-mode fallback.
+    fn adopt_handoff_lease(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        fence: nebula_storage_port::FencingToken,
+        frontier_cancel: CancellationToken,
+    ) -> Result<LeaseGuard, EngineError> {
+        let stores = self.stores.clone().ok_or_else(|| {
+            EngineError::PlanningFailed("handoff lease adoption requires execution stores".into())
+        })?;
+        let holder = self.instance_id.to_string();
+        tracing::debug!(
+            %execution_id,
+            %holder,
+            fence_generation = fence.generation(),
+            ttl_secs = self.lease_ttl.as_secs(),
+            heartbeat_secs = self.lease_heartbeat_interval.as_secs(),
+            "adopting handoff-minted execution lease (#976)"
+        );
+        let backend =
+            crate::store_seam::LeaseBackend::new(stores.execution.clone(), scope.clone(), fence);
+        Ok(self.spawn_lease_guard(backend, execution_id, holder, frontier_cancel))
+    }
+
+    /// Spawn the lease heartbeat task and assemble the [`LeaseGuard`] around
+    /// an already-established [`crate::store_seam::LeaseBackend`].
+    ///
+    /// Shared by both lease entry points: `acquire_and_heartbeat_lease`
+    /// (engine acquires) and [`adopt_handoff_lease`](Self::adopt_handoff_lease)
+    /// (the durable handoff acquired and this engine renews/releases under
+    /// its fence).
+    fn spawn_lease_guard(
+        &self,
+        backend: crate::store_seam::LeaseBackend,
+        execution_id: ExecutionId,
+        holder: String,
+        frontier_cancel: CancellationToken,
+    ) -> LeaseGuard {
+        let ttl = self.lease_ttl;
+        let heartbeat_interval = self.lease_heartbeat_interval;
+
         // Spawn a heartbeat task. A shared `heartbeat_lost` token
         // trips when a renew returns `Ok(false)` (stolen or expired) or
         // errors — the frontier loop observes it via the
@@ -1795,7 +1859,6 @@ impl WorkflowEngine {
         let metrics = self.metrics.clone();
         let heartbeat_lost_cloned = heartbeat_lost.clone();
         let heartbeat_shutdown_cloned = heartbeat_shutdown.clone();
-        let frontier_cancel_cloned = frontier_cancel.clone();
         let handle = tokio::spawn(async move {
             let mut ticker = tokio::time::interval(heartbeat_interval);
             // The first tick fires immediately; skip it — we just
@@ -1841,7 +1904,7 @@ impl WorkflowEngine {
                                      state the new holder now drives (ADR 0008, §12.2)"
                                 );
                                 heartbeat_lost_cloned.cancel();
-                                frontier_cancel_cloned.cancel();
+                                frontier_cancel.cancel();
                                 break;
                             }
                             Err(e) => {
@@ -1870,7 +1933,7 @@ impl WorkflowEngine {
                                      runner conservatively (ADR 0008, §12.2)"
                                 );
                                 heartbeat_lost_cloned.cancel();
-                                frontier_cancel_cloned.cancel();
+                                frontier_cancel.cancel();
                                 break;
                             }
                         }
@@ -1879,14 +1942,14 @@ impl WorkflowEngine {
             }
         });
 
-        Ok(Some(LeaseGuard {
+        LeaseGuard {
             backend,
             execution_id,
             holder,
             handle: Some(handle),
             shutdown: heartbeat_shutdown,
             heartbeat_lost,
-        }))
+        }
     }
 
     /// Pre-flight: reject any `Connection` whose `from_port` the source

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -10,6 +10,20 @@
 
 use super::*;
 
+/// Where the execution lease for a resume turn comes from.
+enum ResumeLeaseSource {
+    /// The engine acquires the lease itself — the control-queue and restart
+    /// paths, where nothing has leased the execution yet.
+    Acquire,
+    /// The durable handoff (#976) already minted the lease when it
+    /// acknowledged the dispatch row; the engine adopts that fence instead of
+    /// acquiring (a live lease blocks acquisition outright, even for the same
+    /// holder, so acquiring here could never succeed).
+    Adopt {
+        fence: nebula_storage_port::FencingToken,
+    },
+}
+
 impl WorkflowEngine {
     /// Resume an incomplete execution after process restart.
     ///
@@ -17,6 +31,10 @@ impl WorkflowEngine {
     /// which nodes are already complete, and re-executes from the frontier of
     /// ready-but-not-yet-executed nodes (nodes whose predecessors are all
     /// terminal but which are not yet terminal themselves).
+    ///
+    /// The execution lease is acquired by this call — use
+    /// [`resume_execution_leased`](Self::resume_execution_leased) when the
+    /// durable handoff already minted it.
     ///
     /// Persisted outputs are pre-loaded into the shared output map so that
     /// resumed nodes receive the correct predecessor data.
@@ -32,6 +50,40 @@ impl WorkflowEngine {
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
+    ) -> Result<ExecutionResult, EngineError> {
+        self.resume_execution_inner(scope, execution_id, ResumeLeaseSource::Acquire)
+            .await
+    }
+
+    /// Resume an execution whose lease the durable handoff already minted.
+    ///
+    /// The orchestrator's handoff (`ExecutionTurnHandoff::accept_turn`)
+    /// acknowledged the dispatch row and acquired this execution's lease in
+    /// one transaction; `fence` is the token it returned. This call adopts
+    /// that fence — renewing and releasing it on the same heartbeat loop the
+    /// acquire path uses — instead of acquiring a second lease.
+    ///
+    /// # Errors
+    ///
+    /// Same error contract as [`resume_execution`](Self::resume_execution);
+    /// additionally returns [`EngineError::PlanningFailed`] when no execution
+    /// stores are configured, since a handoff fence without a storage seam is
+    /// a wiring bug.
+    pub async fn resume_execution_leased(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        fence: nebula_storage_port::FencingToken,
+    ) -> Result<ExecutionResult, EngineError> {
+        self.resume_execution_inner(scope, execution_id, ResumeLeaseSource::Adopt { fence })
+            .await
+    }
+
+    async fn resume_execution_inner(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        lease_source: ResumeLeaseSource,
     ) -> Result<ExecutionResult, EngineError> {
         let started = Instant::now();
 
@@ -368,16 +420,25 @@ impl WorkflowEngine {
         let cancel_token = CancellationToken::new();
         let mut repo_version = repo_version_loaded;
 
-        // Acquire the execution lease before running the frontier (ADR
+        // Establish the execution lease before running the frontier (ADR
         // 0008, #325). Resume is explicitly a second entry point for an
         // existing execution — if another runner is already driving it
         // (whether because the crash recovery loop picked it up or an
-        // operator issued two resumes back-to-back), we fence this call
-        // with `EngineError::Leased` instead of running nodes in parallel
-        // with the existing runner.
-        let lease = self
-            .acquire_and_heartbeat_lease(scope, execution_id, cancel_token.clone())
-            .await?;
+        // operator issued two resumes back-to-back), the acquire path fences
+        // this call with `EngineError::Leased` instead of running nodes in
+        // parallel with the existing runner. The adopt path (#976) skips the
+        // acquire: the durable handoff already minted this lease when it
+        // acknowledged the dispatch row, and this engine renews/releases it
+        // under the returned fence.
+        let lease = match lease_source {
+            ResumeLeaseSource::Acquire => {
+                self.acquire_and_heartbeat_lease(scope, execution_id, cancel_token.clone())
+                    .await?
+            },
+            ResumeLeaseSource::Adopt { fence } => {
+                Some(self.adopt_handoff_lease(scope, execution_id, fence, cancel_token.clone())?)
+            },
+        };
 
         // Fencing token threaded into every checkpoint / final-state
         // commit. `Some` only on the spec-16 port lease path.

--- a/crates/engine/src/engine/resume.rs
+++ b/crates/engine/src/engine/resume.rs
@@ -319,12 +319,22 @@ impl WorkflowEngine {
             // CONTROL-QUEUE row failed, never the execution row itself.
             // Durably fail the execution row before propagating so the
             // rejection is actually observable.
+            //
+            // On the adopt path (#976) the durable handoff already holds the
+            // lease under its fence, so the failure write must commit under
+            // that fence — acquiring is blocked outright by the live lease,
+            // even for the same holder.
+            let handoff_fence = match lease_source {
+                ResumeLeaseSource::Adopt { fence } => Some(fence),
+                ResumeLeaseSource::Acquire => None,
+            };
             self.fail_cold_start_preflight(
                 scope,
                 execution_id,
                 exec_state,
                 repo_version_loaded,
                 &reject,
+                handoff_fence,
             )
             .await;
             return Err(reject);
@@ -706,6 +716,15 @@ impl WorkflowEngine {
     /// succeeds, so no rejection is ever silently swallowed — a row left
     /// stuck in `Created` after a failed best-effort attempt remains
     /// reachable by the existing crash-recovery reclaim path.
+    ///
+    /// `handoff_fence` carries the durable handoff's fence on the adopt path
+    /// (#976): the handoff already holds the lease, so this function commits
+    /// (and afterwards releases) under that fence instead of acquiring — a
+    /// live lease blocks acquisition outright, even for the same holder, and
+    /// the queue row is already acknowledged, so an acquire failure here
+    /// would orphan the row in `Created` with nothing left to redeliver it.
+    /// `None` is the acquire path: this function takes and releases the lease
+    /// itself.
     async fn fail_cold_start_preflight(
         &self,
         scope: &Scope,
@@ -713,6 +732,7 @@ impl WorkflowEngine {
         mut exec_state: ExecutionState,
         repo_version: u64,
         reject: &EngineError,
+        handoff_fence: Option<nebula_storage_port::FencingToken>,
     ) {
         let Some(stores) = &self.stores else {
             // Library mode (no storage) — no durable row to repair.
@@ -722,31 +742,35 @@ impl WorkflowEngine {
         let id = execution_id.to_string();
         let holder = self.instance_id.to_string();
 
-        let lease_token = match stores
-            .execution
-            .acquire_lease(scope, &id, &holder, self.lease_ttl)
-            .await
-        {
-            Ok(Some(token)) => token,
-            Ok(None) => {
-                tracing::warn!(
-                    %execution_id,
-                    error = %reject,
-                    "cold-start preflight rejection: execution lease held by another runner; \
-                     leaving the execution row for that runner to resolve"
-                );
-                return;
-            },
-            Err(e) => {
-                tracing::warn!(
-                    %execution_id,
-                    error = %e,
-                    reject = %reject,
-                    "cold-start preflight rejection: failed to acquire lease; the execution row \
-                     remains Created (recoverable via reclaim)"
-                );
-                return;
-            },
+        let lease_token = if let Some(fence) = handoff_fence {
+            fence
+        } else {
+            match stores
+                .execution
+                .acquire_lease(scope, &id, &holder, self.lease_ttl)
+                .await
+            {
+                Ok(Some(token)) => token,
+                Ok(None) => {
+                    tracing::warn!(
+                        %execution_id,
+                        error = %reject,
+                        "cold-start preflight rejection: execution lease held by another runner; \
+                         leaving the execution row for that runner to resolve"
+                    );
+                    return;
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        %execution_id,
+                        error = %e,
+                        reject = %reject,
+                        "cold-start preflight rejection: failed to acquire lease; the execution row \
+                         remains Created (recoverable via reclaim)"
+                    );
+                    return;
+                },
+            }
         };
 
         // `mark_setup_failed` and each `transition_status` call bump

--- a/crates/engine/src/engine/tests.rs
+++ b/crates/engine/src/engine/tests.rs
@@ -1749,6 +1749,111 @@ async fn resume_execution_rejects_undeclared_port_on_genuine_first_attempt() {
     );
 }
 
+/// The adopt path (#976) must not lose the cold-start pre-flight's durable
+/// failure write. Mirrors
+/// `resume_execution_rejects_undeclared_port_on_genuine_first_attempt`, but
+/// the lease is already held when `resume_execution_leased` starts — exactly
+/// the shape the orchestrator's handoff produces: the queue row is
+/// acknowledged and the execution lease minted before the sink drives the
+/// turn.
+///
+/// Red-ability: if `fail_cold_start_preflight` tried to `acquire_lease` on
+/// this path, the live handoff lease would block it (even for the same
+/// holder), the best-effort write would be skipped, and the row would stay
+/// `Created` — orphaned, because the acknowledged queue row is never
+/// redelivered. The `Failed`-status assertion below is the one that fires.
+#[tokio::test]
+async fn resume_execution_leased_rejects_undeclared_port_and_still_marks_failed() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        EchoHandler,
+    );
+
+    let stores = TestStores::new();
+    let (engine, _) = make_engine(registry);
+    let engine = stores.attach(engine);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "core", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "core", "echo").unwrap(),
+        ],
+        vec![Connection::new(a.clone(), b.clone()).with_from_port(port_key!("typo_port"))],
+    );
+    stores.save_workflow(&wf).await;
+
+    // Cold-start shape persisted by the emitter before the handoff runs.
+    let execution_id = ExecutionId::new();
+    let exec_state = ExecutionState::new(execution_id, wf.id, &[]);
+    let state_json = serde_json::to_value(&exec_state).unwrap();
+    stores.inject_state(execution_id, wf.id, state_json).await;
+
+    let scope = crate::store_seam::single_tenant_scope();
+
+    // The handoff's lease: minted before the sink drives the turn, held
+    // while `resume_execution_leased` runs.
+    let fence = stores
+        .execution
+        .acquire_lease(
+            &scope,
+            &execution_id.to_string(),
+            "orchestrator:test",
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap()
+        .expect("no lease existed yet");
+
+    let result = engine
+        .resume_execution_leased(&scope, execution_id, fence)
+        .await;
+
+    assert!(
+        matches!(result, Err(EngineError::UndeclaredOutputPort { .. })),
+        "expected UndeclaredOutputPort, got {result:?}"
+    );
+
+    // The rejection must still be durable even though the lease was already
+    // held: the row is Failed, not orphaned in Created.
+    let (version, state_json) = stores
+        .get_state(execution_id)
+        .await
+        .unwrap()
+        .expect("row must still exist — a rejection must not delete it");
+    assert!(
+        version > 0,
+        "the Failed transition must be durably committed under the handoff fence"
+    );
+    let state_str = serde_json::to_string(&state_json).unwrap();
+    let persisted: ExecutionState = serde_json::from_str(&state_str).unwrap();
+    assert_eq!(
+        persisted.status,
+        ExecutionStatus::Failed,
+        "a cold-start pre-flight rejection on the adopt path must leave the execution row \
+         Failed, not orphaned in Created with an acknowledged queue row"
+    );
+    assert_eq!(
+        persisted.node_states.get(&a).map(|ns| ns.state),
+        Some(NodeState::Failed),
+        "the offending node must record the rejection"
+    );
+
+    // The handoff lease must be released after the failure write — nothing
+    // else will ever touch this terminal row.
+    let rows = stores.execution.list_all_running().await.unwrap();
+    let row = rows
+        .iter()
+        .find(|r| r.id == execution_id)
+        .expect("row must still exist");
+    assert!(
+        row.lease_holder.is_none(),
+        "the handoff lease must be released once the row is terminally Failed"
+    );
+}
+
 /// The `is_first_attempt` gate must not retroactively enforce the W0 U2
 /// pre-flight on a genuine resume. Mirrors
 /// `resume_execution_rejects_undeclared_port_on_genuine_first_attempt`'s

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -43,15 +43,18 @@ use nebula_engine::{
 };
 use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_metrics::MetricsRegistry;
-use nebula_orchestrator::{ExecutionSink, Orchestrator};
+use nebula_orchestrator::{DispatchedTurn, ExecutionSink, Orchestrator};
 use nebula_storage::{
     InMemoryExecutionStore, InMemoryWorkflowVersionStore,
-    inmem::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox},
+    inmem::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox, InMemoryTurnHandoff},
 };
 use nebula_storage_port::{
     Scope,
     dto::{ControlCommand, JobDispatchMsg, WorkflowVersionRecord},
-    store::{ExecutionStore, JobDispatchQueue, TriggerDedupInbox, WorkflowVersionStore},
+    store::{
+        ExecutionStore, ExecutionTurnHandoff, JobDispatchQueue, TriggerDedupInbox,
+        WorkflowVersionStore,
+    },
 };
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, TriggerBinding, ValidatedWorkflow, Version,
@@ -112,6 +115,13 @@ impl TestStores {
         engine
             .with_execution_stores(self.execution_stores())
             .with_workflow_stores(self.workflow_stores())
+    }
+
+    /// Handoff over the SAME shared core the queue and execution store use —
+    /// the lease write and the queue acknowledgement must land under one
+    /// boundary (#976).
+    fn turn_handoff(&self) -> Arc<InMemoryTurnHandoff> {
+        Arc::new(InMemoryTurnHandoff::new(&self.execution))
     }
 }
 
@@ -286,8 +296,29 @@ fn proc16(b: u8) -> [u8; 16] {
 
 // ── B-series: EngineExecutionSink unit tests ─────────────────────────────────
 
-/// `EngineExecutionSink::dispatch` on a `Created` row drives `resume_execution`
-/// and the execution reaches `Completed`.
+/// Mint a turn fence the way the durable handoff does (#976): acquire the
+/// execution lease and hand the fence to the sink, which adopts it instead of
+/// acquiring a second lease.
+async fn mint_turn_fence(
+    stores: &TestStores,
+    execution_id: ExecutionId,
+) -> nebula_storage_port::FencingToken {
+    stores
+        .execution
+        .acquire_lease(
+            &scope(),
+            &execution_id.to_string(),
+            "test-driver",
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("acquire lease for the test turn")
+        .expect("no live lease yet")
+}
+
+/// `EngineExecutionSink::dispatch` on a `Created` row drives
+/// `resume_execution_leased` under the handoff fence and the execution
+/// reaches `Completed`.
 #[tokio::test(start_paused = true)]
 async fn sink_dispatch_drives_resume_execution() {
     let stores = TestStores::new();
@@ -322,7 +353,9 @@ async fn sink_dispatch_drives_resume_execution() {
         0,
     );
 
-    let result = sink.dispatch(&msg).await;
+    let fence = mint_turn_fence(&stores, execution_id).await;
+    let turn = DispatchedTurn { msg: &msg, fence };
+    let result = sink.dispatch(&turn).await;
     assert!(
         result.is_ok(),
         "EngineExecutionSink::dispatch must succeed on a Created row: {result:?}"
@@ -373,13 +406,18 @@ async fn sink_dispatch_redelivery_is_idempotent() {
         0,
     );
 
-    // First dispatch — drives execution to Completed.
-    sink.dispatch(&msg)
+    // First dispatch — drives execution to Completed under the handoff fence.
+    let fence = mint_turn_fence(&stores, execution_id).await;
+    let turn = DispatchedTurn { msg: &msg, fence };
+    sink.dispatch(&turn)
         .await
         .expect("first dispatch must succeed");
 
-    // Second dispatch (redelivery) — must be Ok without re-running the handler.
-    let second = sink.dispatch(&msg).await;
+    // Second dispatch (redelivery) — must be Ok without re-running the
+    // handler. The idempotency guard short-circuits before the fence is
+    // adopted, so the same (now released) fence value is fine.
+    let redelivery = DispatchedTurn { msg: &msg, fence };
+    let second = sink.dispatch(&redelivery).await;
     assert!(
         second.is_ok(),
         "redelivery must return Ok (idempotency contract): {second:?}"
@@ -592,7 +630,8 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
         "row must be Created before orchestrator claims it; got {status_before:?}"
     );
 
-    // 2. Orchestrator: wire sink, start pull loop, let it claim + dispatch.
+    // 2. Orchestrator: wire sink + handoff, start pull loop, let it claim,
+    //    hand off, and dispatch.
     let sink = Arc::new(EngineExecutionSink::new(
         Arc::clone(&engine),
         stores.execution.clone() as Arc<dyn ExecutionStore>,
@@ -602,6 +641,7 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
     let orch = Orchestrator::new(
         Arc::clone(&queue) as Arc<dyn JobDispatchQueue>,
         sink as Arc<dyn ExecutionSink>,
+        stores.turn_handoff() as Arc<dyn ExecutionTurnHandoff>,
         proc16(0xAA),
         vec![orch_plugin_key],
     );

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -859,8 +859,12 @@ pub const NEBULA_CREDENTIAL_RESOLVER_REAUTH_PERSIST_CAS_EXHAUSTED_TOTAL: &str =
 ///
 /// Labeled by `outcome` (see [`orchestrator_dispatch_outcome`]). Incremented
 /// once per row in `handle_entry`: `dispatched` when the sink returned `Ok`
-/// and `mark_dispatched` was called; `failed` when the sink returned `Err`
-/// and `mark_failed` was called. Cardinality: 2 closed label values.
+/// after the durable handoff accepted the turn; `failed` when the row was
+/// terminalised before or instead of execution — an invalid execution id, an
+/// orphaned execution (handoff `NotFound`), or a sink that returned `Err`
+/// after the handoff. A post-handoff `failed` never touches the queue row
+/// (it is already acknowledged); recovery drives from the execution lease.
+/// Cardinality: 2 closed label values.
 pub const NEBULA_ORCHESTRATOR_DISPATCH_TOTAL: &str = "nebula_orchestrator_dispatch_total";
 
 /// Outcome labels for [`NEBULA_ORCHESTRATOR_DISPATCH_TOTAL`].
@@ -869,10 +873,33 @@ pub const NEBULA_ORCHESTRATOR_DISPATCH_TOTAL: &str = "nebula_orchestrator_dispat
 /// floor. The CI gate test in `crates/metrics/src/naming.rs` fails on silent
 /// expansion.
 pub mod orchestrator_dispatch_outcome {
-    /// Sink returned `Ok`; row marked dispatched.
+    /// Sink returned `Ok` after the handoff accepted the turn.
     pub const DISPATCHED: &str = "dispatched";
-    /// Sink returned `Err`; row marked failed.
+    /// The row failed before or instead of execution; see the counter docs.
     pub const FAILED: &str = "failed";
+}
+
+/// Counter: durable dispatch-claim → execution-turn handoff outcomes (#976).
+///
+/// Labeled by `outcome` (see [`orchestrator_handoff_outcome`]). Incremented
+/// once per `accept_turn` result in `handle_entry`. The label vocabulary
+/// mirrors the storage crate's `acceptance_label` so a dashboard and the
+/// backend spans agree on what happened. Cardinality: 4 closed label values.
+pub const NEBULA_ORCHESTRATOR_HANDOFF_TOTAL: &str = "nebula_orchestrator_handoff_total";
+
+/// Outcome labels for [`NEBULA_ORCHESTRATOR_HANDOFF_TOTAL`].
+///
+/// Closed label set — same cardinality hygiene rationale as
+/// [`orchestrator_dispatch_outcome`].
+pub mod orchestrator_handoff_outcome {
+    /// The turn was durably accepted and the queue row acknowledged.
+    pub const ACCEPTED: &str = "accepted";
+    /// The claim was superseded before the handoff committed; nothing written.
+    pub const CLAIM_SUPERSEDED: &str = "claim_superseded";
+    /// Another holder owns a live lease; the row stays claimable for redelivery.
+    pub const TURN_HELD: &str = "turn_held";
+    /// The backend errored; the row stays `Processing` for reclaim.
+    pub const ERROR: &str = "error";
 }
 
 /// Counter: job-dispatch reclaim sweep outcomes from the orchestrator.
@@ -968,11 +995,11 @@ mod tests {
         NEBULA_CREDENTIAL_RESOLVER_REAUTH_PERSIST_CAS_EXHAUSTED_TOTAL,
         NEBULA_CREDENTIAL_ROTATION_DURATION_SECONDS, NEBULA_CREDENTIAL_ROTATION_FAILURES_TOTAL,
         NEBULA_CREDENTIAL_ROTATIONS_TOTAL, NEBULA_ORCHESTRATOR_DISPATCH_TOTAL,
-        NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL,
-        NEBULA_RESOURCE_ACQUIRE_TOTAL, NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS,
-        NEBULA_RESOURCE_CLEANUP_TOTAL, NEBULA_RESOURCE_CONFIG_RELOADED_TOTAL,
-        NEBULA_RESOURCE_CREATE_TOTAL, NEBULA_RESOURCE_CREDENTIAL_REVOKE_ATTEMPTS_TOTAL,
-        NEBULA_RESOURCE_CREDENTIAL_ROTATED_TOTAL,
+        NEBULA_ORCHESTRATOR_HANDOFF_TOTAL, NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
+        NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL, NEBULA_RESOURCE_ACQUIRE_TOTAL,
+        NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS, NEBULA_RESOURCE_CLEANUP_TOTAL,
+        NEBULA_RESOURCE_CONFIG_RELOADED_TOTAL, NEBULA_RESOURCE_CREATE_TOTAL,
+        NEBULA_RESOURCE_CREDENTIAL_REVOKE_ATTEMPTS_TOTAL, NEBULA_RESOURCE_CREDENTIAL_ROTATED_TOTAL,
         NEBULA_RESOURCE_CREDENTIAL_ROTATION_ATTEMPTS_TOTAL,
         NEBULA_RESOURCE_CREDENTIAL_ROTATION_DISPATCH_LATENCY_SECONDS,
         NEBULA_RESOURCE_CREDENTIAL_ROTATION_SKIPPED_TOTAL, NEBULA_RESOURCE_DESTROY_TOTAL,
@@ -982,10 +1009,11 @@ mod tests {
         NEBULA_RESOURCE_RECYCLE_OUTCOME_TOTAL, NEBULA_RESOURCE_RELEASE_ERROR_TOTAL,
         NEBULA_RESOURCE_RELEASE_TOTAL, NEBULA_RESOURCE_USAGE_DURATION_SECONDS,
         NEBULA_STORAGE_REVISION_CATALOG_OPERATIONS_TOTAL, auth_oauth_provider, auth_outcome,
-        idempotency_reject_reason, orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
-        recycle_outcome, refresh_coord_claim_outcome, refresh_coord_coalesced_tier,
-        refresh_coord_reclaim_outcome, refresh_coord_sentinel_action, revision_catalog_operation,
-        rotation_outcome, webhook_rate_limit_tier, webhook_signature_failure_reason,
+        idempotency_reject_reason, orchestrator_dispatch_outcome, orchestrator_handoff_outcome,
+        orchestrator_reclaim_outcome, recycle_outcome, refresh_coord_claim_outcome,
+        refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome, refresh_coord_sentinel_action,
+        revision_catalog_operation, rotation_outcome, webhook_rate_limit_tier,
+        webhook_signature_failure_reason,
     };
 
     const RESOURCE_METRIC_NAMES: [&str; 22] = [
@@ -1468,9 +1496,10 @@ mod tests {
 
     /// Orchestrator metrics (ADR-0095 pull loop).
     ///
-    /// 2 counters — both labeled by `outcome` with a 2-value closed set.
-    const ORCHESTRATOR_METRIC_NAMES: [&str; 2] = [
+    /// 3 counters — all labeled by `outcome` with a closed label set.
+    const ORCHESTRATOR_METRIC_NAMES: [&str; 3] = [
         NEBULA_ORCHESTRATOR_DISPATCH_TOTAL,
+        NEBULA_ORCHESTRATOR_HANDOFF_TOTAL,
         NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
     ];
 
@@ -1489,14 +1518,14 @@ mod tests {
             );
             assert!(unique.insert(metric_name));
 
-            // Both orchestrator metrics are labeled counters.
+            // All orchestrator metrics are labeled counters.
             let labels = registry.interner().single("outcome", "dispatched");
             let counter = registry.counter_labeled(metric_name, &labels).unwrap();
             counter.inc();
             assert_eq!(counter.get(), 1);
         }
 
-        assert_eq!(unique.len(), 2);
+        assert_eq!(unique.len(), 3);
     }
 
     #[test]
@@ -1525,6 +1554,25 @@ mod tests {
         ];
         let unique: HashSet<&str> = labels.iter().copied().collect();
         assert_eq!(unique.len(), 2, "reclaim outcome labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
+    }
+
+    #[test]
+    fn orchestrator_handoff_outcome_labels_are_closed_set() {
+        // Closed label set — same CI gate as the other orchestrator counters.
+        // The vocabulary mirrors the storage crate's `acceptance_label` so a
+        // dashboard and the backend spans agree on what happened.
+        let labels = [
+            orchestrator_handoff_outcome::ACCEPTED,
+            orchestrator_handoff_outcome::CLAIM_SUPERSEDED,
+            orchestrator_handoff_outcome::TURN_HELD,
+            orchestrator_handoff_outcome::ERROR,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 4, "handoff outcome labels must be unique");
         for label in labels {
             assert!(!label.is_empty());
             assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,9 +1,13 @@
 //! Capability-routed job-dispatch pull loop for the Nebula orchestration layer.
 //!
 //! `nebula-orchestrator` owns exactly one thing: the **leaderless routing pull-loop** —
-//! claim [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`, hand each
-//! [`JobDispatchMsg`] to an [`ExecutionSink`], fence-mark the row dispatched/failed, plus a
-//! periodic [`JobDispatchQueue::reclaim_stuck`] sweep.
+//! claim [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`, end each
+//! claim at the durable handoff ([`ExecutionTurnHandoff`]: lease acquired and row
+//! acknowledged in one transaction), hand the accepted turn to an [`ExecutionSink`], plus a
+//! periodic [`JobDispatchQueue::reclaim_stuck`] sweep for rows whose runner crashed before
+//! its handoff committed.
+//!
+//! [`ExecutionTurnHandoff`]: nebula_storage_port::store::ExecutionTurnHandoff
 //!
 //! ## What this crate defers
 //!
@@ -29,4 +33,4 @@ pub mod orchestrator;
 pub mod sink;
 
 pub use orchestrator::Orchestrator;
-pub use sink::{ExecutionSink, ExecutionSinkError};
+pub use sink::{DispatchedTurn, ExecutionSink, ExecutionSinkError};

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -6,13 +6,35 @@
 //! per-row failure isolation, and optional [`MetricsRegistry`] injection via
 //! the builder.
 //!
+//! ## Claim lifecycle — the handoff (#976)
+//!
+//! A dispatch claim protects **delivery only**, never work. Each claimed row
+//! is processed as `validate → handoff → dispatch`:
+//!
+//! 1. **Validate** the claim locally (the execution id parses). A row that
+//!    can never be dispatched is terminalised with `mark_failed` instead of
+//!    being redelivered forever.
+//! 2. **Hand off** durably via [`ExecutionTurnHandoff::accept_turn`]: the
+//!    execution lease is acquired and the queue row acknowledged in one
+//!    transaction. The claim ends at this point — how long the action
+//!    subsequently runs cannot extend it.
+//! 3. **Dispatch** the accepted turn to the [`ExecutionSink`], which drives
+//!    the execution under the handoff's fence. Post-handoff failures never
+//!    touch queue state: recovery proceeds from the execution lease and
+//!    persisted aggregate truth.
+//!
+//! A crash before the handoff commits leaves the row `Processing` for the
+//! reclaim sweep; a crash after leaves a terminal row and a leased execution
+//! that recovery drives. There is no state in between.
+//!
 //! ## Shutdown contract
 //!
 //! When [`CancellationToken`] is cancelled the orchestrator flushes the
 //! in-flight batch already being processed, then returns. It does **not** begin
 //! a fresh [`JobDispatchQueue::claim_pending`] once shutdown is requested.
-//! Rows claimed but not yet marked remain in `Processing` and are recovered
-//! by the next runner's reclaim sweep.
+//! Rows claimed but not yet handed off remain in `Processing` and are
+//! recovered by the next runner's reclaim sweep; rows already handed off are
+//! governed by their execution lease.
 //!
 //! Worst-case shutdown observability latency is bounded by
 //! `max(one reclaim_stuck() sweep, batch_size × one sink.dispatch() latency)`,
@@ -22,23 +44,30 @@
 //! [`CancellationToken`]: tokio_util::sync::CancellationToken
 //! [`MetricsRegistry`]: nebula_metrics::MetricsRegistry
 //! [`JobDispatchQueue::claim_pending`]: nebula_storage_port::store::JobDispatchQueue::claim_pending
+//! [`ExecutionTurnHandoff::accept_turn`]: nebula_storage_port::store::ExecutionTurnHandoff::accept_turn
 
 use std::{sync::Arc, time::Duration};
 
 use nebula_core::PluginKey;
+use nebula_core::id::ExecutionId;
 use nebula_metrics::{
     MetricsRegistry,
     naming::{
-        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
-        orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
+        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_HANDOFF_TOTAL,
+        NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, orchestrator_dispatch_outcome,
+        orchestrator_handoff_outcome, orchestrator_reclaim_outcome,
     },
 };
-use nebula_storage_port::store::{JobClaim, JobClaimToken, JobDispatchQueue, ReclaimOutcome};
+use nebula_storage_port::StorageError;
+use nebula_storage_port::store::{
+    ExecutionTurnHandoff, JobClaim, JobClaimToken, JobDispatchQueue, ReclaimOutcome,
+    TurnAcceptance, TurnHandoff,
+};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
-use crate::sink::ExecutionSink;
+use crate::sink::{DispatchedTurn, ExecutionSink};
 
 /// Default claim batch size.
 ///
@@ -73,37 +102,35 @@ pub const MAX_CLAIM_ERROR_BACKOFF: Duration = Duration::from_secs(30);
 ///
 /// ## Relationship between the job-dispatch claim and execution liveness
 ///
-/// The job-dispatch claim is held for the **entire synchronous drive** of a
-/// workflow: the orchestrator claims the row, hands it to the sink, and only
-/// marks it `Dispatched` or `Failed` after `ExecutionSink::dispatch` returns.
-/// There is no heartbeat on the claim while the sink is running.
+/// The job-dispatch claim protects **delivery only** (#976): the orchestrator
+/// claims the row, ends the claim at the durable handoff
+/// ([`ExecutionTurnHandoff::accept_turn`]), and only then dispatches the
+/// accepted turn. The row is terminal before the action runs, so how long the
+/// action takes can neither extend the claim nor trip this window — a
+/// deliberately slow action and a crashed runner are no longer the same
+/// signal.
 ///
-/// Execution liveness is tracked separately: the engine issues a per-execution
-/// lease (renewed by `nebula-engine`'s `acquire_and_heartbeat_lease` loop) whose
-/// TTL is the authoritative signal that a runner has crashed.  The
+/// Execution liveness is tracked separately: the handoff acquires the
+/// per-execution lease, and the engine renews it on a heartbeat loop whose
+/// TTL is the authoritative signal that a runner has crashed. The
 /// job-dispatch `reclaim_stuck` sweep is a **routing-layer** recovery
-/// mechanism, not an execution-failure detector.
-///
-/// **Implication for long-running, non-parking workflows:** if a workflow
-/// drives synchronously from `Created` to `Completed` in a single
-/// `resume_execution` call and that drive takes longer than
-/// `reclaim_after × max_reclaim_count`, the orchestrator's reclaim sweep
-/// will eventually mark the dispatch row `Failed` — even though the execution
-/// itself completed correctly.  This is a routing-row observability artifact,
-/// not an execution failure; the execution status in the execution store is
-/// unaffected.
-///
-/// Operators expecting workflows whose single synchronous drive exceeds
-/// `reclaim_after × max_reclaim_count` should increase `max_reclaim_count`
-/// via [`Orchestrator::with_max_reclaim_count`] (or the corresponding builder
-/// method on `WorkerRuntimeBuilder` in `nebula-worker`).
-/// Long workflows that park at a checkpoint do not trigger this: parking
-/// returns control to the engine, the sink returns `Ok(())`, and the dispatch
-/// row is marked `Dispatched` promptly.
+/// mechanism for rows whose runner crashed before the handoff committed —
+/// not an execution-failure detector.
 ///
 /// See ADR-0017 (execution lease contract) and ADR-0095 (job-dispatch
 /// routing) for the full context.
+///
+/// [`ExecutionTurnHandoff::accept_turn`]: nebula_storage_port::store::ExecutionTurnHandoff::accept_turn
 pub const DEFAULT_RECLAIM_AFTER: Duration = Duration::from_secs(150);
+
+/// Default lease TTL the durable handoff mints for the accepted turn.
+///
+/// Matches the engine's `DEFAULT_EXECUTION_LEASE_TTL`: long enough that the
+/// engine's heartbeat loop takes over renewal with margin, short enough to
+/// bound recovery latency when the accepting runner crashes right after the
+/// commit. Every backend clamps it to `[1s, 24h]`, the same window
+/// `ExecutionStore::acquire_lease` enforces.
+pub const DEFAULT_HANDOFF_LEASE_TTL: Duration = Duration::from_secs(30);
 
 /// Default cadence of the reclaim sweep.
 pub const DEFAULT_RECLAIM_INTERVAL: Duration = Duration::from_secs(30);
@@ -112,17 +139,17 @@ pub const DEFAULT_RECLAIM_INTERVAL: Duration = Duration::from_secs(30);
 ///
 /// A row that has been reclaimed this many times transitions to `Failed` on
 /// the next sweep, preventing unbounded redelivery of permanently stuck jobs.
-///
-/// As noted on [`DEFAULT_RECLAIM_AFTER`], operators running long synchronous
-/// workflows should raise this value; the dispatch `Failed` status is a
-/// routing artifact and does not indicate execution failure.
+/// Since the handoff (#976) ends the claim before the action runs, only rows
+/// whose runner repeatedly crashes **before** the handoff commits consume
+/// this budget.
 pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
 
 /// Capability-routed job-dispatch pull loop (ADR-0095).
 ///
 /// Claims [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`,
-/// hands each to an [`ExecutionSink`], and fences the row dispatched or failed.
-/// A periodic sweep reclaims rows stuck in `Processing` after a crashed runner.
+/// ends each claim at the durable handoff, and dispatches the accepted turn
+/// to an [`ExecutionSink`]. A periodic sweep reclaims rows stuck in
+/// `Processing` after a runner crashed before its handoff committed.
 ///
 /// Construct with [`Orchestrator::new`] and optional builder methods, then
 /// call [`Orchestrator::run`] (or [`Orchestrator::spawn`]).
@@ -132,17 +159,29 @@ pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
 pub struct Orchestrator {
     queue: Arc<dyn JobDispatchQueue>,
     sink: Arc<dyn ExecutionSink>,
+    /// Durable owner of the dispatch-claim → execution-turn handoff. MUST be
+    /// backed by the same store the queue and the engine's execution store
+    /// use: the handoff commits the lease write and the queue acknowledgement
+    /// in one transaction, and two backends would give them two boundaries.
+    handoff: Arc<dyn ExecutionTurnHandoff>,
     /// Fixed 16-byte fence token recorded in `processed_by` and matched on
-    /// `mark_dispatched` / `mark_failed`. Typed `[u8; 16]` end-to-end — no
-    /// truncate/pad of an arbitrary-length id, which would let two distinct
-    /// workers collapse to the same token and ack each other's rows.
+    /// `mark_failed`. Typed `[u8; 16]` end-to-end — no truncate/pad of an
+    /// arbitrary-length id, which would let two distinct workers collapse to
+    /// the same token and ack each other's rows.
     processor_id: [u8; 16],
+    /// Identity recorded as the accepted turn's lease holder. Derived from
+    /// `processor_id` so contention diagnostics name the processor, but the
+    /// lease authority is the fence, not this string.
+    lease_holder: String,
     available_plugins: Vec<PluginKey>,
     batch_size: u32,
     poll_interval: Duration,
     reclaim_after: Duration,
     reclaim_interval: Duration,
     max_reclaim_count: u32,
+    /// Lease TTL the handoff mints for each accepted turn. The engine's
+    /// heartbeat loop takes over renewal once the turn is dispatched.
+    handoff_lease_ttl: Duration,
     /// Shared metrics registry. Defaults to a private fresh registry so the
     /// orchestrator is always emit-safe without injection; production
     /// composition roots inject the shared registry via [`with_metrics`] so
@@ -155,25 +194,36 @@ pub struct Orchestrator {
 impl Orchestrator {
     /// Construct an orchestrator.
     ///
+    /// `handoff` is the durable owner of the dispatch-claim → execution-turn
+    /// handoff and MUST share the backend the queue and the engine's
+    /// execution store use — see the field docs. An orchestrator without a
+    /// handoff would hold claims for whole action durations (NS05), so none
+    /// can be constructed.
+    ///
     /// `processor_id` is the fixed 16-byte fence token recorded in the row's
     /// `processed_by`. Supply the full id bytes — no truncation or padding is
     /// done, which would let two distinct workers collapse to the same token.
     pub fn new(
         queue: Arc<dyn JobDispatchQueue>,
         sink: Arc<dyn ExecutionSink>,
+        handoff: Arc<dyn ExecutionTurnHandoff>,
         processor_id: [u8; 16],
         available_plugins: Vec<PluginKey>,
     ) -> Self {
+        let lease_holder = format!("orchestrator:{}", hex_display(&processor_id));
         Self {
             queue,
             sink,
+            handoff,
             processor_id,
+            lease_holder,
             available_plugins,
             batch_size: DEFAULT_BATCH_SIZE,
             poll_interval: DEFAULT_POLL_INTERVAL,
             reclaim_after: DEFAULT_RECLAIM_AFTER,
             reclaim_interval: DEFAULT_RECLAIM_INTERVAL,
             max_reclaim_count: DEFAULT_MAX_RECLAIM_COUNT,
+            handoff_lease_ttl: DEFAULT_HANDOFF_LEASE_TTL,
             metrics: MetricsRegistry::new(),
         }
     }
@@ -208,6 +258,17 @@ impl Orchestrator {
     /// `Failed`. Default: [`DEFAULT_MAX_RECLAIM_COUNT`].
     pub fn with_max_reclaim_count(mut self, n: u32) -> Self {
         self.max_reclaim_count = n;
+        self
+    }
+
+    /// Override the lease TTL the handoff mints for each accepted turn.
+    /// Default: [`DEFAULT_HANDOFF_LEASE_TTL`].
+    ///
+    /// Backends clamp it to `[1s, 24h]`. Shorter values bound recovery
+    /// latency after a post-handoff crash at the cost of less margin before
+    /// the engine's heartbeat loop takes over renewal.
+    pub fn with_handoff_lease_ttl(mut self, d: Duration) -> Self {
+        self.handoff_lease_ttl = d;
         self
     }
 
@@ -439,24 +500,121 @@ impl Orchestrator {
             }
         }
 
-        let sink = Arc::clone(&self.sink);
+        // ── 1. validate ─────────────────────────────────────────────────────
+        //
+        // Check everything decidable from the claim alone before the handoff
+        // writes anything. A row that fails here can never be dispatched, so
+        // it is terminalised instead of being redelivered until the reclaim
+        // budget exhausts. The claim is still ours at this point — the
+        // handoff has not run — so `mark_failed` is the honest write.
+        if msg.execution_id.parse::<ExecutionId>().is_err() {
+            let reason = format!("invalid execution_id `{}`", msg.execution_id);
+            tracing::error!(
+                row_id = %hex_display(&row_id),
+                execution_id = %msg.execution_id,
+                "orchestrator claim failed validation; marking row failed (#976)"
+            );
+            self.mark_failed(&token, &reason).await;
+            self.inc_dispatch(orchestrator_dispatch_outcome::FAILED);
+            return;
+        }
+
+        // ── 2. handoff ──────────────────────────────────────────────────────
+        //
+        // End the claim at a definite point: `accept_turn` acquires the
+        // execution lease and acknowledges the queue row in one transaction.
+        // Past this commit the action's duration is governed by the lease,
+        // and the queue can never redeliver this row.
+        let turn_handoff = TurnHandoff {
+            scope: &msg.scope,
+            execution_id: &msg.execution_id,
+            claim: token,
+            holder: &self.lease_holder,
+            lease_ttl: self.handoff_lease_ttl,
+        };
+        let acceptance = self.handoff.accept_turn(&turn_handoff).await;
+        let fence = match acceptance {
+            Ok(TurnAcceptance::Accepted { fence }) => {
+                self.inc_handoff(orchestrator_handoff_outcome::ACCEPTED);
+                fence
+            },
+            // Another attempt now owns the row — nothing was written, and the
+            // current owner drives the turn. There is nothing to do.
+            Ok(TurnAcceptance::ClaimSuperseded) => {
+                self.inc_handoff(orchestrator_handoff_outcome::CLAIM_SUPERSEDED);
+                tracing::debug!(
+                    row_id = %hex_display(&row_id),
+                    execution_id = %msg.execution_id,
+                    claim_generation = %token.generation(),
+                    "handoff found the claim superseded; the current owner drives the turn (#976)"
+                );
+                return;
+            },
+            // A live lease owned by someone else: the row is deliberately left
+            // claimed so the sweep redelivers it once that lease expires.
+            // Acknowledging here would drop the turn on the floor.
+            Ok(TurnAcceptance::TurnHeldByAnotherOwner) => {
+                self.inc_handoff(orchestrator_handoff_outcome::TURN_HELD);
+                tracing::debug!(
+                    row_id = %hex_display(&row_id),
+                    execution_id = %msg.execution_id,
+                    "turn already owned by another holder; leaving the row claimable for redelivery (#976)"
+                );
+                return;
+            },
+            // The execution (or the row itself) is gone: an orphaned dispatch.
+            // The emitter materialises the execution row and the queue row in
+            // one atomic write, so an execution missing here will not appear
+            // later — terminalise rather than redeliver forever.
+            Err(StorageError::NotFound { .. }) => {
+                self.inc_handoff(orchestrator_handoff_outcome::ERROR);
+                let reason = format!("execution {} not found at handoff", msg.execution_id);
+                tracing::error!(
+                    row_id = %hex_display(&row_id),
+                    execution_id = %msg.execution_id,
+                    "handoff found no execution; marking row failed (#976)"
+                );
+                self.mark_failed(&token, &reason).await;
+                self.inc_dispatch(orchestrator_dispatch_outcome::FAILED);
+                return;
+            },
+            // Backend error: nothing was written, the row stays `Processing`,
+            // and the reclaim sweep redelivers it. No terminal write — the
+            // failure may be transient.
+            Err(ref e) => {
+                self.inc_handoff(orchestrator_handoff_outcome::ERROR);
+                tracing::error!(
+                    row_id = %hex_display(&row_id),
+                    execution_id = %msg.execution_id,
+                    claim_generation = %token.generation(),
+                    error = %e,
+                    "handoff failed; row left in Processing for reclaim (#976)"
+                );
+                return;
+            },
+        };
+
+        // ── 3. dispatch the accepted turn ───────────────────────────────────
+        //
         // Bounded drain on shutdown.
         //
         // Graceful shutdown flushes the in-flight batch — a dispatch that is
-        // nearly done should finish rather than be redelivered. But `dispatch`
+        // nearly done should finish rather than be abandoned. But `dispatch`
         // drives a whole execution step, which can park on a durable timer or
         // an external wait, so awaiting it unconditionally means the loop never
         // returns to its `select!` and a process asked to stop hangs for as
         // long as the workflow does.
         //
         // So: keep flushing after cancellation, but only within
-        // [`SHUTDOWN_DISPATCH_GRACE`]. Past that the row is abandoned to the
-        // documented recovery path — it stays `Processing` and the next
-        // runner's reclaim sweep redelivers it. Acknowledging it either way
-        // would be the unsafe choice: `mark_dispatched` would claim work that
-        // did not finish, and `mark_failed` would terminalise a row that was
-        // merely interrupted.
-        let dispatch = sink.dispatch(&msg).instrument(span);
+        // [`SHUTDOWN_DISPATCH_GRACE`]. Past that the turn is abandoned to the
+        // documented recovery path — the queue row is already acknowledged by
+        // the handoff, and the execution lease this handoff minted expires so
+        // recovery drives from persisted aggregate truth. Nothing here can
+        // lose the turn: a crash at any point past the handoff commit is the
+        // same case.
+        let sink = Arc::clone(&self.sink);
+        let turn = DispatchedTurn { msg: &msg, fence };
+        let dispatch = sink.dispatch(&turn).instrument(span);
         tokio::pin!(dispatch);
         let dispatch_result = tokio::select! {
             biased;
@@ -471,7 +629,7 @@ impl Orchestrator {
                         claim_generation = %token.generation(),
                         grace_ms = SHUTDOWN_DISPATCH_GRACE.as_millis() as u64,
                         "orchestrator dispatch did not drain within the shutdown grace; \
-                         leaving the row Processing for reclaim"
+                         the acknowledged row's execution lease governs recovery (#976)"
                     );
                     return;
                 };
@@ -481,61 +639,50 @@ impl Orchestrator {
 
         match dispatch_result {
             Ok(()) => {
-                self.mark_dispatched(&token).await;
-                let labels = self
-                    .metrics
-                    .interner()
-                    .single("outcome", orchestrator_dispatch_outcome::DISPATCHED);
-                if let Ok(c) = self
-                    .metrics
-                    .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &labels)
-                {
-                    c.inc();
-                }
+                self.inc_dispatch(orchestrator_dispatch_outcome::DISPATCHED);
             },
             Err(ref e) => {
+                // The queue row was already acknowledged by the handoff, so
+                // there is no queue state to fix: the execution lease and
+                // persisted recovery state govern what happens next (lease
+                // expiry → recovery redrive). Record the failure for
+                // operators and move on.
                 tracing::error!(
                     row_id = %hex_display(&row_id),
                     execution_id = %msg.execution_id,
                     command = msg.command.as_str(),
+                    fence_generation = %fence.generation(),
                     error = %e,
-                    "orchestrator dispatch failed; marking row failed (ADR-0095)"
+                    "orchestrator dispatch failed after handoff; recovery drives from the execution lease (#976)"
                 );
-                self.mark_failed(&token, &e.to_string()).await;
-                let labels = self
-                    .metrics
-                    .interner()
-                    .single("outcome", orchestrator_dispatch_outcome::FAILED);
-                if let Ok(c) = self
-                    .metrics
-                    .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &labels)
-                {
-                    c.inc();
-                }
+                self.inc_dispatch(orchestrator_dispatch_outcome::FAILED);
             },
         }
     }
 
-    async fn mark_dispatched(&self, token: &JobClaimToken) {
-        // If `mark_dispatched` fails, the row stays in `Processing` and the
-        // reclaim sweep redelivers. Correctness under redelivery requires the
-        // `ExecutionSink` to be idempotent per `(execution_id, command)`.
-        //
-        // `FencedOut` is the one failure that is not a lost write: this claim
-        // was reclaimed and another attempt now owns the row, so leaving it
-        // alone is exactly right and the current owner will acknowledge it.
-        if let Err(e) = self
-            .queue
-            .mark_dispatched(token)
-            .await
-            .map_err(|e| e.to_string())
+    /// Increment the handoff-outcome counter. Counter construction failure is
+    /// swallowed (same policy as the dispatch/reclaim counters): metrics must
+    /// never take down the pull loop.
+    fn inc_handoff(&self, outcome: &'static str) {
+        let labels = self.metrics.interner().single("outcome", outcome);
+        if let Ok(c) = self
+            .metrics
+            .counter_labeled(NEBULA_ORCHESTRATOR_HANDOFF_TOTAL, &labels)
         {
-            tracing::error!(
-                row_id = %hex_display(token.row_id()),
-                claim_generation = %token.generation(),
-                error = %e,
-                "orchestrator mark_dispatched failed; row left in Processing for reclaim"
-            );
+            c.inc();
+        }
+    }
+
+    /// Increment the dispatch-outcome counter. Counter construction failure is
+    /// swallowed (same policy as the reclaim counter): metrics must never take
+    /// down the pull loop.
+    fn inc_dispatch(&self, outcome: &'static str) {
+        let labels = self.metrics.interner().single("outcome", outcome);
+        if let Ok(c) = self
+            .metrics
+            .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &labels)
+        {
+            c.inc();
         }
     }
 

--- a/crates/orchestrator/src/sink.rs
+++ b/crates/orchestrator/src/sink.rs
@@ -1,31 +1,57 @@
 //! [`ExecutionSink`] — the orchestrator's DIP seam for execution hand-off.
 //!
-//! The orchestrator calls [`ExecutionSink::dispatch`] for each claimed
-//! [`JobDispatchMsg`]. On `Ok` it marks the row dispatched; on `Err` it marks it
-//! failed.  The distinction between [`ExecutionSinkError::Rejected`] and
-//! [`ExecutionSinkError::Internal`] is for operator dashboards, not retry policy:
-//! both outcomes mark the row failed at this layer.
+//! The orchestrator ends each dispatch claim with a durable handoff
+//! ([`ExecutionTurnHandoff::accept_turn`]): the queue row is acknowledged and
+//! the execution lease is acquired in one transaction. Only an accepted turn
+//! reaches the sink. On `Ok` the orchestrator records `dispatched`; on `Err`
+//! it records `failed` — but touches no queue state, because the handoff
+//! already terminalised the row. What happens to the execution next is
+//! governed by the execution lease and persisted recovery state, not by the
+//! dispatch queue. The distinction between [`ExecutionSinkError::Rejected`]
+//! and [`ExecutionSinkError::Internal`] is for operator dashboards, not retry
+//! policy.
 //!
 //! Mirror of `ControlDispatchError {Rejected, Internal}` in `nebula-engine`'s
 //! `control_consumer.rs`.
 //!
-//! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
+//! [`ExecutionTurnHandoff::accept_turn`]: nebula_storage_port::store::ExecutionTurnHandoff::accept_turn
 
+use nebula_storage_port::FencingToken;
 use nebula_storage_port::dto::JobDispatchMsg;
+
+/// One accepted execution turn handed to the sink.
+///
+/// Bundles the claimed [`JobDispatchMsg`] with the [`FencingToken`] the
+/// durable handoff returned. By the time a sink sees a turn, the queue row is
+/// already acknowledged and the execution lease is held under this fence —
+/// the sink drives the turn **under** it rather than acquiring a lease of its
+/// own. A second acquire would be rejected outright: a live lease blocks
+/// acquisition even for the same holder, so the handoff's fence is the only
+/// authority this turn runs under.
+#[derive(Debug, Clone, Copy)]
+pub struct DispatchedTurn<'a> {
+    /// The claimed job-dispatch message.
+    pub msg: &'a JobDispatchMsg,
+    /// Fence proving ownership of the accepted turn. Every write the
+    /// execution makes must be gated by it; once a reclaim supersedes it the
+    /// turn's writes are rejected.
+    pub fence: FencingToken,
+}
 
 /// Hand-off seam between the orchestrator pull-loop and execution.
 ///
 /// The future `nebula-worker` crate provides the real implementation, which
-/// drives the engine Start path. Tests use a spy (`RecordingSink` in
-/// `crates/orchestrator/tests/`).
+/// drives the engine resume path under the turn's fence. Tests use a spy
+/// (`RecordingSink` in `crates/orchestrator/tests/`).
 ///
 /// ## Idempotency contract
 ///
-/// Implementations MUST be idempotent per `(execution_id, command)`: the
-/// reclaim sweep can redeliver a job whose `dispatch` succeeded but whose
-/// `mark_dispatched` failed (the row stays `Processing` until reclaimed).
-/// Re-delivering to a sink that has already processed that pair must return
-/// `Ok(())`, not an error.
+/// After the handoff the queue row is terminal, so the job queue itself never
+/// redelivers a dispatched turn. Implementations MUST still be idempotent per
+/// `(execution_id, command)`: a second queue row for the same execution (e.g.
+/// a restart fan-out) and the control-queue consumer both reach the same
+/// engine state, and driving an execution that is already running or terminal
+/// must return `Ok(())`, not an error.
 ///
 /// ## Dyn-dispatch
 ///
@@ -36,29 +62,27 @@ use nebula_storage_port::dto::JobDispatchMsg;
 /// `ControlDispatch`.
 #[async_trait::async_trait]
 pub trait ExecutionSink: Send + Sync + std::fmt::Debug {
-    /// Hand off a routed, claimed job to the execution layer.
+    /// Hand off an accepted turn to the execution layer.
     ///
-    /// The orchestrator marks the row `Dispatched` on `Ok` and calls
-    /// [`JobDispatchQueue::mark_failed`] on `Err`. Both error variants
-    /// produce a `mark_failed` — the variant is for operator dashboards.
+    /// The queue row was already acknowledged by the handoff before this call;
+    /// neither outcome touches queue state. `Ok` records `dispatched`; `Err`
+    /// records `failed` and leaves the execution to lease-governed recovery.
     ///
     /// # Errors
     ///
     /// Returns [`ExecutionSinkError::Rejected`] when the execution layer
     /// performs a domain-level rejection (e.g. the execution is already
     /// terminal). Returns [`ExecutionSinkError::Internal`] on a transport or
-    /// engine-internal failure. Both produce `mark_failed` at the orchestrator
+    /// engine-internal failure. Both record `failed` at the orchestrator
     /// layer.
-    ///
-    /// [`JobDispatchQueue::mark_failed`]: nebula_storage_port::store::JobDispatchQueue::mark_failed
-    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError>;
+    async fn dispatch(&self, turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError>;
 }
 
 /// Errors returned from [`ExecutionSink::dispatch`].
 ///
 /// Mirrors `ControlDispatchError` in the engine's `control_consumer` module.
-/// Both variants result in `mark_failed` at the orchestrator layer; the split
-/// is for operator dashboards (domain reject vs engine/transport failure).
+/// Both variants record `failed` at the orchestrator layer; the split is for
+/// operator dashboards (domain reject vs engine/transport failure).
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ExecutionSinkError {

--- a/crates/orchestrator/tests/orchestrator_wiring.rs
+++ b/crates/orchestrator/tests/orchestrator_wiring.rs
@@ -1,23 +1,33 @@
-//! Integration tests for [`Orchestrator`] wiring against [`InMemoryJobDispatchQueue`]
-//! and a [`RecordingSink`] spy, using the paused tokio clock.
+//! Integration tests for [`Orchestrator`] wiring against [`InMemoryJobDispatchQueue`],
+//! [`InMemoryTurnHandoff`], and a [`RecordingSink`] spy, using the paused tokio clock.
+//!
+//! Every row a test enqueues gets a seeded execution row under the same
+//! in-memory core the queue and the handoff share: since the handoff (#976)
+//! ends each claim at `accept_turn`, a row without an execution is an orphan
+//! and is terminalised, not dispatched.
 //!
 //! Tests:
 //!
 //! 1. `routes_by_tag` — alpha + beta jobs, worker advertises [alpha]; spy sees only alpha.
 //! 2. `claim_route_sink_mark_dispatched` — sink Ok once; row terminal-dispatched; counter=1.
 //! 3. `dispatched_row_not_reclaimed` — terminal row is not re-served by a second claim.
-//! 4. `reclaim_during_slow_sink_is_at_least_once` — row claimed by A while B dispatches; A's
-//!    late mark_dispatched returns StorageError::NotFound (fenced — ownership predicate
-//!    satisfied 0 rows) and the error is swallowed; sink sees the row once (A's call only);
-//!    processor-B claims and acks via direct queue manipulation, proving at-least-once across
-//!    the full dispatch path without a second sink invocation.
-//! 5. `sink_failure_marks_failed` — sink Err(Rejected); not re-served; failed counter=1.
-//! 6. `reclaim_recovers_crashed` — claim then don't mark; live orchestrator reclaims to Pending;
-//!    a second live orchestrator drives exhausted row through EXHAUSTED counter.
-//! 7. `graceful_shutdown_flushes_in_flight_dispatch` — cancel while sink blocked mid-dispatch;
-//!    dispatch completes after release; row is marked Dispatched, not left Processing.
-//! 8. `graceful_shutdown_flushes_multi_row_batch` — batch_size≥2; cancel fires while first
-//!    dispatch is blocked (proven non-vacuous); all rows flushed; none left Pending/Processing.
+//! 4. `blocked_action_outlives_claim_without_renewal_or_duplicates` — the NS05
+//!    acceptance: a deliberately blocked action outlives the dispatch claim with
+//!    no claim renewal and no second live owner.
+//! 5. `invalid_execution_id_marks_failed` — validation terminalises rows that can
+//!    never be dispatched before the handoff writes anything.
+//! 6. `orphaned_execution_marks_failed` — a valid id with no execution row is an
+//!    orphaned dispatch and is terminalised at the handoff.
+//! 7. `post_handoff_sink_failure_keeps_row_terminal` — a sink error after the
+//!    handoff records `failed` without touching the acknowledged row; the lease
+//!    governs recovery.
+//! 8. `reclaim_recovers_crashed` — a claim abandoned before the handoff is
+//!    reclaimed to Pending; a second live orchestrator drives a row through the
+//!    EXHAUSTED counter.
+//! 9. `graceful_shutdown_flushes_in_flight_dispatch` — cancel while sink blocked
+//!    mid-dispatch; dispatch completes after release; the row stays terminal.
+//! 10. `graceful_shutdown_flushes_multi_row_batch` — batch_size≥2; cancel fires
+//!     while first dispatch is blocked (proven non-vacuous); all rows flushed.
 
 use std::{
     sync::{
@@ -28,20 +38,23 @@ use std::{
 };
 
 use async_trait::async_trait;
-use nebula_core::PluginKey;
+use nebula_core::{PluginKey, id::ExecutionId};
 use nebula_metrics::{
     MetricsRegistry,
     naming::{
-        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
-        orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
+        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_HANDOFF_TOTAL,
+        NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, orchestrator_dispatch_outcome,
+        orchestrator_handoff_outcome, orchestrator_reclaim_outcome,
     },
 };
-use nebula_orchestrator::{ExecutionSink, ExecutionSinkError, Orchestrator};
-use nebula_storage::inmem::{InMemoryExecutionStore, InMemoryJobDispatchQueue};
+use nebula_orchestrator::{DispatchedTurn, ExecutionSink, ExecutionSinkError, Orchestrator};
+use nebula_storage::inmem::{
+    InMemoryExecutionStore, InMemoryJobDispatchQueue, InMemoryTurnHandoff,
+};
 use nebula_storage_port::{
     Scope,
     dto::{ControlCommand, JobDispatchMsg},
-    store::JobDispatchQueue,
+    store::{ExecutionStore, ExecutionTurnHandoff, JobDispatchQueue},
 };
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
@@ -58,14 +71,48 @@ fn proc16(label: &[u8]) -> [u8; 16] {
     id
 }
 
-/// Build a fresh `InMemoryJobDispatchQueue` over its own execution store core.
-fn make_queue() -> Arc<InMemoryJobDispatchQueue> {
-    let store = InMemoryExecutionStore::new();
-    Arc::new(InMemoryJobDispatchQueue::new(&store))
-}
-
 fn scope() -> Scope {
     Scope::new("ws_test", "org_test")
+}
+
+/// One shared in-memory core: execution store, job-dispatch queue, and turn
+/// handoff over the SAME state. Sharing the core is the wiring invariant the
+/// production composition roots honour (#976): the handoff commits the lease
+/// write and the queue acknowledgement under one boundary.
+struct TestCore {
+    store: Arc<InMemoryExecutionStore>,
+    queue: Arc<InMemoryJobDispatchQueue>,
+    handoff: Arc<InMemoryTurnHandoff>,
+}
+
+impl TestCore {
+    fn new() -> Self {
+        let store = Arc::new(InMemoryExecutionStore::new());
+        let queue = Arc::new(InMemoryJobDispatchQueue::new(&store));
+        let handoff = Arc::new(InMemoryTurnHandoff::new(&store));
+        Self {
+            store,
+            queue,
+            handoff,
+        }
+    }
+
+    /// Seed a `Created` execution row and return the parseable execution id
+    /// string the queue row carries. A queue row without one is an orphan:
+    /// the handoff terminalises it instead of dispatching.
+    async fn seed_execution(&self) -> String {
+        let id = ExecutionId::new().to_string();
+        self.store
+            .create(
+                &scope(),
+                &id,
+                "wf_test",
+                serde_json::json!({"status": "Created"}),
+            )
+            .await
+            .expect("seed execution row");
+        id
+    }
 }
 
 /// Build a minimal [`JobDispatchMsg`] stamped with `row_id`.
@@ -93,7 +140,7 @@ fn make_msg(row_id: u8, required_plugin_key: &str, execution_id: &str) -> JobDis
 
 // ── RecordingSink ─────────────────────────────────────────────────────────────
 
-/// Spy that records every successful dispatch. Optionally returns
+/// Spy that records every accepted turn. Optionally returns
 /// `Err(Rejected)` for the next call (resets after one use).
 #[derive(Debug, Default)]
 struct RecordingSink {
@@ -119,7 +166,7 @@ impl RecordingSink {
 
 #[async_trait]
 impl ExecutionSink for RecordingSink {
-    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+    async fn dispatch(&self, turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError> {
         let fail = {
             let mut f = self.fail_next.lock().expect("poisoned lock");
             let was = *f;
@@ -129,13 +176,13 @@ impl ExecutionSink for RecordingSink {
         if fail {
             return Err(ExecutionSinkError::Rejected(format!(
                 "test reject for execution_id={}",
-                msg.execution_id
+                turn.msg.execution_id
             )));
         }
         self.observations
             .lock()
             .expect("poisoned lock")
-            .push(msg.clone());
+            .push(turn.msg.clone());
         self.notify.notify_waiters();
         Ok(())
     }
@@ -145,12 +192,12 @@ impl ExecutionSink for RecordingSink {
 
 /// Sink that blocks inside `dispatch` until `release` is notified. Used to
 /// park the orchestrator mid-dispatch so the test can cancel and verify the
-/// row was left in `Processing`.
+/// row was left terminal (the handoff already acknowledged it).
 ///
 /// `entered` is notified the moment the orchestrator calls `dispatch`, before
 /// the blocking wait. The test awaits `entered` to confirm the orchestrator
-/// holds the row in Processing — no polling of `claim_pending` needed, which
-/// avoids the probe accidentally claiming the row and defeating the test.
+/// holds the turn — no polling of `claim_pending` needed, which avoids the
+/// probe accidentally claiming the row and defeating the test.
 #[derive(Debug)]
 struct StalledSink {
     entered: Arc<Notify>,
@@ -159,8 +206,8 @@ struct StalledSink {
 
 #[async_trait]
 impl ExecutionSink for StalledSink {
-    async fn dispatch(&self, _msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
-        // Signal the test that we are inside dispatch (row is Processing).
+    async fn dispatch(&self, _turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError> {
+        // Signal the test that we are inside dispatch (turn accepted).
         self.entered.notify_one();
         // Block until the test notifies the release gate.
         self.release.notified().await;
@@ -170,31 +217,25 @@ impl ExecutionSink for StalledSink {
 
 // ── StalledRecordingSink ──────────────────────────────────────────────────────
 
-/// Sink that records every dispatch call AND blocks the very first call until
-/// `release` is notified. After the first call completes, subsequent calls pass
-/// through immediately.
+/// Sink that counts every dispatch entry, records every completed dispatch,
+/// and blocks until `release` is notified. Used by the NS05 acceptance test to
+/// hold the orchestrator inside dispatch long past `reclaim_after` and prove
+/// the claim neither renewed nor redelivered the row.
 ///
-/// Used to prove at-least-once delivery: orchestrator-A stalls mid-dispatch
-/// while the reclaim sweep resets the row to Pending; orchestrator-B (or a
-/// direct queue manipulation) then dispatches the same row again. Both
-/// invocations are recorded — the row was dispatched twice.
+/// `entries` increments BEFORE the block, so the test can assert exactly one
+/// turn was handed to the sink while it is still blocked; `observations`
+/// fills after release.
 #[derive(Debug, Default)]
 struct StalledRecordingSink {
+    entries: std::sync::atomic::AtomicUsize,
     observations: Mutex<Vec<JobDispatchMsg>>,
     entered: Arc<Notify>,
     release: Arc<Notify>,
-    /// True after the first dispatch call has been released.
-    released_once: AtomicBool,
 }
 
 impl StalledRecordingSink {
     fn new() -> Arc<Self> {
-        Arc::new(Self {
-            observations: Mutex::new(vec![]),
-            entered: Arc::new(Notify::new()),
-            release: Arc::new(Notify::new()),
-            released_once: AtomicBool::new(false),
-        })
+        Arc::new(Self::default())
     }
 
     fn entered_notify(&self) -> Arc<Notify> {
@@ -205,6 +246,10 @@ impl StalledRecordingSink {
         Arc::clone(&self.release)
     }
 
+    fn entry_count(&self) -> usize {
+        self.entries.load(Ordering::Acquire)
+    }
+
     fn snapshot(&self) -> Vec<JobDispatchMsg> {
         self.observations.lock().expect("poisoned lock").clone()
     }
@@ -212,16 +257,14 @@ impl StalledRecordingSink {
 
 #[async_trait]
 impl ExecutionSink for StalledRecordingSink {
-    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+    async fn dispatch(&self, turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError> {
+        self.entries.fetch_add(1, Ordering::AcqRel);
         self.entered.notify_one();
-        if !self.released_once.load(Ordering::Acquire) {
-            self.release.notified().await;
-            self.released_once.store(true, Ordering::Release);
-        }
+        self.release.notified().await;
         self.observations
             .lock()
             .expect("poisoned lock")
-            .push(msg.clone());
+            .push(turn.msg.clone());
         Ok(())
     }
 }
@@ -269,7 +312,7 @@ impl GateSink {
 
 #[async_trait]
 impl ExecutionSink for GateSink {
-    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+    async fn dispatch(&self, turn: &DispatchedTurn<'_>) -> Result<(), ExecutionSinkError> {
         self.entered.notify_one();
         if !self.gate_open.load(Ordering::Acquire) {
             self.gate.notified().await;
@@ -278,9 +321,20 @@ impl ExecutionSink for GateSink {
         self.observations
             .lock()
             .expect("poisoned lock")
-            .push(msg.clone());
+            .push(turn.msg.clone());
         Ok(())
     }
+}
+
+/// Read the handoff `accepted` counter from `registry`.
+fn accepted_count(registry: &MetricsRegistry) -> u64 {
+    let labels = registry
+        .interner()
+        .single("outcome", orchestrator_handoff_outcome::ACCEPTED);
+    registry
+        .counter_labeled(NEBULA_ORCHESTRATOR_HANDOFF_TOTAL, &labels)
+        .unwrap()
+        .get()
 }
 
 // ── test 1: routes_by_tag ─────────────────────────────────────────────────────
@@ -290,22 +344,25 @@ impl ExecutionSink for GateSink {
 /// remain Pending (claimable by a beta-capable worker).
 #[tokio::test(start_paused = true)]
 async fn routes_by_tag() {
-    let queue = make_queue();
+    let core = TestCore::new();
     let spy = RecordingSink::new();
 
-    queue
-        .enqueue(&make_msg(1, "alpha", "exec-alpha"))
+    let alpha_id = core.seed_execution().await;
+    let beta_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(1, "alpha", &alpha_id))
         .await
         .unwrap();
-    queue
-        .enqueue(&make_msg(2, "beta", "exec-beta"))
+    core.queue
+        .enqueue(&make_msg(2, "beta", &beta_id))
         .await
         .unwrap();
 
     let shutdown = CancellationToken::new();
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-alpha"),
         vec!["alpha".parse::<PluginKey>().unwrap()],
     )
@@ -339,7 +396,8 @@ async fn routes_by_tag() {
 
     // Beta job must still be Pending — claimable by a beta-capable worker.
     let beta_tags = vec!["beta".parse::<PluginKey>().unwrap()];
-    let leftover = queue
+    let leftover = core
+        .queue
         .claim_pending(&proc16(b"beta-worker-"), 8, &beta_tags)
         .await
         .unwrap();
@@ -353,23 +411,26 @@ async fn routes_by_tag() {
 
 // ── test 2: claim_route_sink_mark_dispatched ──────────────────────────────────
 
-/// Sink returns `Ok` once. The `dispatched` counter reaches 1. A second
-/// `claim_pending` from a fresh processor returns nothing (row is terminal).
+/// Sink returns `Ok` once. The `dispatched` counter reaches 1 and the handoff
+/// `accepted` counter reaches 1. A second `claim_pending` from a fresh
+/// processor returns nothing (row is terminal).
 #[tokio::test(start_paused = true)]
 async fn claim_route_sink_mark_dispatched() {
-    let queue = make_queue();
+    let core = TestCore::new();
     let spy = RecordingSink::new();
     let registry = MetricsRegistry::new();
 
-    queue
-        .enqueue(&make_msg(10, "plugin-a", "exec-1"))
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(10, "plugin-a", &exec_id))
         .await
         .unwrap();
 
     let shutdown = CancellationToken::new();
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-1"),
         vec!["plugin-a".parse::<PluginKey>().unwrap()],
     )
@@ -406,10 +467,16 @@ async fn claim_route_sink_mark_dispatched() {
         .unwrap()
         .get();
     assert_eq!(dispatched, 1, "dispatched counter must be 1");
+    assert_eq!(
+        accepted_count(&registry),
+        1,
+        "handoff accepted counter must be 1"
+    );
 
     // Row is terminal — a fresh processor finds nothing Pending.
     let tags = vec!["plugin-a".parse::<PluginKey>().unwrap()];
-    let leftover = queue
+    let leftover = core
+        .queue
         .claim_pending(&proc16(b"fresh-proc--"), 8, &tags)
         .await
         .unwrap();
@@ -421,29 +488,25 @@ async fn claim_route_sink_mark_dispatched() {
 
 // ── test 3: dispatched_row_not_reclaimed ──────────────────────────────────────
 
-/// After one dispatch-and-ack, the spy count stays at 1. A second
+/// After one handoff-and-dispatch, the spy count stays at 1. A second
 /// `claim_pending` from a different processor returns nothing — the row is
-/// terminal (Dispatched) and is not re-served.
-///
-/// Note: this test proves that a *terminally-dispatched* row is not re-served.
-/// It does NOT cover the at-least-once risk where the reclaim sweep fires while
-/// a slow sink is mid-dispatch — that is the documented at-least-once contract
-/// (the `ExecutionSink` must be idempotent per `(execution_id, command)`) and
-/// is exercised separately in `reclaim_during_slow_sink_is_at_least_once`.
+/// terminal (acknowledged by the handoff) and is not re-served.
 #[tokio::test(start_paused = true)]
 async fn dispatched_row_not_reclaimed() {
-    let queue = make_queue();
+    let core = TestCore::new();
     let spy = RecordingSink::new();
 
-    queue
-        .enqueue(&make_msg(20, "plugin-b", "exec-2"))
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(20, "plugin-b", &exec_id))
         .await
         .unwrap();
 
     let shutdown = CancellationToken::new();
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-nd"),
         vec!["plugin-b".parse::<PluginKey>().unwrap()],
     )
@@ -463,7 +526,7 @@ async fn dispatched_row_not_reclaimed() {
     .await
     .expect("job dispatched");
 
-    // Let the orchestrator complete the ack before we shut down.
+    // Let the orchestrator finish the entry before we shut down.
     tokio::time::advance(Duration::from_millis(30)).await;
 
     shutdown.cancel();
@@ -471,10 +534,11 @@ async fn dispatched_row_not_reclaimed() {
 
     assert_eq!(spy.snapshot().len(), 1, "sink must be invoked exactly once");
 
-    // Second processor sees nothing — the row is Dispatched (terminal) and
-    // must not be re-served via claim_pending.
+    // Second processor sees nothing — the row was acknowledged by the
+    // handoff and must not be re-served via claim_pending.
     let tags = vec!["plugin-b".parse::<PluginKey>().unwrap()];
-    let second = queue
+    let second = core
+        .queue
         .claim_pending(&proc16(b"proc-nd-2---"), 8, &tags)
         .await
         .unwrap();
@@ -484,42 +548,40 @@ async fn dispatched_row_not_reclaimed() {
     );
 }
 
-// ── test 3b: reclaim_during_slow_sink_is_at_least_once ───────────────────────
+// ── test 4: blocked_action_outlives_claim_without_renewal_or_duplicates ───────
 
-/// Proves the documented at-least-once delivery contract:
+/// The NS05 acceptance criterion (#976): **action duration must not extend
+/// dispatch-queue claim ownership.**
 ///
-/// 1. Orchestrator-A claims a row and blocks inside `StalledRecordingSink`.
-/// 2. Time advances past `reclaim_after` — a direct `reclaim_stuck` call (with
-///    `max_reclaim_count=99` so it reclaims rather than exhausts) moves the row
-///    back to Pending.
-/// 3. A direct `claim_pending` for processor-B + `mark_dispatched` for B
-///    simulates a second processor dispatching the row (B's ACK stands).
-/// 4. Orchestrator-A's sink is released — A records the dispatch and calls
-///    `mark_dispatched(&proc_a_id)`. Because the row is now Dispatched (by B),
-///    the fence (`status=="Processing" AND processed_by=proc_a`) matches 0 rows
-///    and returns `StorageError::NotFound`. The orchestrator swallows that error
-///    and continues normally.
-/// 5. Assert: A's sink observed the row exactly **once** (B acked via direct
-///    queue manipulation, not via a second sink call), and the row remains
-///    Dispatched — B's ACK stands and A's fenced mark_dispatched is discarded.
+/// 1. The orchestrator claims the row and blocks inside `StalledRecordingSink`
+///    — but only AFTER the handoff committed: the row is already acknowledged
+///    and the execution holds a durable lease.
+/// 2. Real time advances far past `reclaim_after`.
+/// 3. A reclaim sweep finds nothing to reclaim (the row is not `Processing`).
+/// 4. A second processor claims nothing — no redelivery.
+/// 5. A second runner cannot take the execution lease — no duplicate live
+///    owner while the first sink is still blocked.
+/// 6. The sink observed the row exactly once.
 ///
-/// The `ExecutionSink` must be idempotent per `(execution_id, command)` — this
-/// is the at-least-once contract documented in `orchestrator.rs`.
+/// Red-ability: reverting the orchestrator to the pre-#976 flow (dispatch
+/// first, ack after) makes the row `Processing` during the stall, so step 3
+/// reclaims it (`reclaimed == 1`) and step 4 hands it to processor-B — both
+/// assertions fail.
 #[tokio::test]
-async fn reclaim_during_slow_sink_is_at_least_once() {
-    let queue = make_queue();
+async fn blocked_action_outlives_claim_without_renewal_or_duplicates() {
+    let core = TestCore::new();
     let sink = StalledRecordingSink::new();
     let entered = sink.entered_notify();
     let release = sink.release_notify();
 
-    queue
-        .enqueue(&make_msg(21, "plugin-b2", "exec-aloe"))
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(21, "plugin-ns5", &exec_id))
         .await
         .unwrap();
 
-    let tags = vec!["plugin-b2".parse::<PluginKey>().unwrap()];
-    let proc_a = proc16(b"proc-aloe-a-");
-    let proc_b = proc16(b"proc-aloe-b-");
+    let tags = vec!["plugin-ns5".parse::<PluginKey>().unwrap()];
+    let proc_a = proc16(b"proc-ns5-a--");
 
     let shutdown = CancellationToken::new();
 
@@ -528,14 +590,15 @@ async fn reclaim_during_slow_sink_is_at_least_once() {
     tokio::pin!(entered_fut);
 
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         sink.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc_a,
         tags.clone(),
     )
     .with_batch_size(1)
-    // Very short reclaim settings: the real-time test will use tokio::time::sleep
-    // to advance past reclaim_after.
+    // Very short reclaim window: the blocked action will outlive it many
+    // times over without any claim renewal.
     .with_reclaim_after(Duration::from_millis(20))
     .with_reclaim_interval(Duration::from_millis(50))
     .with_max_reclaim_count(99)
@@ -543,87 +606,119 @@ async fn reclaim_during_slow_sink_is_at_least_once() {
 
     let handle = orch.spawn(shutdown.clone());
 
-    // Step 1: wait until orchestrator-A is inside dispatch (row is Processing).
+    // Step 1: wait until the orchestrator is inside dispatch. The handoff has
+    // already committed at this point — prove it: the execution row carries
+    // the orchestrator's lease.
     tokio::time::timeout(Duration::from_secs(5), &mut entered_fut)
         .await
-        .expect("orchestrator-A entered dispatch within 5s");
+        .expect("orchestrator entered dispatch within 5s");
 
-    // Step 2: wait past reclaim_after so the row becomes stale.
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    let record = core
+        .store
+        .get(&scope(), &exec_id)
+        .await
+        .unwrap()
+        .expect("execution row exists");
+    assert!(
+        record
+            .lease_holder
+            .as_deref()
+            .is_some_and(|h| h.starts_with("orchestrator:")),
+        "the handoff must hold the execution lease before dispatch runs; got {:?}",
+        record.lease_holder
+    );
 
-    // Step 3: directly reclaim the row (simulates the reclaim sweep that would
-    // run in a separate instance). max_reclaim_count=99 so it reclaims, not
-    // exhausts.
-    let reclaim_outcome = queue
+    // Step 2: outlive the claim window several times over.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    // Step 3: the sweep finds nothing — the row was acknowledged at handoff
+    // time and never sat `Processing` while the action ran.
+    let swept = core
+        .queue
         .reclaim_stuck(Duration::from_millis(5), 99)
         .await
         .unwrap();
     assert_eq!(
-        reclaim_outcome.reclaimed, 1,
-        "row must be reclaimed to Pending for at-least-once test"
+        swept.reclaimed, 0,
+        "a blocked action must not leave its row reclaimable (claim ended at handoff)"
     );
+    assert_eq!(swept.exhausted, 0, "nothing may be exhausted either");
 
-    // Step 4: processor-B claims and marks the row dispatched — B's ACK stands.
-    let b_claimed = queue.claim_pending(&proc_b, 1, &tags).await.unwrap();
-    assert_eq!(
-        b_claimed.len(),
-        1,
-        "processor-B must claim the reclaimed row"
-    );
-    queue.mark_dispatched(&b_claimed[0].token).await.unwrap();
-
-    // Step 5: release orchestrator-A's stall. A acknowledges with the token
-    // from its own (now superseded) claim, which returns
-    // `StorageError::FencedOut` — the generation fence matches 0 rows because
-    // the row is Dispatched under B's later claim. The orchestrator swallows
-    // the error and continues; the row stays terminal under B's ACK.
-    release.notify_one();
-
-    // Shut down and wait for the orchestrator to finish its current batch.
-    shutdown.cancel();
-    handle.await.expect("graceful shutdown");
-
-    // At-least-once: sink saw the row twice (A's blocked dispatch + B's
-    // direct queue manipulation). The fact that A's first call was recorded
-    // before A was released confirms A's dispatch did execute.
-    let seen = sink.snapshot();
-    assert_eq!(
-        seen.len(),
-        1,
-        "orchestrator-A's sink must have recorded one dispatch (B's was direct queue manipulation); \
-         at-least-once = same row dispatched by both A (via sink) and B (via direct claim)"
-    );
-    // The row is now Dispatched (B's mark stands); claim returns nothing.
-    let leftover = queue
-        .claim_pending(&proc16(b"probe-------"), 8, &tags)
+    // Step 4: a second processor claims nothing — no redelivery of a turn
+    // that is already running.
+    let second = core
+        .queue
+        .claim_pending(&proc16(b"proc-ns5-b--"), 8, &tags)
         .await
         .unwrap();
     assert!(
-        leftover.is_empty(),
-        "row must be terminal (Dispatched by B) after A's late mark_dispatched was fenced"
+        second.is_empty(),
+        "no redelivery: the row is terminal, a second worker must claim nothing"
+    );
+
+    // Step 5: no duplicate live owner — the execution lease blocks a second
+    // acquisition outright while the first sink is still blocked.
+    let stolen = core
+        .store
+        .acquire_lease(
+            &scope(),
+            &exec_id,
+            "probe-second-runner",
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert!(
+        stolen.is_none(),
+        "a second runner must not acquire the lease while the blocked action owns it"
+    );
+
+    // Step 6: exactly one sink entry — no duplicate turn while blocked.
+    assert_eq!(
+        sink.entry_count(),
+        1,
+        "the blocked action must be dispatched exactly once"
+    );
+
+    // Release the sink and shut down cleanly.
+    release.notify_one();
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    assert_eq!(
+        sink.entry_count(),
+        1,
+        "releasing the stall must not re-dispatch the turn"
+    );
+    assert_eq!(
+        sink.snapshot().len(),
+        1,
+        "the released dispatch must complete exactly once"
     );
 }
 
-// ── test 4: sink_failure_marks_failed ────────────────────────────────────────
+// ── test 5: invalid_execution_id_marks_failed ─────────────────────────────────
 
-/// Sink returns `Err(Rejected)`. The `failed` counter reaches 1. The row is
-/// not re-served (it is marked Failed by the orchestrator).
+/// A row whose execution id does not parse can never be dispatched. The
+/// orchestrator terminalises it before the handoff writes anything: `failed`
+/// counter 1, no handoff accepted, row not re-served.
 #[tokio::test(start_paused = true)]
-async fn sink_failure_marks_failed() {
-    let queue = make_queue();
+async fn invalid_execution_id_marks_failed() {
+    let core = TestCore::new();
     let spy = RecordingSink::new();
-    spy.set_fail_next();
     let registry = MetricsRegistry::new();
 
-    queue
-        .enqueue(&make_msg(30, "plugin-c", "exec-3"))
+    // No execution row seeded — the id never even reaches the handoff.
+    core.queue
+        .enqueue(&make_msg(30, "plugin-c", "not-an-execution-id"))
         .await
         .unwrap();
 
     let shutdown = CancellationToken::new();
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-fail---"),
         vec!["plugin-c".parse::<PluginKey>().unwrap()],
     )
@@ -660,54 +755,242 @@ async fn sink_failure_marks_failed() {
         .unwrap()
         .get();
     assert_eq!(failed, 1, "failed counter must be 1");
+    assert_eq!(
+        accepted_count(&registry),
+        0,
+        "validation failure must never reach the handoff"
+    );
+    assert!(
+        spy.snapshot().is_empty(),
+        "an invalid execution id must never reach the sink"
+    );
 
-    // Failed row must not be re-served by a subsequent claim.
+    // The terminalised row must not be re-served.
     let tags = vec!["plugin-c".parse::<PluginKey>().unwrap()];
-    let leftover = queue
+    let leftover = core
+        .queue
         .claim_pending(&proc16(b"other-proc--"), 8, &tags)
         .await
         .unwrap();
     assert!(
         leftover.is_empty(),
-        "failed row must not be re-served via claim_pending"
+        "invalid-id row must be terminal, not re-served"
     );
 }
 
-// ── test 5: reclaim_recovers_crashed ─────────────────────────────────────────
+// ── test 6: orphaned_execution_marks_failed ───────────────────────────────────
 
-/// Simulate a crashed runner: claim a row manually (putting it in Processing),
-/// never mark it. A fresh orchestrator with aggressive reclaim settings sweeps
-/// it back to Pending (RECLAIMED counter ≥ 1). Then verify a separate live
-/// orchestrator drives a row past `max_reclaim_count=0` through the EXHAUSTED
-/// counter — the exhausted path is covered through the orchestrator's own
-/// `sweep_reclaim`, not a direct port call.
+/// A valid execution id with no execution row is an orphaned dispatch: the
+/// emitter materialises both rows atomically, so a missing execution will not
+/// appear later. The handoff reports NotFound and the orchestrator
+/// terminalises the row instead of redelivering forever.
 #[tokio::test(start_paused = true)]
-async fn reclaim_recovers_crashed() {
-    // ── sub-case 1: live orchestrator reclaims a crashed row ─────────────────
-    let queue = make_queue();
+async fn orphaned_execution_marks_failed() {
+    let core = TestCore::new();
     let spy = RecordingSink::new();
     let registry = MetricsRegistry::new();
 
-    queue
-        .enqueue(&make_msg(40, "plugin-d", "exec-4"))
+    // Valid, parseable id — but deliberately NOT seeded in the store.
+    let orphan_id = ExecutionId::new().to_string();
+    core.queue
+        .enqueue(&make_msg(31, "plugin-orp", &orphan_id))
         .await
         .unwrap();
 
-    // Claim the row without marking it — simulates a crashed runner.
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
+        proc16(b"proc-orphan-"),
+        vec!["plugin-orp".parse::<PluginKey>().unwrap()],
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_metrics(registry.clone());
+
+    let handle = orch.spawn(shutdown.clone());
+
+    let failed_labels = registry
+        .interner()
+        .single("outcome", orchestrator_dispatch_outcome::FAILED);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let f = registry
+                .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &failed_labels)
+                .unwrap()
+                .get();
+            if f >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("failed counter reached 1 within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let handoff_error_labels = registry
+        .interner()
+        .single("outcome", orchestrator_handoff_outcome::ERROR);
+    let handoff_errors = registry
+        .counter_labeled(NEBULA_ORCHESTRATOR_HANDOFF_TOTAL, &handoff_error_labels)
+        .unwrap()
+        .get();
+    assert_eq!(
+        handoff_errors, 1,
+        "the handoff must report the missing execution once"
+    );
+    assert_eq!(
+        accepted_count(&registry),
+        0,
+        "an orphaned execution must never be accepted"
+    );
+    assert!(
+        spy.snapshot().is_empty(),
+        "an orphaned execution must never reach the sink"
+    );
+
+    let tags = vec!["plugin-orp".parse::<PluginKey>().unwrap()];
+    let leftover = core
+        .queue
+        .claim_pending(&proc16(b"probe-orphan"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "orphaned row must be terminal after mark_failed"
+    );
+}
+
+// ── test 7: post_handoff_sink_failure_keeps_row_terminal ──────────────────────
+
+/// A sink error AFTER the handoff records `failed` for operators but touches
+/// no queue state: the row was already acknowledged, and recovery is governed
+/// by the execution lease the handoff minted. The row is not re-served, and
+/// the lease stays held for lease-governed recovery.
+#[tokio::test(start_paused = true)]
+async fn post_handoff_sink_failure_keeps_row_terminal() {
+    let core = TestCore::new();
+    let spy = RecordingSink::new();
+    spy.set_fail_next();
+    let registry = MetricsRegistry::new();
+
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(32, "plugin-pf", &exec_id))
+        .await
+        .unwrap();
+
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
+        proc16(b"proc-pf-----"),
+        vec!["plugin-pf".parse::<PluginKey>().unwrap()],
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_metrics(registry.clone());
+
+    let handle = orch.spawn(shutdown.clone());
+
+    let failed_labels = registry
+        .interner()
+        .single("outcome", orchestrator_dispatch_outcome::FAILED);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let f = registry
+                .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &failed_labels)
+                .unwrap()
+                .get();
+            if f >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("failed counter reached 1 within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    assert_eq!(
+        accepted_count(&registry),
+        1,
+        "the handoff must have accepted the turn before the sink failed"
+    );
+
+    // The acknowledged row is not re-served.
+    let tags = vec!["plugin-pf".parse::<PluginKey>().unwrap()];
+    let leftover = core
+        .queue
+        .claim_pending(&proc16(b"probe-pf----"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "a post-handoff sink failure must not make the row claimable again"
+    );
+
+    // Recovery is lease-governed: the handoff's lease is still on the row.
+    let record = core
+        .store
+        .get(&scope(), &exec_id)
+        .await
+        .unwrap()
+        .expect("execution row exists");
+    assert!(
+        record.lease_holder.is_some(),
+        "the execution lease must remain held for lease-governed recovery"
+    );
+}
+
+// ── test 8: reclaim_recovers_crashed ─────────────────────────────────────────
+
+/// Simulate a runner that crashed BEFORE its handoff committed: claim a row
+/// manually (putting it in Processing), never hand off, never mark. A fresh
+/// orchestrator with aggressive reclaim settings sweeps it back to Pending
+/// (RECLAIMED counter ≥ 1). Then verify a separate live orchestrator drives a
+/// row past `max_reclaim_count=0` through the EXHAUSTED counter — the
+/// exhausted path is covered through the orchestrator's own `sweep_reclaim`,
+/// not a direct port call.
+#[tokio::test(start_paused = true)]
+async fn reclaim_recovers_crashed() {
+    // ── sub-case 1: live orchestrator reclaims a crashed row ─────────────────
+    let core = TestCore::new();
+    let spy = RecordingSink::new();
+    let registry = MetricsRegistry::new();
+
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(40, "plugin-d", &exec_id))
+        .await
+        .unwrap();
+
+    // Claim the row without handing off or marking — crash simulated.
     let tags = vec!["plugin-d".parse::<PluginKey>().unwrap()];
-    let claimed = queue
+    let claimed = core
+        .queue
         .claim_pending(&proc16(b"crashed-proc"), 1, &tags)
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1, "row must be claimed into Processing");
-    // Intentionally not calling mark_dispatched or mark_failed — crash simulated.
+    // Intentionally no handoff, no mark — crash simulated.
 
     // Fresh orchestrator with short reclaim_after so the paused clock just needs
     // a small advance to make the row stale.
     let reclaim_after = Duration::from_millis(10);
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"fresh-proc--"),
         tags.clone(),
     )
@@ -756,22 +1039,25 @@ async fn reclaim_recovers_crashed() {
 
     // ── sub-case 2: live orchestrator drives a row to EXHAUSTED ──────────────
     //
-    // A second queue seeds a row that is already in Processing (crashed runner).
+    // A second core seeds a row that is already in Processing (crashed runner).
     // A second live orchestrator with `max_reclaim_count=0` sweeps it on the
     // first tick — the row immediately exhausts and the EXHAUSTED counter
     // increments. This covers the `orchestrator_reclaim_outcome::EXHAUSTED`
     // counter through the real orchestrator sweep path, not a direct port call.
-    let queue2 = make_queue();
+    let core2 = TestCore::new();
     let spy2 = RecordingSink::new();
     let registry2 = MetricsRegistry::new();
     let tags2 = vec!["plugin-d2".parse::<PluginKey>().unwrap()];
 
-    queue2
-        .enqueue(&make_msg(41, "plugin-d2", "exec-5"))
+    let exec_id2 = core2.seed_execution().await;
+    core2
+        .queue
+        .enqueue(&make_msg(41, "plugin-d2", &exec_id2))
         .await
         .unwrap();
     // Claim without marking — crashed runner simulation.
-    let claimed2 = queue2
+    let claimed2 = core2
+        .queue
         .claim_pending(&proc16(b"crash-proc2-"), 1, &tags2)
         .await
         .unwrap();
@@ -780,8 +1066,9 @@ async fn reclaim_recovers_crashed() {
     // Orchestrator with max_reclaim_count=0: any Processing row immediately
     // exhausts on the first sweep (reclaim_count starts at 0, budget is 0).
     let orch2 = Orchestrator::new(
-        queue2.clone() as Arc<dyn JobDispatchQueue>,
+        core2.queue.clone() as Arc<dyn JobDispatchQueue>,
         spy2.clone() as Arc<dyn ExecutionSink>,
+        core2.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"exhaust-proc"),
         tags2.clone(),
     )
@@ -831,32 +1118,32 @@ async fn reclaim_recovers_crashed() {
     );
 }
 
-// ── test 6: graceful_shutdown_flushes_in_flight_dispatch ─────────────────────
+// ── test 9: graceful_shutdown_flushes_in_flight_dispatch ─────────────────────
 
 /// Cancelling the orchestrator while a dispatch is in flight does NOT drop the
 /// in-flight work: the shutdown contract is batch-flush (finish the current
-/// batch, then exit). The row must be marked Dispatched, not left Processing.
+/// batch, then exit). The row was acknowledged by the handoff before dispatch
+/// began; the flush completes the dispatch and the row stays terminal.
 ///
-/// The "row left Processing for reclaim" contract only applies to a hard crash
-/// (OS kill) — tested in `reclaim_recovers_crashed` (test-5). This test
-/// exercises the graceful-flush path.
+/// The "row left Processing for reclaim" contract applies only to rows whose
+/// runner crashed BEFORE the handoff committed — tested in
+/// `reclaim_recovers_crashed` (test 8). This test exercises the
+/// graceful-flush path.
 ///
 /// Sequence:
-/// 1. Enqueue a row.
+/// 1. Enqueue a row (execution seeded).
 /// 2. Start the orchestrator with `StalledSink`. `StalledSink::dispatch` fires
 ///    `entered` before blocking on `release`, giving the test an exact signal
-///    that the row is Processing and the orchestrator is inside dispatch.
+///    that the turn was accepted and the orchestrator is inside dispatch.
 /// 3. Await `entered` — no `claim_pending` polling so no probe-claim race.
 /// 4. Cancel the token while the orchestrator is blocked in dispatch.
-/// 5. Release the sink — dispatch returns `Ok`. The orchestrator calls
-///    `mark_dispatched`, then loops back to the biased select, sees the
-///    cancellation, and exits.
+/// 5. Release the sink — dispatch returns `Ok`. The orchestrator finishes the
+///    entry, loops back to the biased select, sees the cancellation, and exits.
 /// 6. `handle.await` completes.
-/// 7. A fresh `claim_pending` returns empty — row is Dispatched (terminal), not
-///    Processing, confirming the flush happened.
+/// 7. A fresh `claim_pending` returns empty — the row is terminal.
 #[tokio::test]
 async fn graceful_shutdown_flushes_in_flight_dispatch() {
-    let queue = make_queue();
+    let core = TestCore::new();
     let entered = Arc::new(Notify::new());
     let release = Arc::new(Notify::new());
     let sink: Arc<dyn ExecutionSink> = Arc::new(StalledSink {
@@ -864,8 +1151,9 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
         release: release.clone(),
     });
 
-    queue
-        .enqueue(&make_msg(50, "plugin-e", "exec-6"))
+    let exec_id = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(50, "plugin-e", &exec_id))
         .await
         .unwrap();
 
@@ -879,8 +1167,9 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
     tokio::pin!(entered_fut);
 
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         sink,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-sd-----"),
         tags.clone(),
     )
@@ -890,7 +1179,6 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
     let handle = orch.spawn(shutdown.clone());
 
     // Exact handshake: block until the orchestrator is inside StalledSink::dispatch.
-    // The row is Processing under proc16(b"proc-sd-----") at this point.
     tokio::time::timeout(Duration::from_secs(5), &mut entered_fut)
         .await
         .expect("orchestrator entered dispatch within 5s");
@@ -902,29 +1190,30 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
     shutdown.cancel();
 
     // Release the sink so dispatch completes with Ok. The orchestrator then
-    // calls `mark_dispatched`, finishes `tick()`, re-enters the biased select,
-    // sees `cancelled()`, and exits.
+    // finishes `tick()`, re-enters the biased select, sees `cancelled()`, and
+    // exits.
     release.notify_waiters();
 
     handle.await.expect("graceful shutdown after cancel");
 
-    // Row is Dispatched (terminal) — a fresh claim returns empty.
-    let leftover = queue
+    // Row is terminal — a fresh claim returns empty.
+    let leftover = core
+        .queue
         .claim_pending(&proc16(b"recovery----"), 4, &tags)
         .await
         .unwrap();
     assert!(
         leftover.is_empty(),
-        "row must be Dispatched (terminal) after graceful flush; \
-         claim_pending must return empty"
+        "row must be terminal after graceful flush; claim_pending must return empty"
     );
 }
 
-// ── test 7: graceful_shutdown_flushes_multi_row_batch ────────────────────────
+// ── test 10: graceful_shutdown_flushes_multi_row_batch ────────────────────────
 
 /// Proves that graceful shutdown flushes the **entire** in-flight batch, not
-/// just the first row.  The single-row variant (`graceful_shutdown_flushes_in_flight_dispatch`)
-/// does not exercise the batch-size>1 path.
+/// just the first row. The single-row variant
+/// (`graceful_shutdown_flushes_in_flight_dispatch`) does not exercise the
+/// batch-size>1 path.
 ///
 /// Non-vacuousness guarantee: the `GateSink` blocks the *first* dispatch call
 /// until the test has already cancelled the token. The test pre-registers the
@@ -933,24 +1222,24 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
 /// request arriving mid-batch.
 ///
 /// Sequence:
-/// 1. Enqueue 2 rows.
+/// 1. Enqueue 2 rows (both executions seeded).
 /// 2. Start the orchestrator with `batch_size=2` and a `GateSink`.
 /// 3. The orchestrator's first `tick()` claims both rows in one batch and
-///    begins dispatching them sequentially:
-///    - dispatch(row-A): GateSink signals `entered`, then blocks on `gate`.
+///    begins handing off + dispatching them sequentially:
+///    - handoff(row-A), dispatch(row-A): GateSink signals `entered`, then
+///      blocks on `gate`.
 /// 4. Test observes `entered` (first dispatch is blocked — proven non-vacuous).
 /// 5. Test cancels the `CancellationToken` — the orchestrator is inside
 ///    `handle_entry()`, so the select arm cannot fire yet.
 /// 6. Test opens the gate (`gate.notify_waiters()`).
-/// 7. dispatch(row-A) unblocks → mark_dispatched(row-A).
-///    dispatch(row-B): GateSink sees `gate_open=true` → passes through immediately
-///    → mark_dispatched(row-B).
+/// 7. dispatch(row-A) unblocks; handoff(row-B) + dispatch(row-B) pass through
+///    immediately (gate_open=true after first dispatch returns).
 /// 8. `tick()` returns. The orchestrator re-enters the biased select, observes
 ///    cancellation, and exits.
-/// 9. Both rows must be Dispatched (terminal); none left Pending or Processing.
+/// 9. Both rows must be terminal; none left Pending or Processing.
 #[tokio::test]
 async fn graceful_shutdown_flushes_multi_row_batch() {
-    let queue = make_queue();
+    let core = TestCore::new();
 
     // Shared observation list — GateSink records every successfully dispatched
     // message here.
@@ -968,12 +1257,14 @@ async fn graceful_shutdown_flushes_multi_row_batch() {
     ));
 
     // Enqueue 2 rows with the same tag so both are claimed in one batch.
-    queue
-        .enqueue(&make_msg(60, "plugin-f", "exec-mra-1"))
+    let exec_id1 = core.seed_execution().await;
+    let exec_id2 = core.seed_execution().await;
+    core.queue
+        .enqueue(&make_msg(60, "plugin-f", &exec_id1))
         .await
         .unwrap();
-    queue
-        .enqueue(&make_msg(61, "plugin-f", "exec-mra-2"))
+    core.queue
+        .enqueue(&make_msg(61, "plugin-f", &exec_id2))
         .await
         .unwrap();
 
@@ -987,8 +1278,9 @@ async fn graceful_shutdown_flushes_multi_row_batch() {
     tokio::pin!(entered_fut);
 
     let orch = Orchestrator::new(
-        queue.clone() as Arc<dyn JobDispatchQueue>,
+        core.queue.clone() as Arc<dyn JobDispatchQueue>,
         sink,
+        core.handoff.clone() as Arc<dyn ExecutionTurnHandoff>,
         proc16(b"proc-mra----"),
         tags.clone(),
     )
@@ -1030,13 +1322,14 @@ async fn graceful_shutdown_flushes_multi_row_batch() {
         "GateSink must record both rows: batch-flush must complete despite cancel mid-batch"
     );
 
-    let leftover = queue
+    let leftover = core
+        .queue
         .claim_pending(&proc16(b"recovery-mr-"), 8, &tags)
         .await
         .unwrap();
     assert!(
         leftover.is_empty(),
-        "all rows must be terminal (Dispatched) after multi-row batch flush; \
+        "all rows must be terminal after multi-row batch flush; \
          none must be left Pending or Processing"
     );
 }

--- a/crates/storage-port/src/lib.rs
+++ b/crates/storage-port/src/lib.rs
@@ -49,6 +49,7 @@ pub use error::StorageError;
 pub use ids::{CredentialId, FencingToken};
 pub use scope::Scope;
 pub use store::{
-    CredentialAlreadyExistsKey, CredentialPersistence, CredentialPersistenceError, OperationLedger,
-    OperationLedgerAdjudicator, PlanFlavorCatalog, PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter,
+    CredentialAlreadyExistsKey, CredentialPersistence, CredentialPersistenceError,
+    ExecutionTurnHandoff, OperationLedger, OperationLedgerAdjudicator, PlanFlavorCatalog,
+    PlanFlavorCatalogAdmin, PlanFlavorCatalogWriter, TurnAcceptance, TurnHandoff,
 };

--- a/crates/storage-port/src/store/mod.rs
+++ b/crates/storage-port/src/store/mod.rs
@@ -22,6 +22,7 @@ mod resume_token;
 mod revision_catalog;
 mod start_acceptance;
 mod trigger_dedup;
+mod turn_handoff;
 mod webhook;
 mod workflow;
 
@@ -52,5 +53,6 @@ pub use start_acceptance::{
     FingerprintVersion, KeyedStart, StartAcceptance, StartAcceptanceStore, StartFingerprint,
 };
 pub use trigger_dedup::TriggerDedupInbox;
+pub use turn_handoff::{ExecutionTurnHandoff, TurnAcceptance, TurnHandoff};
 pub use webhook::WebhookActivationStore;
 pub use workflow::{WorkflowStore, WorkflowVersionStore};

--- a/crates/storage-port/src/store/turn_handoff.rs
+++ b/crates/storage-port/src/store/turn_handoff.rs
@@ -51,6 +51,13 @@ pub struct TurnHandoff<'a> {
     ///
     /// This bounds recovery latency after a crash, not how long the action may
     /// run: a live owner renews it, and the queue claim is already finished.
+    ///
+    /// Every backend clamps it to `[1s, 24h]`, exactly as
+    /// [`crate::store::ExecutionStore::acquire_lease`] does, so a handoff cannot
+    /// mint a lease the execution store would have refused. `Duration::ZERO`
+    /// therefore becomes one second rather than an already-expired lease — a
+    /// caller cannot acknowledge a queue row and be left with no durable
+    /// ownership.
     pub lease_ttl: Duration,
 }
 

--- a/crates/storage-port/src/store/turn_handoff.rs
+++ b/crates/storage-port/src/store/turn_handoff.rs
@@ -1,0 +1,112 @@
+//! Durable handoff from a dispatch claim to an execution turn.
+//!
+//! A dispatch claim protects *delivery*, not work. Holding one for the duration
+//! of an action makes the queue's reclaim timeout an implicit limit on how long
+//! an action may run: a slow action outlives its claim, a sweep redelivers the
+//! row, and a second worker starts the same turn while the first is still
+//! running it. Extending the claim while the action runs only moves the
+//! problem — it turns the queue row into a second, weaker lease competing with
+//! the execution aggregate's own.
+//!
+//! The handoff ends the claim at a definite point instead. Runtime control
+//! durably accepts ownership of the execution turn under the aggregate's
+//! lease/fence **and** acknowledges the queue row in one transaction, so the
+//! two can never disagree:
+//!
+//! - Crash before the commit: the row is still `Processing`, the reclaim sweep
+//!   redelivers it, and no turn was ever accepted.
+//! - Crash after the commit: the row is acknowledged and the execution holds a
+//!   durable lease, so recovery drives from aggregate truth rather than from
+//!   the queue.
+//!
+//! After the handoff the action's duration is governed by the execution lease
+//! and persisted recovery state. The dispatch claim is already finished, so it
+//! cannot be extended by how long the action takes.
+
+use core::fmt;
+use std::time::Duration;
+
+use crate::error::StorageError;
+use crate::ids::FencingToken;
+use crate::scope::Scope;
+use crate::store::job_dispatch::JobClaimToken;
+
+/// Everything one durable handoff needs, in one transaction.
+#[derive(Debug, Clone)]
+pub struct TurnHandoff<'a> {
+    /// Tenant that owns the execution and the queue row.
+    pub scope: &'a Scope,
+    /// Execution whose turn is being accepted.
+    pub execution_id: &'a str,
+    /// Proof the caller currently owns the queue row it is acknowledging.
+    ///
+    /// A processor identity cannot serve here: a stable processor may claim a
+    /// row, lose it to a reclaim sweep, and claim it again, so an
+    /// acknowledgement issued against the first claim would terminalise a row
+    /// the second claim is still working.
+    pub claim: JobClaimToken,
+    /// Identity recorded as the execution's lease holder.
+    pub holder: &'a str,
+    /// How long the accepted turn's lease is valid for.
+    ///
+    /// This bounds recovery latency after a crash, not how long the action may
+    /// run: a live owner renews it, and the queue claim is already finished.
+    pub lease_ttl: Duration,
+}
+
+/// What a durable handoff did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnAcceptance {
+    /// The turn is durably owned and the queue row is acknowledged.
+    ///
+    /// The fence is the execution aggregate's, so every subsequent write this
+    /// owner makes is rejected once a reclaim supersedes it.
+    Accepted {
+        /// Fence proving ownership of the accepted turn.
+        fence: FencingToken,
+    },
+    /// The claim was superseded before the handoff committed.
+    ///
+    /// Nothing was written: neither the lease nor the queue row moved. The
+    /// caller must not begin the turn — another worker already holds the row.
+    ClaimSuperseded,
+    /// Another holder owns a live lease on this execution.
+    ///
+    /// Nothing was written, and the queue row is deliberately left
+    /// unacknowledged so the sweep can redeliver it once that lease expires.
+    /// Acknowledging here would drop the turn on the floor: the row would be
+    /// terminal while no owner ever ran it.
+    TurnHeldByAnotherOwner,
+}
+
+/// Durable owner of the dispatch-claim → execution-turn handoff.
+///
+/// Implementations **own** both writes and must not delegate to
+/// [`crate::store::ExecutionStore::acquire_lease`] plus
+/// [`crate::store::JobDispatchQueue::mark_dispatched`] — those run as separate
+/// operations, and a crash between them is exactly the state this capability
+/// exists to make unreachable.
+#[async_trait::async_trait]
+pub trait ExecutionTurnHandoff: Send + Sync + fmt::Debug {
+    /// Accept the execution turn and acknowledge the queue row, committing once.
+    ///
+    /// **Ordering (all backends), inside one transaction:**
+    ///
+    /// 1. Re-check the queue row is still `Processing` at the claim's
+    ///    generation. A superseded generation returns
+    ///    [`TurnAcceptance::ClaimSuperseded`] with nothing written.
+    /// 2. Acquire the execution lease for `holder`. A live lease held by
+    ///    someone else returns [`TurnAcceptance::TurnHeldByAnotherOwner`], again
+    ///    with nothing written — including no queue acknowledgement.
+    /// 3. Acknowledge the queue row.
+    /// 4. Commit, returning [`TurnAcceptance::Accepted`] with the fence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::NotFound`] when the queue row or the execution
+    /// does not exist, and a connection error when the backend is unreachable.
+    /// A failure at any step rolls back the whole transaction, so a turn is
+    /// never accepted without its acknowledgement and a row is never
+    /// acknowledged without an owner.
+    async fn accept_turn(&self, handoff: &TurnHandoff<'_>) -> Result<TurnAcceptance, StorageError>;
+}

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -40,4 +40,5 @@ pub use resume_producer::InMemoryResumeProducer;
 pub use resume_token::InMemoryResumeTokenStore;
 pub use start_acceptance::InMemoryStartAcceptanceStore;
 pub use turn_handoff::InMemoryTurnHandoff;
+pub(crate) use turn_handoff::acceptance_label;
 pub use workflow::{InMemoryWorkflowStore, InMemoryWorkflowVersionStore};

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -40,5 +40,6 @@ pub use resume_producer::InMemoryResumeProducer;
 pub use resume_token::InMemoryResumeTokenStore;
 pub use start_acceptance::InMemoryStartAcceptanceStore;
 pub use turn_handoff::InMemoryTurnHandoff;
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub(crate) use turn_handoff::acceptance_label;
 pub use workflow::{InMemoryWorkflowStore, InMemoryWorkflowVersionStore};

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -20,6 +20,7 @@ mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
 mod start_acceptance;
+mod turn_handoff;
 mod workflow;
 
 pub use control_queue::InMemoryControlQueue;
@@ -38,4 +39,5 @@ pub use plan_flavor_catalog::InMemoryPlanFlavorCatalog;
 pub use resume_producer::InMemoryResumeProducer;
 pub use resume_token::InMemoryResumeTokenStore;
 pub use start_acceptance::InMemoryStartAcceptanceStore;
+pub use turn_handoff::InMemoryTurnHandoff;
 pub use workflow::{InMemoryWorkflowStore, InMemoryWorkflowVersionStore};

--- a/crates/storage/src/inmem/turn_handoff.rs
+++ b/crates/storage/src/inmem/turn_handoff.rs
@@ -64,15 +64,23 @@ impl ExecutionTurnHandoff for InMemoryTurnHandoff {
             // Decide everything before writing: this critical section cannot
             // roll back, so a rejection discovered after a write would leave
             // the execution leased to a worker that must not run it.
-            let job = state
-                .jobs
-                .get(handoff.claim.row_id())
-                .ok_or_else(|| StorageError::not_found("job_dispatch", "claimed row"))?;
-            if job.status != "Processing"
-                || job.claim_generation != handoff.claim.generation().get()
-            {
-                Ok(TurnAcceptance::ClaimSuperseded)
-            } else {
+            // A vanished row is the superseded case, not an error: the SQL
+            // backends select on identity, status, and generation together, so
+            // a purged row yields no match there either. A caller swapping
+            // backends must not see a typed outcome on one and a hard error on
+            // the other.
+            //
+            // The row must also belong to the execution and tenant this handoff
+            // names. A valid token from one job paired with another execution id
+            // would otherwise lease the wrong aggregate and acknowledge —
+            // dropping — the job that was actually claimed.
+            let claim_live = state.jobs.get(handoff.claim.row_id()).is_some_and(|job| {
+                job.status == "Processing"
+                    && job.claim_generation == handoff.claim.generation().get()
+                    && job.msg.execution_id == handoff.execution_id
+                    && &job.msg.scope == handoff.scope
+            });
+            if claim_live {
                 let row = state
                     .rows
                     .get(handoff.execution_id)
@@ -113,6 +121,8 @@ impl ExecutionTurnHandoff for InMemoryTurnHandoff {
                         fence: FencingToken::from_generation(generation),
                     })
                 }
+            } else {
+                Ok(TurnAcceptance::ClaimSuperseded)
             }
         };
 

--- a/crates/storage/src/inmem/turn_handoff.rs
+++ b/crates/storage/src/inmem/turn_handoff.rs
@@ -1,0 +1,141 @@
+//! In-memory dispatch-claim → execution-turn handoff.
+//!
+//! The queue rows and the execution rows already live under the execution
+//! store's single lock, so the whole handoff runs in one critical section —
+//! the in-memory equivalent of the SQL backends' single transaction.
+//!
+//! The mutex is not a transaction: there is no rollback, so every rejection is
+//! decided before the first write. Acquiring the lease and then discovering the
+//! claim was superseded would leave the execution leased to a worker that must
+//! not run it, with no way to undo.
+
+use std::time::Duration;
+
+use nebula_storage_port::store::{ExecutionTurnHandoff, TurnAcceptance, TurnHandoff};
+use nebula_storage_port::{FencingToken, StorageError};
+
+use super::execution::SharedState;
+
+/// In-memory owner of the dispatch-claim → execution-turn handoff.
+#[derive(Clone, Debug)]
+pub struct InMemoryTurnHandoff {
+    inner: SharedState,
+}
+
+impl InMemoryTurnHandoff {
+    /// Build a handoff over an execution store's shared core.
+    ///
+    /// Sharing the core is required, not convenient: the lease write and the
+    /// queue acknowledgement must land together, and two stores would give
+    /// them two boundaries.
+    #[must_use]
+    pub fn new(store: &super::InMemoryExecutionStore) -> Self {
+        Self {
+            inner: store.shared(),
+        }
+    }
+}
+
+/// Clamp the lease TTL the same way the execution store does, so a handoff
+/// cannot mint a lease the store itself would have refused to issue.
+fn normalized_ttl(ttl: Duration) -> Duration {
+    Duration::from_secs_f64(ttl.as_secs_f64().clamp(1.0, 86_400.0))
+}
+
+#[async_trait::async_trait]
+impl ExecutionTurnHandoff for InMemoryTurnHandoff {
+    #[tracing::instrument(
+        level = "debug",
+        name = "turn_handoff.accept_turn",
+        skip(self, handoff),
+        fields(
+            backend = "in_memory",
+            execution_id = handoff.execution_id,
+            claim_generation = handoff.claim.generation().get(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn accept_turn(&self, handoff: &TurnHandoff<'_>) -> Result<TurnAcceptance, StorageError> {
+        let ttl = normalized_ttl(handoff.lease_ttl);
+        let result = {
+            let mut state = self.inner.lock();
+            let now = chrono::Utc::now();
+
+            // Decide everything before writing: this critical section cannot
+            // roll back, so a rejection discovered after a write would leave
+            // the execution leased to a worker that must not run it.
+            let job = state
+                .jobs
+                .get(handoff.claim.row_id())
+                .ok_or_else(|| StorageError::not_found("job_dispatch", "claimed row"))?;
+            if job.status != "Processing"
+                || job.claim_generation != handoff.claim.generation().get()
+            {
+                Ok(TurnAcceptance::ClaimSuperseded)
+            } else {
+                let row = state
+                    .rows
+                    .get(handoff.execution_id)
+                    .filter(|row| &row.scope == handoff.scope)
+                    .ok_or_else(|| StorageError::not_found("execution", handoff.execution_id))?;
+                let held = matches!(row.lease_expires_at, Some(expiry) if expiry >= now);
+                if held {
+                    // The queue row is deliberately left claimed: acknowledging
+                    // here would make it terminal while no owner ever ran the
+                    // turn, so the sweep must still be able to redeliver it.
+                    Ok(TurnAcceptance::TurnHeldByAnotherOwner)
+                } else {
+                    // Past this point every write is infallible, so the lease
+                    // and the acknowledgement land together or not at all.
+                    let generation = {
+                        let row = state.rows.get_mut(handoff.execution_id).ok_or_else(|| {
+                            StorageError::not_found("execution", handoff.execution_id)
+                        })?;
+                        // Every acquire bumps the generation, so a token from
+                        // before this handoff is dead — including one held by a
+                        // crashed-then-restarted runner reusing its identity.
+                        row.fencing_generation = row.fencing_generation.saturating_add(1);
+                        handoff
+                            .holder
+                            .clone_into(row.lease_holder.get_or_insert_with(String::new));
+                        row.lease_expires_at = Some(
+                            now + chrono::Duration::from_std(ttl)
+                                .unwrap_or_else(|_overflow| chrono::Duration::zero()),
+                        );
+                        row.fencing_generation
+                    };
+                    let job = state
+                        .jobs
+                        .get_mut(handoff.claim.row_id())
+                        .ok_or_else(|| StorageError::not_found("job_dispatch", "claimed row"))?;
+                    "Dispatched".clone_into(&mut job.status);
+                    Ok(TurnAcceptance::Accepted {
+                        fence: FencingToken::from_generation(generation),
+                    })
+                }
+            }
+        };
+
+        let outcome = acceptance_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(
+            target: "nebula_storage::inmem",
+            outcome,
+            "dispatch claim handed off to an execution turn"
+        );
+        result
+    }
+}
+
+/// Stable label naming one handoff outcome, so every backend reports the same
+/// vocabulary on its spans.
+pub(crate) const fn acceptance_label(
+    result: &Result<TurnAcceptance, StorageError>,
+) -> &'static str {
+    match *result {
+        Ok(TurnAcceptance::Accepted { .. }) => "accepted",
+        Ok(TurnAcceptance::ClaimSuperseded) => "claim_superseded",
+        Ok(TurnAcceptance::TurnHeldByAnotherOwner) => "turn_held_by_another_owner",
+        Err(_) => "error",
+    }
+}

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -21,6 +21,7 @@ mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
 mod start_acceptance;
+mod turn_handoff;
 mod workflow;
 
 pub use control_queue::{PgControlQueue, PgJournalReader};
@@ -36,6 +37,7 @@ pub use plan_flavor_catalog::PgPlanFlavorCatalog;
 pub use resume_producer::PgResumeProducer;
 pub use resume_token::PgResumeTokenStore;
 pub use start_acceptance::PgStartAcceptanceStore;
+pub use turn_handoff::PgTurnHandoff;
 pub use workflow::{PgWorkflowStore, PgWorkflowVersionStore};
 
 /// Admit a canonical schema and apply every pending ordered migration under

--- a/crates/storage/src/postgres/turn_handoff.rs
+++ b/crates/storage/src/postgres/turn_handoff.rs
@@ -1,0 +1,157 @@
+//! PostgreSQL dispatch-claim → execution-turn handoff.
+//!
+//! The claim re-check, the lease acquisition, and the queue acknowledgement are
+//! three statements in **one** transaction, so a crash can only land on one
+//! side of it: either the row is still `Processing` and no turn was accepted,
+//! or the row is acknowledged and the execution holds the lease that governs
+//! the work.
+//!
+//! The claim row is re-read `FOR UPDATE`, so a concurrent reclaim sweep cannot
+//! move it between the check and the acknowledgement — the window that would
+//! otherwise let two workers believe they own the same turn.
+//!
+//! The database stamps the lease deadline from `clock_timestamp()`, exactly as
+//! `acquire_lease` does. A caller's clock never decides liveness: one running
+//! fast would fence out a healthy peer, one running slow would mint an
+//! already-dead lease, and neither is detectable from the row afterwards.
+
+use nebula_storage_port::store::{ExecutionTurnHandoff, TurnAcceptance, TurnHandoff};
+use nebula_storage_port::{FencingToken, StorageError};
+use sqlx::PgPool;
+
+use crate::inmem::acceptance_label;
+use crate::postgres::execution::conn_err;
+
+/// PostgreSQL-backed owner of the dispatch-claim → execution-turn handoff.
+#[derive(Clone, Debug)]
+pub struct PgTurnHandoff {
+    pool: PgPool,
+}
+
+impl PgTurnHandoff {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Clamp the lease TTL exactly as the execution store does, so a handoff cannot
+/// mint a lease the store itself would have refused to issue.
+fn normalized_ttl_ms(ttl: std::time::Duration) -> i64 {
+    let clamped = std::time::Duration::from_secs_f64(ttl.as_secs_f64().clamp(1.0, 86_400.0));
+    i64::try_from(clamped.as_millis()).unwrap_or(i64::MAX)
+}
+
+#[async_trait::async_trait]
+impl ExecutionTurnHandoff for PgTurnHandoff {
+    #[tracing::instrument(
+        level = "debug",
+        name = "turn_handoff.accept_turn",
+        skip(self, handoff),
+        fields(
+            backend = "postgres",
+            execution_id = handoff.execution_id,
+            claim_generation = handoff.claim.generation().get(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn accept_turn(&self, handoff: &TurnHandoff<'_>) -> Result<TurnAcceptance, StorageError> {
+        let ttl_ms = normalized_ttl_ms(handoff.lease_ttl);
+        let result = async {
+            let mut tx = self.pool.begin().await.map_err(conn_err)?;
+
+            // `SELECT 1` is INT4 in PostgreSQL, not INT8: decoding it as i64
+            // fails at the driver. The probe only needs existence, so the
+            // narrow type is also the honest one.
+            let still_claimed: Option<i32> = sqlx::query_scalar(
+                "SELECT 1 FROM port_job_dispatch_queue \
+                 WHERE id = $1 AND status = 'Processing' AND claim_generation = $2 \
+                 FOR UPDATE",
+            )
+            .bind(handoff.claim.row_id().as_slice())
+            .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+            if still_claimed.is_none() {
+                drop(tx.rollback().await);
+                return Ok(TurnAcceptance::ClaimSuperseded);
+            }
+
+            // Same statement shape as `acquire_lease`: the database decides
+            // live-vs-expired and stamps the deadline, so a caller's clock
+            // cannot fence out a healthy peer or mint an already-dead lease.
+            let acquired: Option<i64> = sqlx::query_scalar(
+                "UPDATE port_executions \
+                 SET lease_holder = $1, \
+                     lease_expires_at_ms = \
+                         (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint + $2, \
+                     fencing_generation = fencing_generation + 1 \
+                 WHERE id = $3 AND workspace_id = $4 AND org_id = $5 \
+                   AND (lease_expires_at_ms IS NULL \
+                        OR lease_expires_at_ms \
+                           < (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint) \
+                 RETURNING fencing_generation",
+            )
+            .bind(handoff.holder)
+            .bind(ttl_ms)
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+
+            let Some(generation) = acquired else {
+                // Either a live lease blocks the turn, or the execution does
+                // not exist in this tenant. Distinguishing them costs one read
+                // and is worth it: a caller must not treat a missing execution
+                // as contention it can wait out.
+                let exists: Option<i32> = sqlx::query_scalar(
+                    "SELECT 1 FROM port_executions \
+                     WHERE id = $1 AND workspace_id = $2 AND org_id = $3",
+                )
+                .bind(handoff.execution_id)
+                .bind(&handoff.scope.workspace_id)
+                .bind(&handoff.scope.org_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(conn_err)?;
+                drop(tx.rollback().await);
+                return if exists.is_some() {
+                    // The queue row stays claimed on purpose: acknowledging it
+                    // would make it terminal while no owner ever ran the turn.
+                    Ok(TurnAcceptance::TurnHeldByAnotherOwner)
+                } else {
+                    Err(StorageError::not_found("execution", handoff.execution_id))
+                };
+            };
+
+            sqlx::query(
+                "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
+                 WHERE id = $1 AND status = 'Processing' AND claim_generation = $2",
+            )
+            .bind(handoff.claim.row_id().as_slice())
+            .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .execute(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+
+            tx.commit().await.map_err(conn_err)?;
+            Ok(TurnAcceptance::Accepted {
+                fence: FencingToken::from_generation(u64::try_from(generation).unwrap_or_default()),
+            })
+        }
+        .await;
+
+        let outcome = acceptance_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            outcome,
+            "dispatch claim handed off to an execution turn"
+        );
+        result
+    }
+}

--- a/crates/storage/src/postgres/turn_handoff.rs
+++ b/crates/storage/src/postgres/turn_handoff.rs
@@ -65,12 +65,20 @@ impl ExecutionTurnHandoff for PgTurnHandoff {
             // fails at the driver. The probe only needs existence, so the
             // narrow type is also the honest one.
             let still_claimed: Option<i32> = sqlx::query_scalar(
+                // The row must belong to the execution and tenant this handoff
+                // names. A valid token from one job paired with another
+                // execution id would otherwise lease the wrong aggregate and
+                // acknowledge — dropping — the job that was actually claimed.
                 "SELECT 1 FROM port_job_dispatch_queue \
                  WHERE id = $1 AND status = 'Processing' AND claim_generation = $2 \
+                   AND execution_id = $3 AND workspace_id = $4 AND org_id = $5 \
                  FOR UPDATE",
             )
             .bind(handoff.claim.row_id().as_slice())
             .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
             .fetch_optional(&mut *tx)
             .await
             .map_err(conn_err)?;
@@ -130,10 +138,14 @@ impl ExecutionTurnHandoff for PgTurnHandoff {
 
             sqlx::query(
                 "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
-                 WHERE id = $1 AND status = 'Processing' AND claim_generation = $2",
+                 WHERE id = $1 AND status = 'Processing' AND claim_generation = $2 \
+                   AND execution_id = $3 AND workspace_id = $4 AND org_id = $5",
             )
             .bind(handoff.claim.row_id().as_slice())
             .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
             .execute(&mut *tx)
             .await
             .map_err(conn_err)?;

--- a/crates/storage/src/postgres/turn_handoff.rs
+++ b/crates/storage/src/postgres/turn_handoff.rs
@@ -151,8 +151,18 @@ impl ExecutionTurnHandoff for PgTurnHandoff {
             .map_err(conn_err)?;
 
             tx.commit().await.map_err(conn_err)?;
+            // A negative generation here would mean the monotone column was
+            // written out of band — fail closed with a typed error rather
+            // than handing out fence 0 (the lowest possible value, which a
+            // stale token compares against as at least as new).
+            let generation = u64::try_from(generation).map_err(|_| {
+                StorageError::Internal(format!(
+                    "fencing_generation out of u64 range for execution {}: {generation}",
+                    handoff.execution_id
+                ))
+            })?;
             Ok(TurnAcceptance::Accepted {
-                fence: FencingToken::from_generation(u64::try_from(generation).unwrap_or_default()),
+                fence: FencingToken::from_generation(generation),
             })
         }
         .await;

--- a/crates/storage/src/sqlite/mod.rs
+++ b/crates/storage/src/sqlite/mod.rs
@@ -22,6 +22,7 @@ mod plan_flavor_catalog;
 mod resume_producer;
 mod resume_token;
 mod start_acceptance;
+mod turn_handoff;
 mod workflow;
 
 pub use control_queue::{SqliteControlQueue, SqliteJournalReader};
@@ -37,6 +38,7 @@ pub use plan_flavor_catalog::SqlitePlanFlavorCatalog;
 pub use resume_producer::SqliteResumeProducer;
 pub use resume_token::SqliteResumeTokenStore;
 pub use start_acceptance::SqliteStartAcceptanceStore;
+pub use turn_handoff::SqliteTurnHandoff;
 pub use workflow::{SqliteWorkflowStore, SqliteWorkflowVersionStore};
 
 /// Admit a canonical schema and apply every pending ordered migration under

--- a/crates/storage/src/sqlite/turn_handoff.rs
+++ b/crates/storage/src/sqlite/turn_handoff.rs
@@ -1,0 +1,155 @@
+//! SQLite dispatch-claim → execution-turn handoff.
+//!
+//! The claim re-check, the lease acquisition, and the queue acknowledgement are
+//! three statements in **one** `BEGIN IMMEDIATE` transaction, so a crash can
+//! only land on one side of it: either the row is still `Processing` and no
+//! turn was accepted, or the row is acknowledged and the execution holds the
+//! lease that governs the work.
+//!
+//! The database stamps the lease deadline, exactly as `acquire_lease` does.
+//! There is one rule for lease time across all three backends, so a lease
+//! cannot mean something different depending on which adapter is wired.
+
+use nebula_storage_port::store::{ExecutionTurnHandoff, TurnAcceptance, TurnHandoff};
+use nebula_storage_port::{FencingToken, StorageError};
+use sqlx::SqlitePool;
+
+use crate::inmem::acceptance_label;
+use crate::sqlite::execution::conn_err;
+
+/// SQLite-backed owner of the dispatch-claim → execution-turn handoff.
+#[derive(Clone, Debug)]
+pub struct SqliteTurnHandoff {
+    pool: SqlitePool,
+}
+
+impl SqliteTurnHandoff {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Clamp the lease TTL exactly as the execution store does, so a handoff cannot
+/// mint a lease the store itself would have refused to issue.
+fn normalized_ttl_ms(ttl: std::time::Duration) -> i64 {
+    let clamped = std::time::Duration::from_secs_f64(ttl.as_secs_f64().clamp(1.0, 86_400.0));
+    i64::try_from(clamped.as_millis()).unwrap_or(i64::MAX)
+}
+
+#[async_trait::async_trait]
+impl ExecutionTurnHandoff for SqliteTurnHandoff {
+    #[tracing::instrument(
+        level = "debug",
+        name = "turn_handoff.accept_turn",
+        skip(self, handoff),
+        fields(
+            backend = "sqlite",
+            execution_id = handoff.execution_id,
+            claim_generation = handoff.claim.generation().get(),
+            outcome = tracing::field::Empty,
+        )
+    )]
+    async fn accept_turn(&self, handoff: &TurnHandoff<'_>) -> Result<TurnAcceptance, StorageError> {
+        let ttl_ms = normalized_ttl_ms(handoff.lease_ttl);
+        let result = async {
+            // The write lock is taken up front: the claim re-check decides
+            // whether the lease may be acquired, and a deferred transaction
+            // would let a reclaim sweep move the row in between.
+            let mut tx = self
+                .pool
+                .begin_with("BEGIN IMMEDIATE")
+                .await
+                .map_err(conn_err)?;
+
+            let still_claimed: Option<i64> = sqlx::query_scalar(
+                "SELECT 1 FROM port_job_dispatch_queue \
+                 WHERE id = ? AND status = 'Processing' AND claim_generation = ?",
+            )
+            .bind(handoff.claim.row_id().as_slice())
+            .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+            if still_claimed.is_none() {
+                drop(tx.rollback().await);
+                return Ok(TurnAcceptance::ClaimSuperseded);
+            }
+
+            // Same statement shape as `acquire_lease`: the database decides
+            // live-vs-expired and stamps the deadline, so a caller's clock
+            // cannot fence out a healthy peer or mint an already-dead lease.
+            let acquired: Option<i64> = sqlx::query_scalar(
+                "UPDATE port_executions \
+                 SET lease_holder = ?, \
+                     lease_expires_at_ms = \
+                         CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER) + ?, \
+                     fencing_generation = fencing_generation + 1 \
+                 WHERE id = ? AND workspace_id = ? AND org_id = ? \
+                   AND (lease_expires_at_ms IS NULL \
+                        OR lease_expires_at_ms \
+                           < CAST((julianday('now') - 2440587.5) * 86400000.0 AS INTEGER)) \
+                 RETURNING fencing_generation",
+            )
+            .bind(handoff.holder)
+            .bind(ttl_ms)
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+
+            let Some(generation) = acquired else {
+                // Either a live lease blocks the turn, or the execution does
+                // not exist in this tenant. Distinguishing them costs one read
+                // and is worth it: a caller must not treat a missing execution
+                // as contention it can wait out.
+                let exists: Option<i64> = sqlx::query_scalar(
+                    "SELECT 1 FROM port_executions \
+                     WHERE id = ? AND workspace_id = ? AND org_id = ?",
+                )
+                .bind(handoff.execution_id)
+                .bind(&handoff.scope.workspace_id)
+                .bind(&handoff.scope.org_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(conn_err)?;
+                drop(tx.rollback().await);
+                return if exists.is_some() {
+                    // The queue row stays claimed on purpose: acknowledging it
+                    // would make it terminal while no owner ever ran the turn.
+                    Ok(TurnAcceptance::TurnHeldByAnotherOwner)
+                } else {
+                    Err(StorageError::not_found("execution", handoff.execution_id))
+                };
+            };
+
+            sqlx::query(
+                "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
+                 WHERE id = ? AND status = 'Processing' AND claim_generation = ?",
+            )
+            .bind(handoff.claim.row_id().as_slice())
+            .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .execute(&mut *tx)
+            .await
+            .map_err(conn_err)?;
+
+            tx.commit().await.map_err(conn_err)?;
+            Ok(TurnAcceptance::Accepted {
+                fence: FencingToken::from_generation(u64::try_from(generation).unwrap_or_default()),
+            })
+        }
+        .await;
+
+        let outcome = acceptance_label(&result);
+        tracing::Span::current().record("outcome", outcome);
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            outcome,
+            "dispatch claim handed off to an execution turn"
+        );
+        result
+    }
+}

--- a/crates/storage/src/sqlite/turn_handoff.rs
+++ b/crates/storage/src/sqlite/turn_handoff.rs
@@ -64,11 +64,19 @@ impl ExecutionTurnHandoff for SqliteTurnHandoff {
                 .map_err(conn_err)?;
 
             let still_claimed: Option<i64> = sqlx::query_scalar(
+                // The row must belong to the execution and tenant this handoff
+                // names. A valid token from one job paired with another
+                // execution id would otherwise lease the wrong aggregate and
+                // acknowledge — dropping — the job that was actually claimed.
                 "SELECT 1 FROM port_job_dispatch_queue \
-                 WHERE id = ? AND status = 'Processing' AND claim_generation = ?",
+                 WHERE id = ? AND status = 'Processing' AND claim_generation = ? \
+                   AND execution_id = ? AND workspace_id = ? AND org_id = ?",
             )
             .bind(handoff.claim.row_id().as_slice())
             .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
             .fetch_optional(&mut *tx)
             .await
             .map_err(conn_err)?;
@@ -128,10 +136,14 @@ impl ExecutionTurnHandoff for SqliteTurnHandoff {
 
             sqlx::query(
                 "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
-                 WHERE id = ? AND status = 'Processing' AND claim_generation = ?",
+                 WHERE id = ? AND status = 'Processing' AND claim_generation = ? \
+                   AND execution_id = ? AND workspace_id = ? AND org_id = ?",
             )
             .bind(handoff.claim.row_id().as_slice())
             .bind(i64::try_from(handoff.claim.generation().get()).unwrap_or(i64::MAX))
+            .bind(handoff.execution_id)
+            .bind(&handoff.scope.workspace_id)
+            .bind(&handoff.scope.org_id)
             .execute(&mut *tx)
             .await
             .map_err(conn_err)?;

--- a/crates/storage/src/sqlite/turn_handoff.rs
+++ b/crates/storage/src/sqlite/turn_handoff.rs
@@ -149,8 +149,18 @@ impl ExecutionTurnHandoff for SqliteTurnHandoff {
             .map_err(conn_err)?;
 
             tx.commit().await.map_err(conn_err)?;
+            // A negative generation here would mean the monotone column was
+            // written out of band — fail closed with a typed error rather
+            // than handing out fence 0 (the lowest possible value, which a
+            // stale token compares against as at least as new).
+            let generation = u64::try_from(generation).map_err(|_| {
+                StorageError::Internal(format!(
+                    "fencing_generation out of u64 range for execution {}: {generation}",
+                    handoff.execution_id
+                ))
+            })?;
             Ok(TurnAcceptance::Accepted {
-                fence: FencingToken::from_generation(u64::try_from(generation).unwrap_or_default()),
+                fence: FencingToken::from_generation(generation),
             })
         }
         .await;

--- a/crates/storage/tests/turn_handoff_conformance_inmem.rs
+++ b/crates/storage/tests/turn_handoff_conformance_inmem.rs
@@ -1,0 +1,225 @@
+//! Dispatch-claim → execution-turn handoff conformance (in-memory reference).
+//!
+//! The property NS05 turns on is that an action's duration never extends the
+//! dispatch claim. These cases prove the claim is *finished* at handoff, so
+//! there is nothing left to extend.
+
+use std::time::Duration;
+
+use nebula_core::PluginKey;
+use nebula_storage::inmem::{
+    InMemoryExecutionStore, InMemoryJobDispatchQueue, InMemoryTurnHandoff,
+};
+use nebula_storage_port::dto::{ControlCommand, JobDispatchMsg};
+use nebula_storage_port::store::{
+    ExecutionStore, ExecutionTurnHandoff, JobDispatchQueue, TurnAcceptance, TurnHandoff,
+};
+use nebula_storage_port::{Scope, StorageError};
+
+const TTL: Duration = Duration::from_secs(30);
+
+/// Processor identities are observability labels; the claim token carries the
+/// authority, so two distinct processors is all these cases need.
+const PROCESSOR_A: [u8; 16] = [0xa1; 16];
+const PROCESSOR_B: [u8; 16] = [0xb2; 16];
+
+fn scope() -> Scope {
+    Scope::new("ws-handoff", "org-handoff")
+}
+
+struct Fixture {
+    store: InMemoryExecutionStore,
+    queue: InMemoryJobDispatchQueue,
+    handoff: InMemoryTurnHandoff,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let store = InMemoryExecutionStore::new();
+        let queue = InMemoryJobDispatchQueue::new(&store);
+        let handoff = InMemoryTurnHandoff::new(&store);
+        Self {
+            store,
+            queue,
+            handoff,
+        }
+    }
+
+    async fn seed(&self, execution_id: &str) -> nebula_storage_port::store::JobClaimToken {
+        self.store
+            .create(&scope(), execution_id, "wf", serde_json::json!({}))
+            .await
+            .expect("the execution row is created");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let msg = JobDispatchMsg::new(
+            *uuid::Uuid::new_v4().as_bytes(),
+            execution_id.to_owned(),
+            ControlCommand::Start,
+            scope(),
+            serde_json::json!({}),
+            None::<String>,
+            "flavor-sha",
+            plugin.clone(),
+            vec![plugin],
+            None::<String>,
+            0,
+        );
+        self.queue.enqueue(&msg).await.expect("the job enqueues");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let claimed = self
+            .queue
+            .claim_pending(&PROCESSOR_A, 1, &[plugin])
+            .await
+            .expect("the job is claimable");
+        claimed
+            .into_iter()
+            .next()
+            .expect("exactly one job was claimable")
+            .token
+    }
+
+    fn request<'a>(
+        &self,
+        execution_id: &'a str,
+        claim: nebula_storage_port::store::JobClaimToken,
+        holder: &'a str,
+        scope_ref: &'a Scope,
+    ) -> TurnHandoff<'a> {
+        TurnHandoff {
+            scope: scope_ref,
+            execution_id,
+            claim,
+            holder,
+            lease_ttl: TTL,
+        }
+    }
+}
+
+/// The happy path: the turn is owned and the claim is finished in one commit.
+#[tokio::test]
+async fn accepting_a_turn_acknowledges_the_claim_in_one_commit() {
+    let fixture = Fixture::new();
+    let scope = scope();
+    let execution = "exe-accept";
+    let claim = fixture.seed(execution).await;
+
+    let accepted = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("a fresh claim on an unleased execution hands off");
+    let TurnAcceptance::Accepted { fence } = accepted else {
+        panic!("expected an accepted turn, got {accepted:?}");
+    };
+    assert!(
+        fence.generation() > 0,
+        "an accepted turn must carry a live fence"
+    );
+
+    // The claim is already terminal, so nothing about the action's duration
+    // can extend it — acknowledging again is refused.
+    assert!(matches!(
+        fixture.queue.mark_dispatched(&claim).await,
+        Err(StorageError::FencedOut { .. } | StorageError::NotFound { .. })
+    ));
+}
+
+/// A superseded claim cannot take the turn, and writes nothing.
+#[tokio::test]
+async fn a_superseded_claim_cannot_accept_the_turn() {
+    let fixture = Fixture::new();
+    let scope = scope();
+    let execution = "exe-superseded";
+    let stale = fixture.seed(execution).await;
+
+    // A reclaim sweep hands the row to someone else, bumping the generation.
+    fixture
+        .queue
+        .reclaim_stuck(Duration::from_secs(0), 8)
+        .await
+        .expect("the sweep runs");
+    let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+    let fresh = fixture
+        .queue
+        .claim_pending(&PROCESSOR_B, 1, &[plugin])
+        .await
+        .expect("the reclaimed job is claimable again");
+    assert_eq!(fresh.len(), 1, "the sweep returned the row to the queue");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, stale, "worker-a", &scope))
+            .await
+            .expect("a superseded claim is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
+
+    // Nothing was written: the execution still has no lease, so the current
+    // claim holder can still take the turn.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(
+            execution,
+            fresh.into_iter().next().expect("one job").token,
+            "worker-b",
+            &scope,
+        ))
+        .await
+        .expect("the current claim holder can take the turn");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a rejected handoff must leave the execution takeable, got {taken:?}"
+    );
+}
+
+/// A live lease held by another owner blocks the turn and leaves the queue row
+/// claimable, so the work is redelivered rather than dropped.
+#[tokio::test]
+async fn a_live_foreign_lease_blocks_the_turn_without_acknowledging_the_row() {
+    let fixture = Fixture::new();
+    let scope = scope();
+    let execution = "exe-contended";
+    let claim = fixture.seed(execution).await;
+
+    fixture
+        .store
+        .acquire_lease(&scope, execution, "worker-z", TTL)
+        .await
+        .expect("the competing lease is acquirable")
+        .expect("no lease existed yet");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+            .await
+            .expect("contention is a typed outcome, not an error"),
+        TurnAcceptance::TurnHeldByAnotherOwner
+    );
+
+    // The row was NOT acknowledged: acknowledging would make it terminal while
+    // no owner ever ran the turn.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claim still owns a live row");
+}
+
+/// A handoff for another tenant's execution is refused.
+#[tokio::test]
+async fn a_foreign_tenant_cannot_accept_the_turn() {
+    let fixture = Fixture::new();
+    let execution = "exe-tenant";
+    let claim = fixture.seed(execution).await;
+    let intruder = Scope::new("ws-other", "org-other");
+
+    assert!(matches!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
+            .await,
+        Err(StorageError::NotFound { .. })
+    ));
+}

--- a/crates/storage/tests/turn_handoff_conformance_inmem.rs
+++ b/crates/storage/tests/turn_handoff_conformance_inmem.rs
@@ -211,6 +211,7 @@ async fn a_live_foreign_lease_blocks_the_turn_without_acknowledging_the_row() {
 #[tokio::test]
 async fn a_foreign_tenant_cannot_accept_the_turn() {
     let fixture = Fixture::new();
+    let scope = scope();
     let execution = "exe-tenant";
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
@@ -226,6 +227,19 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
             .await
             .expect("a foreign tenant is a typed outcome, not an error"),
         TurnAcceptance::ClaimSuperseded
+    );
+
+    // The refusal wrote nothing: the original handoff, retried with its own
+    // scope and claim, is still accepted — the claim was not consumed and the
+    // execution was not leased under the foreign scope.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("the original handoff still runs after the foreign refusal");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a foreign-tenant refusal must leave the original claim intact, got {taken:?}"
     );
 }
 

--- a/crates/storage/tests/turn_handoff_conformance_inmem.rs
+++ b/crates/storage/tests/turn_handoff_conformance_inmem.rs
@@ -215,11 +215,59 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
 
-    assert!(matches!(
+    // The claim predicate carries the tenant, so a foreign scope fails there
+    // first and answers `ClaimSuperseded` rather than reporting anything about
+    // the execution. That is the stronger reply: it does not reveal whether the
+    // execution exists in some other tenant.
+    assert_eq!(
         fixture
             .handoff
             .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
-            .await,
-        Err(StorageError::NotFound { .. })
-    ));
+            .await
+            .expect("a foreign tenant is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
+}
+
+/// A claim token is authority over *one* row, not a bearer pass.
+///
+/// Pairing a valid token from one job with a different execution id would
+/// otherwise lease the wrong aggregate and acknowledge — dropping — the job
+/// that was actually claimed.
+#[tokio::test]
+async fn a_claim_token_cannot_be_paired_with_another_execution() {
+    let fixture = Fixture::new();
+    let scope = scope();
+    let claimed = "exe-claimed";
+    let other = "exe-other";
+    let claim = fixture.seed(claimed).await;
+    fixture
+        .store
+        .create(&scope, other, "wf", serde_json::json!({}))
+        .await
+        .expect("the second execution row is created");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(other, claim, "worker-a", &scope))
+            .await
+            .expect("a mismatched pairing is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded,
+        "a token proves ownership of one row, so it cannot drive another execution"
+    );
+
+    // Neither side moved: the claimed row is still acknowledgeable, and the
+    // unrelated execution was never leased.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claimed row is untouched");
+    fixture
+        .store
+        .acquire_lease(&scope, other, "worker-b", TTL)
+        .await
+        .expect("the unrelated execution is reachable")
+        .expect("the unrelated execution was never leased");
 }

--- a/crates/storage/tests/turn_handoff_conformance_postgres.rs
+++ b/crates/storage/tests/turn_handoff_conformance_postgres.rs
@@ -201,7 +201,7 @@ async fn a_superseded_claim_cannot_accept_the_turn() {
     let stale = fixture.seed(execution).await;
 
     // Age the claim so the sweep is guaranteed to see it, rather than racing
-    // the clock. SQLite's reclaim predicate is `processed_at_ms < cutoff`
+    // the clock. Postgres's reclaim predicate is `processed_at_ms < cutoff`
     // (strict) while the in-memory model uses `elapsed >= reclaim_after`
     // (inclusive), so a zero window reclaims immediately on one backend and
     // never on the other — a boundary divergence worth naming, and one this
@@ -299,6 +299,7 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
         eprintln!("PostgreSQL unreachable in this environment");
         return;
     };
+    let scope = scope();
     let execution = &unique("tenant");
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
@@ -315,4 +316,63 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
             .expect("a foreign tenant is a typed outcome, not an error"),
         TurnAcceptance::ClaimSuperseded
     );
+
+    // The refusal wrote nothing: the original handoff, retried with its own
+    // scope and claim, is still accepted — the claim was not consumed and the
+    // execution was not leased under the foreign scope.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("the original handoff still runs after the foreign refusal");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a foreign-tenant refusal must leave the original claim intact, got {taken:?}"
+    );
+}
+
+/// A claim token is authority over *one* row, not a bearer pass.
+///
+/// Pairing a valid token from one job with a different execution id would
+/// otherwise lease the wrong aggregate and acknowledge — dropping — the job
+/// that was actually claimed.
+#[tokio::test]
+async fn a_claim_token_cannot_be_paired_with_another_execution() {
+    let Some(fixture) = Fixture::new().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let scope = scope();
+    let claimed = unique("claimed");
+    let other = unique("other");
+    let claim = fixture.seed(&claimed).await;
+    fixture
+        .store
+        .create(&scope, &other, "wf", serde_json::json!({}))
+        .await
+        .expect("the second execution row is created");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(&other, claim, "worker-a", &scope))
+            .await
+            .expect("a mismatched pairing is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded,
+        "a token proves ownership of one row, so it cannot drive another execution"
+    );
+
+    // Neither side moved: the claimed row is still acknowledgeable, and the
+    // unrelated execution was never leased.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claimed row is untouched");
+    fixture
+        .store
+        .acquire_lease(&scope, &other, "worker-b", TTL)
+        .await
+        .expect("the unrelated execution is reachable")
+        .expect("the unrelated execution was never leased");
 }

--- a/crates/storage/tests/turn_handoff_conformance_postgres.rs
+++ b/crates/storage/tests/turn_handoff_conformance_postgres.rs
@@ -95,12 +95,25 @@ impl Fixture {
         })
     }
 
+    /// A plugin key unique to one execution.
+    ///
+    /// The required PostgreSQL job runs against a shared `DATABASE_URL`, so a
+    /// shared routing key would let `claim_pending` return another case's
+    /// pending row. Binding the key to the execution keeps each case claiming
+    /// only what it enqueued.
+    fn plugin_for(execution_id: &str) -> PluginKey {
+        execution_id
+            .replace('-', "")
+            .parse()
+            .expect("a hex execution id is a valid plugin key")
+    }
+
     async fn seed(&self, execution_id: &str) -> nebula_storage_port::store::JobClaimToken {
         self.store
             .create(&scope(), execution_id, "wf", serde_json::json!({}))
             .await
             .expect("the execution row is created");
-        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let plugin = Self::plugin_for(execution_id);
         let msg = JobDispatchMsg::new(
             *uuid::Uuid::new_v4().as_bytes(),
             execution_id.to_owned(),
@@ -115,10 +128,9 @@ impl Fixture {
             0,
         );
         self.queue.enqueue(&msg).await.expect("the job enqueues");
-        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
         let claimed = self
             .queue
-            .claim_pending(&PROCESSOR_A, 1, &[plugin])
+            .claim_pending(&PROCESSOR_A, 1, &[Self::plugin_for(execution_id)])
             .await
             .expect("the job is claimable");
         claimed
@@ -195,8 +207,10 @@ async fn a_superseded_claim_cannot_accept_the_turn() {
     // never on the other — a boundary divergence worth naming, and one this
     // test must not depend on either way.
     sqlx::query(
-        "UPDATE port_job_dispatch_queue SET processed_at_ms = 0 WHERE status = 'Processing'",
+        "UPDATE port_job_dispatch_queue SET processed_at_ms = 0 \
+         WHERE status = 'Processing' AND execution_id = $1",
     )
+    .bind(execution)
     .execute(&fixture.pool)
     .await
     .expect("the claim is backdated");
@@ -207,10 +221,9 @@ async fn a_superseded_claim_cannot_accept_the_turn() {
         .reclaim_stuck(Duration::from_secs(0), 8)
         .await
         .expect("the sweep runs");
-    let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
     let fresh = fixture
         .queue
-        .claim_pending(&PROCESSOR_B, 1, &[plugin])
+        .claim_pending(&PROCESSOR_B, 1, &[Fixture::plugin_for(execution)])
         .await
         .expect("the reclaimed job is claimable again");
     assert_eq!(fresh.len(), 1, "the sweep returned the row to the queue");
@@ -290,11 +303,16 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
 
-    assert!(matches!(
+    // The claim predicate carries the tenant, so a foreign scope fails there
+    // first and answers `ClaimSuperseded` rather than reporting anything about
+    // the execution. That is the stronger reply: it does not reveal whether the
+    // execution exists in some other tenant.
+    assert_eq!(
         fixture
             .handoff
             .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
-            .await,
-        Err(StorageError::NotFound { .. })
-    ));
+            .await
+            .expect("a foreign tenant is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
 }

--- a/crates/storage/tests/turn_handoff_conformance_postgres.rs
+++ b/crates/storage/tests/turn_handoff_conformance_postgres.rs
@@ -1,0 +1,300 @@
+//! Dispatch-claim → execution-turn handoff conformance (PostgreSQL backend).
+//!
+//! PostgreSQL is a deployment backend, so its absence is a job failure rather
+//! than a silent substitution: with `NEBULA_REQUIRE_POSTGRES=1` and no
+//! `DATABASE_URL`, every case fails.
+//!
+//! The property NS05 turns on is that an action's duration never extends the
+//! dispatch claim. These cases prove the claim is *finished* at handoff, so
+//! there is nothing left to extend.
+
+#![cfg(feature = "postgres")]
+
+use std::time::Duration;
+
+use nebula_core::PluginKey;
+
+use nebula_storage::postgres::{PgExecutionStore, PgJobDispatchQueue, PgTurnHandoff, init_schema};
+use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use tokio::sync::OnceCell;
+
+static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
+use nebula_storage_port::dto::{ControlCommand, JobDispatchMsg};
+use nebula_storage_port::store::{
+    ExecutionStore, ExecutionTurnHandoff, JobDispatchQueue, TurnAcceptance, TurnHandoff,
+};
+use nebula_storage_port::{Scope, StorageError};
+
+const TTL: Duration = Duration::from_secs(30);
+
+/// Processor identities are observability labels; the claim token carries the
+/// authority, so two distinct processors is all these cases need.
+const PROCESSOR_A: [u8; 16] = [0xa1; 16];
+const PROCESSOR_B: [u8; 16] = [0xb2; 16];
+
+/// Execution ids unique per process, so cases share one database without
+/// meeting an earlier run's rows.
+fn unique(label: &str) -> String {
+    format!("exe-{label}-{}", uuid::Uuid::new_v4().simple())
+}
+
+fn scope() -> Scope {
+    Scope::new("ws-handoff", "org-handoff")
+}
+
+/// Connect to `DATABASE_URL` and apply the ordered migration catalog, or report
+/// that PostgreSQL is unreachable.
+async fn fresh_pool() -> Option<PgPool> {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(std::env::VarError::NotPresent) => {
+            assert_ne!(
+                std::env::var("NEBULA_REQUIRE_POSTGRES").as_deref(),
+                Ok("1"),
+                "DATABASE_URL must be set when NEBULA_REQUIRE_POSTGRES=1: \
+                 PostgreSQL is a deployment backend and is never substituted"
+            );
+            return None;
+        },
+        Err(error) => panic!("DATABASE_URL is set but invalid: {error}"),
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+    SCHEMA_READY
+        .get_or_init(|| async {
+            init_schema(&pool)
+                .await
+                .expect("apply the ordered PostgreSQL migration catalog");
+        })
+        .await;
+    Some(pool)
+}
+
+struct Fixture {
+    store: PgExecutionStore,
+    queue: PgJobDispatchQueue,
+    handoff: PgTurnHandoff,
+    pool: PgPool,
+}
+
+impl Fixture {
+    async fn new() -> Option<Self> {
+        let pool = fresh_pool().await?;
+        let store = PgExecutionStore::new(pool.clone());
+        let queue = PgJobDispatchQueue::new(pool.clone());
+        let handoff = PgTurnHandoff::new(pool.clone());
+        Some(Self {
+            store,
+            queue,
+            handoff,
+            pool,
+        })
+    }
+
+    async fn seed(&self, execution_id: &str) -> nebula_storage_port::store::JobClaimToken {
+        self.store
+            .create(&scope(), execution_id, "wf", serde_json::json!({}))
+            .await
+            .expect("the execution row is created");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let msg = JobDispatchMsg::new(
+            *uuid::Uuid::new_v4().as_bytes(),
+            execution_id.to_owned(),
+            ControlCommand::Start,
+            scope(),
+            serde_json::json!({}),
+            None::<String>,
+            "flavor-sha",
+            plugin.clone(),
+            vec![plugin],
+            None::<String>,
+            0,
+        );
+        self.queue.enqueue(&msg).await.expect("the job enqueues");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let claimed = self
+            .queue
+            .claim_pending(&PROCESSOR_A, 1, &[plugin])
+            .await
+            .expect("the job is claimable");
+        claimed
+            .into_iter()
+            .next()
+            .expect("exactly one job was claimable")
+            .token
+    }
+
+    fn request<'a>(
+        &self,
+        execution_id: &'a str,
+        claim: nebula_storage_port::store::JobClaimToken,
+        holder: &'a str,
+        scope_ref: &'a Scope,
+    ) -> TurnHandoff<'a> {
+        TurnHandoff {
+            scope: scope_ref,
+            execution_id,
+            claim,
+            holder,
+            lease_ttl: TTL,
+        }
+    }
+}
+
+/// The happy path: the turn is owned and the claim is finished in one commit.
+#[tokio::test]
+async fn accepting_a_turn_acknowledges_the_claim_in_one_commit() {
+    let Some(fixture) = Fixture::new().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let scope = scope();
+    let execution = &unique("accept");
+    let claim = fixture.seed(execution).await;
+
+    let accepted = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("a fresh claim on an unleased execution hands off");
+    let TurnAcceptance::Accepted { fence } = accepted else {
+        panic!("expected an accepted turn, got {accepted:?}");
+    };
+    assert!(
+        fence.generation() > 0,
+        "an accepted turn must carry a live fence"
+    );
+
+    // The claim is already terminal, so nothing about the action's duration
+    // can extend it — acknowledging again is refused.
+    assert!(matches!(
+        fixture.queue.mark_dispatched(&claim).await,
+        Err(StorageError::FencedOut { .. } | StorageError::NotFound { .. })
+    ));
+}
+
+/// A superseded claim cannot take the turn, and writes nothing.
+#[tokio::test]
+async fn a_superseded_claim_cannot_accept_the_turn() {
+    let Some(fixture) = Fixture::new().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let scope = scope();
+    let execution = &unique("superseded");
+    let stale = fixture.seed(execution).await;
+
+    // Age the claim so the sweep is guaranteed to see it, rather than racing
+    // the clock. SQLite's reclaim predicate is `processed_at_ms < cutoff`
+    // (strict) while the in-memory model uses `elapsed >= reclaim_after`
+    // (inclusive), so a zero window reclaims immediately on one backend and
+    // never on the other — a boundary divergence worth naming, and one this
+    // test must not depend on either way.
+    sqlx::query(
+        "UPDATE port_job_dispatch_queue SET processed_at_ms = 0 WHERE status = 'Processing'",
+    )
+    .execute(&fixture.pool)
+    .await
+    .expect("the claim is backdated");
+
+    // A reclaim sweep hands the row to someone else, bumping the generation.
+    fixture
+        .queue
+        .reclaim_stuck(Duration::from_secs(0), 8)
+        .await
+        .expect("the sweep runs");
+    let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+    let fresh = fixture
+        .queue
+        .claim_pending(&PROCESSOR_B, 1, &[plugin])
+        .await
+        .expect("the reclaimed job is claimable again");
+    assert_eq!(fresh.len(), 1, "the sweep returned the row to the queue");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, stale, "worker-a", &scope))
+            .await
+            .expect("a superseded claim is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
+
+    // Nothing was written: the execution still has no lease, so the current
+    // claim holder can still take the turn.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(
+            execution,
+            fresh.into_iter().next().expect("one job").token,
+            "worker-b",
+            &scope,
+        ))
+        .await
+        .expect("the current claim holder can take the turn");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a rejected handoff must leave the execution takeable, got {taken:?}"
+    );
+}
+
+/// A live lease held by another owner blocks the turn and leaves the queue row
+/// claimable, so the work is redelivered rather than dropped.
+#[tokio::test]
+async fn a_live_foreign_lease_blocks_the_turn_without_acknowledging_the_row() {
+    let Some(fixture) = Fixture::new().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let scope = scope();
+    let execution = &unique("contended");
+    let claim = fixture.seed(execution).await;
+
+    fixture
+        .store
+        .acquire_lease(&scope, execution, "worker-z", TTL)
+        .await
+        .expect("the competing lease is acquirable")
+        .expect("no lease existed yet");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+            .await
+            .expect("contention is a typed outcome, not an error"),
+        TurnAcceptance::TurnHeldByAnotherOwner
+    );
+
+    // The row was NOT acknowledged: acknowledging would make it terminal while
+    // no owner ever ran the turn.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claim still owns a live row");
+}
+
+/// A handoff for another tenant's execution is refused.
+#[tokio::test]
+async fn a_foreign_tenant_cannot_accept_the_turn() {
+    let Some(fixture) = Fixture::new().await else {
+        eprintln!("PostgreSQL unreachable in this environment");
+        return;
+    };
+    let execution = &unique("tenant");
+    let claim = fixture.seed(execution).await;
+    let intruder = Scope::new("ws-other", "org-other");
+
+    assert!(matches!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
+            .await,
+        Err(StorageError::NotFound { .. })
+    ));
+}

--- a/crates/storage/tests/turn_handoff_conformance_sqlite.rs
+++ b/crates/storage/tests/turn_handoff_conformance_sqlite.rs
@@ -251,6 +251,7 @@ async fn a_live_foreign_lease_blocks_the_turn_without_acknowledging_the_row() {
 #[tokio::test]
 async fn a_foreign_tenant_cannot_accept_the_turn() {
     let fixture = Fixture::new().await;
+    let scope = scope();
     let execution = "exe-tenant";
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
@@ -267,4 +268,60 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
             .expect("a foreign tenant is a typed outcome, not an error"),
         TurnAcceptance::ClaimSuperseded
     );
+
+    // The refusal wrote nothing: the original handoff, retried with its own
+    // scope and claim, is still accepted — the claim was not consumed and the
+    // execution was not leased under the foreign scope.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("the original handoff still runs after the foreign refusal");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a foreign-tenant refusal must leave the original claim intact, got {taken:?}"
+    );
+}
+
+/// A claim token is authority over *one* row, not a bearer pass.
+///
+/// Pairing a valid token from one job with a different execution id would
+/// otherwise lease the wrong aggregate and acknowledge — dropping — the job
+/// that was actually claimed.
+#[tokio::test]
+async fn a_claim_token_cannot_be_paired_with_another_execution() {
+    let fixture = Fixture::new().await;
+    let scope = scope();
+    let claimed = "exe-claimed";
+    let other = "exe-other";
+    let claim = fixture.seed(claimed).await;
+    fixture
+        .store
+        .create(&scope, other, "wf", serde_json::json!({}))
+        .await
+        .expect("the second execution row is created");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(other, claim, "worker-a", &scope))
+            .await
+            .expect("a mismatched pairing is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded,
+        "a token proves ownership of one row, so it cannot drive another execution"
+    );
+
+    // Neither side moved: the claimed row is still acknowledgeable, and the
+    // unrelated execution was never leased.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claimed row is untouched");
+    fixture
+        .store
+        .acquire_lease(&scope, other, "worker-b", TTL)
+        .await
+        .expect("the unrelated execution is reachable")
+        .expect("the unrelated execution was never leased");
 }

--- a/crates/storage/tests/turn_handoff_conformance_sqlite.rs
+++ b/crates/storage/tests/turn_handoff_conformance_sqlite.rs
@@ -1,0 +1,265 @@
+//! Dispatch-claim → execution-turn handoff conformance (SQLite backend).
+//!
+//! The property NS05 turns on is that an action's duration never extends the
+//! dispatch claim. These cases prove the claim is *finished* at handoff, so
+//! there is nothing left to extend.
+
+#![cfg(feature = "sqlite")]
+
+use std::time::Duration;
+
+use nebula_core::PluginKey;
+use std::str::FromStr;
+
+use nebula_storage::sqlite::{
+    SqliteExecutionStore, SqliteJobDispatchQueue, SqliteTurnHandoff, init_schema,
+};
+use nebula_storage_port::dto::{ControlCommand, JobDispatchMsg};
+use nebula_storage_port::store::{
+    ExecutionStore, ExecutionTurnHandoff, JobDispatchQueue, TurnAcceptance, TurnHandoff,
+};
+use nebula_storage_port::{Scope, StorageError};
+use sqlx::SqlitePool;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+const TTL: Duration = Duration::from_secs(30);
+
+/// Processor identities are observability labels; the claim token carries the
+/// authority, so two distinct processors is all these cases need.
+const PROCESSOR_A: [u8; 16] = [0xa1; 16];
+const PROCESSOR_B: [u8; 16] = [0xb2; 16];
+
+fn scope() -> Scope {
+    Scope::new("ws-handoff", "org-handoff")
+}
+
+/// An isolated in-memory database with the ordered migration catalog applied.
+async fn fresh_pool() -> SqlitePool {
+    let database = format!("nebula-handoff-{}", uuid::Uuid::new_v4());
+    let url = format!("sqlite:file:{database}?mode=memory&cache=shared");
+    let options = SqliteConnectOptions::from_str(&url)
+        .expect("in-memory SQLite URL must parse")
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(4)
+        .connect_with(options)
+        .await
+        .expect("connect to in-memory SQLite");
+    init_schema(&pool)
+        .await
+        .expect("apply the ordered SQLite migration catalog");
+    pool
+}
+
+struct Fixture {
+    store: SqliteExecutionStore,
+    queue: SqliteJobDispatchQueue,
+    handoff: SqliteTurnHandoff,
+    pool: SqlitePool,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let pool = fresh_pool().await;
+        let store = SqliteExecutionStore::new(pool.clone());
+        let queue = SqliteJobDispatchQueue::new(pool.clone());
+        let handoff = SqliteTurnHandoff::new(pool.clone());
+        Self {
+            store,
+            queue,
+            handoff,
+            pool,
+        }
+    }
+
+    async fn seed(&self, execution_id: &str) -> nebula_storage_port::store::JobClaimToken {
+        self.store
+            .create(&scope(), execution_id, "wf", serde_json::json!({}))
+            .await
+            .expect("the execution row is created");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let msg = JobDispatchMsg::new(
+            *uuid::Uuid::new_v4().as_bytes(),
+            execution_id.to_owned(),
+            ControlCommand::Start,
+            scope(),
+            serde_json::json!({}),
+            None::<String>,
+            "flavor-sha",
+            plugin.clone(),
+            vec![plugin],
+            None::<String>,
+            0,
+        );
+        self.queue.enqueue(&msg).await.expect("the job enqueues");
+        let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+        let claimed = self
+            .queue
+            .claim_pending(&PROCESSOR_A, 1, &[plugin])
+            .await
+            .expect("the job is claimable");
+        claimed
+            .into_iter()
+            .next()
+            .expect("exactly one job was claimable")
+            .token
+    }
+
+    fn request<'a>(
+        &self,
+        execution_id: &'a str,
+        claim: nebula_storage_port::store::JobClaimToken,
+        holder: &'a str,
+        scope_ref: &'a Scope,
+    ) -> TurnHandoff<'a> {
+        TurnHandoff {
+            scope: scope_ref,
+            execution_id,
+            claim,
+            holder,
+            lease_ttl: TTL,
+        }
+    }
+}
+
+/// The happy path: the turn is owned and the claim is finished in one commit.
+#[tokio::test]
+async fn accepting_a_turn_acknowledges_the_claim_in_one_commit() {
+    let fixture = Fixture::new().await;
+    let scope = scope();
+    let execution = "exe-accept";
+    let claim = fixture.seed(execution).await;
+
+    let accepted = fixture
+        .handoff
+        .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+        .await
+        .expect("a fresh claim on an unleased execution hands off");
+    let TurnAcceptance::Accepted { fence } = accepted else {
+        panic!("expected an accepted turn, got {accepted:?}");
+    };
+    assert!(
+        fence.generation() > 0,
+        "an accepted turn must carry a live fence"
+    );
+
+    // The claim is already terminal, so nothing about the action's duration
+    // can extend it — acknowledging again is refused.
+    assert!(matches!(
+        fixture.queue.mark_dispatched(&claim).await,
+        Err(StorageError::FencedOut { .. } | StorageError::NotFound { .. })
+    ));
+}
+
+/// A superseded claim cannot take the turn, and writes nothing.
+#[tokio::test]
+async fn a_superseded_claim_cannot_accept_the_turn() {
+    let fixture = Fixture::new().await;
+    let scope = scope();
+    let execution = "exe-superseded";
+    let stale = fixture.seed(execution).await;
+
+    // Age the claim so the sweep is guaranteed to see it, rather than racing
+    // the clock. SQLite's reclaim predicate is `processed_at_ms < cutoff`
+    // (strict) while the in-memory model uses `elapsed >= reclaim_after`
+    // (inclusive), so a zero window reclaims immediately on one backend and
+    // never on the other — a boundary divergence worth naming, and one this
+    // test must not depend on either way.
+    sqlx::query(
+        "UPDATE port_job_dispatch_queue SET processed_at_ms = 0 WHERE status = 'Processing'",
+    )
+    .execute(&fixture.pool)
+    .await
+    .expect("the claim is backdated");
+
+    // A reclaim sweep hands the row to someone else, bumping the generation.
+    fixture
+        .queue
+        .reclaim_stuck(Duration::from_secs(0), 8)
+        .await
+        .expect("the sweep runs");
+    let plugin: PluginKey = "demo".parse().expect("the fixture plugin key is valid");
+    let fresh = fixture
+        .queue
+        .claim_pending(&PROCESSOR_B, 1, &[plugin])
+        .await
+        .expect("the reclaimed job is claimable again");
+    assert_eq!(fresh.len(), 1, "the sweep returned the row to the queue");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, stale, "worker-a", &scope))
+            .await
+            .expect("a superseded claim is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
+
+    // Nothing was written: the execution still has no lease, so the current
+    // claim holder can still take the turn.
+    let taken = fixture
+        .handoff
+        .accept_turn(&fixture.request(
+            execution,
+            fresh.into_iter().next().expect("one job").token,
+            "worker-b",
+            &scope,
+        ))
+        .await
+        .expect("the current claim holder can take the turn");
+    assert!(
+        matches!(taken, TurnAcceptance::Accepted { .. }),
+        "a rejected handoff must leave the execution takeable, got {taken:?}"
+    );
+}
+
+/// A live lease held by another owner blocks the turn and leaves the queue row
+/// claimable, so the work is redelivered rather than dropped.
+#[tokio::test]
+async fn a_live_foreign_lease_blocks_the_turn_without_acknowledging_the_row() {
+    let fixture = Fixture::new().await;
+    let scope = scope();
+    let execution = "exe-contended";
+    let claim = fixture.seed(execution).await;
+
+    fixture
+        .store
+        .acquire_lease(&scope, execution, "worker-z", TTL)
+        .await
+        .expect("the competing lease is acquirable")
+        .expect("no lease existed yet");
+
+    assert_eq!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &scope))
+            .await
+            .expect("contention is a typed outcome, not an error"),
+        TurnAcceptance::TurnHeldByAnotherOwner
+    );
+
+    // The row was NOT acknowledged: acknowledging would make it terminal while
+    // no owner ever ran the turn.
+    fixture
+        .queue
+        .mark_dispatched(&claim)
+        .await
+        .expect("the claim still owns a live row");
+}
+
+/// A handoff for another tenant's execution is refused.
+#[tokio::test]
+async fn a_foreign_tenant_cannot_accept_the_turn() {
+    let fixture = Fixture::new().await;
+    let execution = "exe-tenant";
+    let claim = fixture.seed(execution).await;
+    let intruder = Scope::new("ws-other", "org-other");
+
+    assert!(matches!(
+        fixture
+            .handoff
+            .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
+            .await,
+        Err(StorageError::NotFound { .. })
+    ));
+}

--- a/crates/storage/tests/turn_handoff_conformance_sqlite.rs
+++ b/crates/storage/tests/turn_handoff_conformance_sqlite.rs
@@ -255,11 +255,16 @@ async fn a_foreign_tenant_cannot_accept_the_turn() {
     let claim = fixture.seed(execution).await;
     let intruder = Scope::new("ws-other", "org-other");
 
-    assert!(matches!(
+    // The claim predicate carries the tenant, so a foreign scope fails there
+    // first and answers `ClaimSuperseded` rather than reporting anything about
+    // the execution. That is the stronger reply: it does not reveal whether the
+    // execution exists in some other tenant.
+    assert_eq!(
         fixture
             .handoff
             .accept_turn(&fixture.request(execution, claim, "worker-a", &intruder))
-            .await,
-        Err(StorageError::NotFound { .. })
-    ));
+            .await
+            .expect("a foreign tenant is a typed outcome, not an error"),
+        TurnAcceptance::ClaimSuperseded
+    );
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! use nebula_core::PluginKey;
 //! use nebula_engine::{ExecutionStores, WorkflowEngine};
-//! use nebula_storage_port::store::JobDispatchQueue;
+//! use nebula_storage_port::store::{ControlQueue, ExecutionTurnHandoff, JobDispatchQueue};
 //! use nebula_worker::WorkerRuntimeBuilder;
 //! use tokio_util::sync::CancellationToken;
 //!
@@ -35,11 +35,15 @@
 //! #     engine: Arc<WorkflowEngine>,
 //! #     stores: ExecutionStores,
 //! #     queue: Arc<dyn JobDispatchQueue>,
+//! #     control_queue: Arc<dyn ControlQueue>,
+//! #     handoff: Arc<dyn ExecutionTurnHandoff>,
 //! #     plugins: Vec<PluginKey>,
 //! #     proc_id: [u8; 16],
 //! #     shutdown_token: CancellationToken,
 //! # ) -> Result<(), Box<dyn std::error::Error>> {
 //! let runtime = WorkerRuntimeBuilder::from_wired_engine(engine, stores, queue, plugins, proc_id)
+//!     .with_control_queue(control_queue)
+//!     .with_turn_handoff(handoff)
 //!     .with_batch_size(16)
 //!     .build()?;
 //!
@@ -63,7 +67,7 @@ use nebula_engine::{
 };
 use nebula_metrics::MetricsRegistry;
 use nebula_orchestrator::Orchestrator;
-use nebula_storage_port::store::{ControlQueue, JobDispatchQueue};
+use nebula_storage_port::store::{ControlQueue, ExecutionTurnHandoff, JobDispatchQueue};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
 
@@ -89,6 +93,16 @@ pub enum WorkerBuildError {
     /// the queue makes that miswiring a build error instead of silence.
     #[error("no control queue wired — accepted Start commands would never be consumed")]
     NoControlQueue,
+
+    /// No turn handoff was wired.
+    ///
+    /// Without it the orchestrator cannot end dispatch claims at the durable
+    /// runtime handoff (#976): claims would be held for whole action
+    /// durations and the reclaim window would cap how long an action may run.
+    /// Requiring the handoff makes that miswiring a build error instead of
+    /// silently restoring the pre-#976 behaviour.
+    #[error("no turn handoff wired — dispatch claims could not end at the durable runtime handoff")]
+    NoTurnHandoff,
 
     /// The timer-scan interval is zero.
     ///
@@ -352,6 +366,9 @@ pub struct WorkerRuntimeBuilder {
     /// Durable control queue the API writes accepted commands to. Required at
     /// `build` time — see [`WorkerBuildError::NoControlQueue`].
     control_queue: Option<Arc<dyn ControlQueue>>,
+    /// Durable owner of the dispatch-claim → execution-turn handoff. Required
+    /// at `build` time — see [`WorkerBuildError::NoTurnHandoff`].
+    turn_handoff: Option<Arc<dyn ExecutionTurnHandoff>>,
     available_plugins: Vec<PluginKey>,
     processor_id: [u8; 16],
     // Optional orchestrator overrides — all None means "use Orchestrator defaults".
@@ -360,6 +377,7 @@ pub struct WorkerRuntimeBuilder {
     reclaim_after: Option<Duration>,
     reclaim_interval: Option<Duration>,
     max_reclaim_count: Option<u32>,
+    handoff_lease_ttl: Option<Duration>,
     metrics: Option<MetricsRegistry>,
     // Optional timer scanner override — None means DEFAULT_TIMER_SCAN_INTERVAL.
     timer_scan_interval: Option<Duration>,
@@ -405,6 +423,7 @@ impl WorkerRuntimeBuilder {
             stores,
             queue,
             control_queue: None,
+            turn_handoff: None,
             available_plugins,
             processor_id,
             batch_size: None,
@@ -412,6 +431,7 @@ impl WorkerRuntimeBuilder {
             reclaim_after: None,
             reclaim_interval: None,
             max_reclaim_count: None,
+            handoff_lease_ttl: None,
             metrics: None,
             timer_scan_interval: None,
         }
@@ -424,6 +444,18 @@ impl WorkerRuntimeBuilder {
     /// component reports healthy.
     pub fn with_control_queue(mut self, control_queue: Arc<dyn ControlQueue>) -> Self {
         self.control_queue = Some(control_queue);
+        self
+    }
+
+    /// Wire the durable owner of the dispatch-claim → execution-turn handoff
+    /// (#976).
+    ///
+    /// MUST be constructed over the same backend the `queue` and the engine's
+    /// execution store use: the handoff commits the lease write and the queue
+    /// acknowledgement in one transaction, and two backends would give them
+    /// two boundaries.
+    pub fn with_turn_handoff(mut self, handoff: Arc<dyn ExecutionTurnHandoff>) -> Self {
+        self.turn_handoff = Some(handoff);
         self
     }
 
@@ -459,6 +491,13 @@ impl WorkerRuntimeBuilder {
         self
     }
 
+    /// Override the lease TTL the handoff mints for each accepted turn
+    /// (default: [`Orchestrator`] default = 30 s).
+    pub fn with_handoff_lease_ttl(mut self, d: Duration) -> Self {
+        self.handoff_lease_ttl = Some(d);
+        self
+    }
+
     /// Inject the shared [`MetricsRegistry`] the orchestrator emits counters into.
     ///
     /// Without this the counters increment against a private registry no scraper
@@ -483,12 +522,16 @@ impl WorkerRuntimeBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`WorkerBuildError::NoPlugins`] when `available_plugins` is empty.
+    /// Returns [`WorkerBuildError::NoPlugins`] when `available_plugins` is
+    /// empty, [`WorkerBuildError::NoControlQueue`] when no control queue was
+    /// wired, and [`WorkerBuildError::NoTurnHandoff`] when no turn handoff
+    /// was wired.
     pub fn build(self) -> Result<WorkerRuntime, WorkerBuildError> {
         if self.available_plugins.is_empty() {
             return Err(WorkerBuildError::NoPlugins);
         }
         let control_queue = self.control_queue.ok_or(WorkerBuildError::NoControlQueue)?;
+        let turn_handoff = self.turn_handoff.ok_or(WorkerBuildError::NoTurnHandoff)?;
         let timer_scan_interval = self
             .timer_scan_interval
             .unwrap_or(DEFAULT_TIMER_SCAN_INTERVAL);
@@ -506,8 +549,13 @@ impl WorkerRuntimeBuilder {
 
         let available_plugins_count = self.available_plugins.len();
 
-        let mut orchestrator =
-            Orchestrator::new(self.queue, sink, self.processor_id, self.available_plugins);
+        let mut orchestrator = Orchestrator::new(
+            self.queue,
+            sink,
+            turn_handoff,
+            self.processor_id,
+            self.available_plugins,
+        );
 
         if let Some(n) = self.batch_size {
             orchestrator = orchestrator.with_batch_size(n);
@@ -523,6 +571,9 @@ impl WorkerRuntimeBuilder {
         }
         if let Some(n) = self.max_reclaim_count {
             orchestrator = orchestrator.with_max_reclaim_count(n);
+        }
+        if let Some(d) = self.handoff_lease_ttl {
+            orchestrator = orchestrator.with_handoff_lease_ttl(d);
         }
         if let Some(m) = self.metrics {
             orchestrator = orchestrator.with_metrics(m);

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -111,6 +111,15 @@ impl TestStores {
             .with_execution_stores(self.execution_stores())
             .with_workflow_stores(self.workflow_stores())
     }
+
+    /// Handoff over the SAME shared core the queue and execution store use —
+    /// the lease write and the queue acknowledgement must land under one
+    /// boundary (#976).
+    fn turn_handoff(&self) -> Arc<nebula_storage::inmem::InMemoryTurnHandoff> {
+        Arc::new(nebula_storage::inmem::InMemoryTurnHandoff::new(
+            &self.execution,
+        ))
+    }
 }
 
 /// Test scope used for worker integration tests. Matches `nebula_engine::store_seam::single_tenant_scope()`
@@ -343,6 +352,7 @@ async fn worker_runtime_drives_execution_to_completed() {
         proc16(0xBB),
     )
     .with_control_queue(Arc::new(InMemoryControlQueue::new(&stores.execution)))
+    .with_turn_handoff(stores.turn_handoff())
     // Use a fast poll interval so virtual-time advance is small.
     .with_poll_interval(Duration::from_millis(10))
     .build()
@@ -411,6 +421,7 @@ async fn builder_rejects_a_zero_timer_scan_interval() {
         proc16(0x01),
     )
     .with_control_queue(Arc::new(InMemoryControlQueue::new(&stores.execution)))
+    .with_turn_handoff(stores.turn_handoff())
     .with_timer_scan_interval(Duration::ZERO)
     .build();
 
@@ -541,6 +552,7 @@ async fn reclaim_then_rerun_drives_exactly_once_via_real_sink() {
         proc_b,
     )
     .with_control_queue(Arc::new(InMemoryControlQueue::new(&stores.execution)))
+    .with_turn_handoff(stores.turn_handoff())
     .with_poll_interval(Duration::from_millis(10))
     .build()
     .expect("WorkerRuntimeBuilder::build must succeed");
@@ -592,7 +604,7 @@ async fn reclaim_then_rerun_drives_exactly_once_via_real_sink() {
 #[tokio::test(start_paused = true)]
 async fn redelivered_start_on_running_or_terminal_is_noop() {
     use nebula_engine::EngineExecutionSink;
-    use nebula_orchestrator::ExecutionSink;
+    use nebula_orchestrator::{DispatchedTurn, ExecutionSink};
 
     let stores = TestStores::new();
     let (engine, echo_count) = make_engine(&stores).await;
@@ -615,6 +627,20 @@ async fn redelivered_start_on_running_or_terminal_is_noop() {
         Arc::clone(&stores.execution) as Arc<dyn ExecutionStore>,
     );
 
+    // Mint the turn the way the durable handoff does: lease acquired under
+    // this test's driver identity, fence threaded into the sink (#976).
+    let fence = stores
+        .execution
+        .acquire_lease(
+            &scope(),
+            &execution_id.to_string(),
+            "test-driver",
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("acquire lease for the test turn")
+        .expect("no live lease yet");
+
     let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
     let job_id = [0xCCu8; 16];
     let msg = JobDispatchMsg::new(
@@ -631,8 +657,10 @@ async fn redelivered_start_on_running_or_terminal_is_noop() {
         0,
     );
 
-    // First dispatch: drives Created → Completed; handler runs once.
-    let result1 = sink.dispatch(&msg).await;
+    // First dispatch: drives Created → Completed under the handoff fence;
+    // handler runs once.
+    let turn = DispatchedTurn { msg: &msg, fence };
+    let result1 = sink.dispatch(&turn).await;
     assert!(
         result1.is_ok(),
         "first dispatch must succeed; got {result1:?}"
@@ -652,8 +680,11 @@ async fn redelivered_start_on_running_or_terminal_is_noop() {
         "execution must be Completed after first dispatch; got {status_after_first:?}"
     );
 
-    // Second dispatch: execution is already Completed; must be a no-op.
-    let result2 = sink.dispatch(&msg).await;
+    // Second dispatch: execution is already Completed; the idempotency guard
+    // short-circuits before the fence is ever adopted, so the same (now
+    // released) fence value is fine.
+    let redelivery = DispatchedTurn { msg: &msg, fence };
+    let result2 = sink.dispatch(&redelivery).await;
     assert!(
         result2.is_ok(),
         "re-delivered Start on a Completed execution must return Ok(()); got {result2:?}"


### PR DESCRIPTION
Closes #976.

## The problem

`Orchestrator::handle_entry` awaits `sink.dispatch(&msg)` — a whole execution step that, by its own comment, "can park on a durable timer or an external wait" — and only then calls `mark_dispatched`. The dispatch claim is therefore held for the entire action duration, which makes the queue's reclaim timeout an implicit limit on how long an action may run. A slow action outlives its claim, a sweep redelivers the row, and a second worker starts a turn the first is still running.

Renewing the claim while the action runs does not fix it: it turns the queue row into a second, weaker lease competing with the execution aggregate's own.

## The shape

`ExecutionTurnHandoff::accept_turn` ends the claim at a definite point. It acquires the execution lease under the aggregate fence **and** acknowledges the queue row in one transaction, so the two can never disagree:

- Crash before the commit — the row is still `Processing`, the sweep redelivers, and no turn was accepted.
- Crash after — the row is acknowledged and the execution holds a durable lease, so recovery drives from aggregate truth rather than from the queue.

The trait doc explicitly forbids assembling this from `acquire_lease` + `mark_dispatched`: those are separate operations, and the crash window between them is the state this capability exists to make unreachable.

`TurnHeldByAnotherOwner` deliberately leaves the queue row unacknowledged. Acknowledging there would drop the turn on the floor — the row would be terminal while no owner ever ran it — so it stays claimable and the sweep redelivers once the competing lease expires.

The handoff carries a `JobClaimToken`, not a processor identity: a stable processor may claim a row, lose it to a sweep, and claim it again, so an acknowledgement issued against the first claim would terminalise a row the second is still working.

## Backends

SQLite takes the write lock up front with `BEGIN IMMEDIATE`. PostgreSQL re-reads the claim row `FOR UPDATE`, closing the window where a reclaim sweep could move it between the check and the acknowledgement. Both stamp the lease deadline in the database, matching `acquire_lease` — a caller's clock never decides liveness, because one running fast would fence out a healthy peer and one running slow would mint an already-dead lease, neither detectable from the row afterwards.

When the lease cannot be taken, one extra read distinguishes a live foreign lease from a missing execution: a caller must not treat a nonexistent execution as contention it can wait out.

## Two findings from writing the evidence

Both recorded rather than smoothed over:

- **`SELECT 1` is INT4 in PostgreSQL, not INT8.** Decoding the existence probes as `i64` failed at the driver. Only the live-PostgreSQL run could surface this; a SQLite-only suite would have shipped it.
- **The reclaim predicates disagree at the boundary.** The in-memory model uses `elapsed >= reclaim_after`, SQLite uses `processed_at_ms < cutoff`, so a zero window reclaims immediately on one backend and never on the other. The SQL cases backdate the claim explicitly rather than depend on either reading. The divergence is pre-existing reclaim behaviour, named here so it is not rediscovered later as a flake.

## Scope note

This PR lands the storage capability and its three-backend evidence. The orchestrator refactor to `claim → validate → handoff → dispatch` follows on this branch; the acceptance criterion about a blocked action outliving its claim is proven end-to-end there.

## Evidence

- 6771 workspace tests pass (3 skipped); 598 nebula-storage tests.
- 4 handoff cases pass on each of in-memory, SQLite, and live PostgreSQL 17-alpine.
- The PostgreSQL suite is added to the required `postgres-conformance` job rather than left to skip.
- clippy clean on default, sqlite-only, postgres-only, and all-features; `task quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable dispatch-claim handoff to execution turns across in-memory, PostgreSQL, and SQLite storage.
  * Execution leases and queue acknowledgments now complete atomically before dispatch.
  * Added fenced execution resumption and lease-based recovery after dispatch failures.
  * Added handoff outcome metrics and configurable handoff lease durations.
  * Added handling for superseded claims, conflicting leases, missing executions, and cross-tenant requests.

* **Tests**
  * Added conformance and integration coverage across storage backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->